### PR TITLE
webos-ports-emulator: change emulator disk from IDE to SATA

### DIFF
--- a/recipes-core/images/webos-ports-emulator-appliance/webos-ports-emulator.ovf
+++ b/recipes-core/images/webos-ports-emulator-appliance/webos-ports-emulator.ovf
@@ -51,21 +51,12 @@
       </Item>
       <Item>
         <rasd:Address>0</rasd:Address>
-        <rasd:Caption>ideController0</rasd:Caption>
-        <rasd:Description>IDE Controller</rasd:Description>
-        <rasd:ElementName>ideController0</rasd:ElementName>
+        <rasd:Caption>sataController0</rasd:Caption>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>sataController0</rasd:ElementName>
         <rasd:InstanceID>3</rasd:InstanceID>
-        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
-        <rasd:ResourceType>5</rasd:ResourceType>
-      </Item>
-      <Item>
-        <rasd:Address>1</rasd:Address>
-        <rasd:Caption>ideController1</rasd:Caption>
-        <rasd:Description>IDE Controller</rasd:Description>
-        <rasd:ElementName>ideController1</rasd:ElementName>
-        <rasd:InstanceID>4</rasd:InstanceID>
-        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
-        <rasd:ResourceType>5</rasd:ResourceType>
+        <rasd:ResourceSubType>AHCI</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
       </Item>
       <Item>
         <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
@@ -248,7 +239,7 @@
         <GuestProperties/>
       </Hardware>
       <StorageControllers>
-        <StorageController name="webos-ports-image" type="PIIX4" PortCount="2" useHostIOCache="true" Bootable="true">
+        <StorageController name="webos-ports-image" type="AHCI" PortCount="1" useHostIOCache="true" Bootable="true" IDE0MasterEmulationPort="0" IDE0SlaveEmulationPort="1" IDE1MasterEmulationPort="2" IDE1SlaveEmulationPort="3">
           <AttachedDevice type="HardDisk" port="0" device="0">
             <Image uuid="{1303714f-3752-4dec-994b-82f2762ac9f8}"/>
           </AttachedDevice>


### PR DESCRIPTION
The Yocto_Build_Appliance.vmx has change disk type from IDE to SATA
since commit be5b17b7f, which will make webos-ports-emulator can't boot
into the rootfs.

Signed-off-by: Yen-Chin Lee coldnew.tw@gmail.com
