### PR TITLE
webos-keyboard: unset WEBOS_SYSTEM_BUS_SKIP_DO_TASKS

### DIFF
--- a/recipes-webos/webos-keyboard/webos-keyboard.bb
+++ b/recipes-webos/webos-keyboard/webos-keyboard.bb
@@ -37,6 +37,8 @@ EXTRA_QMAKEVARS_PRE = "\
 INSANE_SKIP_${PN} += "libdir staticdev"
 INSANE_SKIP_${PN}-dbg += "libdir"
 
+WEBOS_SYSTEM_BUS_SKIP_DO_TASKS = ""
+
 FILES_${PN} += "\
     ${libdir}/maliit \
     ${datadir} \


### PR DESCRIPTION
Needed to install ls2 roles file for maliit-server.
Signed-off-by: Nikolay Nizov nizovn@gmail.com
