### PR TITLE
fixed issue 559

### DIFF
--- a/recipes-webos/app-services/app-services.bb
+++ b/recipes-webos/app-services/app-services.bb
@@ -17,7 +17,7 @@ SRC_URI = "${OPENWEBOS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
 inherit webos-ports-submissions
-SRCREV = "296364eddeda2ddf1c7ef7c8b8ce84051b57e4b0"
+SRCREV = "4d2cb023ab78d6f06311cbbe15c194f9140b9c67"
 
 do_install() {
     install -d ${D}${webos_servicesdir}


### PR DESCRIPTION
See: http://issues.webos-ports.org/issues/559

This was caused by a corrupt .json files in /etc/palm/tempdb. Strange thing is that this file was not changed for ages... probably it was not read until recently, because it is in a subfolder? Anyhow, with this change the luna-send calls and reboot both work to configure db kinds and permissions.
