### PR TITLE
switch to luneos as distro_name in initramfs

### DIFF
--- a/recipes-core/initrdscripts/initramfs-boot-android/distro.conf
+++ b/recipes-core/initrdscripts/initramfs-boot-android/distro.conf
@@ -1,1 +1,4 @@
-distro_name="webos"
+distro_name="luneos"
+
+# file that init script can expect to exist inside a valid rootfs
+distro_rootfs_file="/etc/webos-release"


### PR DESCRIPTION
initramfs script uses distro_name to find rootfs directories (or rootfs volume
in tenderloin case). Project has been renamed, and directory names/volumes
should use the new name.

Also adding a new variable distro_rootfs_file which has the name of a file
which is known to exist in a luneos release. distro_rootfs_file will be used
to sanity-check a prospective rootfs volume in the tenderloin-specific
initramfs script (see https://github.com/webOS-ports/meta-smartphone/pull/7)

Despite webos being replaced in distro_name, distro_rootfs_file points to
/etc/webos-release because there "webos" represents the family of distros,
like when debian-based distros still create /etc/debian_version

Signed-off-by: S. Lockwood-Childs sjl@vctlabs.com
