### PR TITLE
org.webosports.service.messaging: bump SRCREV

### DIFF
--- a/meta-luneos/recipes-luneos/services/org.webosports.cdav.bb
+++ b/meta-luneos/recipes-luneos/services/org.webosports.cdav.bb
@@ -8,8 +8,8 @@ inherit allarch
 inherit webos_filesystem_paths
 inherit webos_system_bus
 
-PV = "0.3.19+gitr${SRCPV}"
-SRCREV = "27bbcdb0d8e2bcd63e035626e8128335390b80d9"
+PV = "0.3.23+gitr${SRCPV}"
+SRCREV = "c15259df0561aecf43c83728bab3181a9390032d"
 
 WEBOS_REPO_NAME = "org.webosports.service.contacts.carddav"
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
@@ -46,6 +46,9 @@ do_install() {
     # account creation application
     install -d ${D}${webos_applicationsdir}/org.webosports.cdav.app
     cp -rv ${S}/app-enyo/* ${D}${webos_applicationsdir}/org.webosports.cdav.app/
+
+    # copy urlschemes.js from service dir to application dir
+    cp -v ${S}/service/javascript/urlschemes.js ${D}${webos_applicationsdir}/org.webosports.cdav.app/CrossAppTarget/
 }
 
 FILES_${PN} += "${webos_applicationsdir} ${webos_servicesdir} ${webos_accttemplatesdir}"


### PR DESCRIPTION
Updated C+Dav from 0.3.19 to 0.3.23. During this upgrades, it became necessary  to have the urlschemes.js file in the app dir, too. So I modified the recipe to copy the file from the service directory to the app directory after everything else is done.

0.3.23:
	o App: stats and status display improvements
	o refresh Auth on 401 errors for OAuth and Digest Auth
	o reworked ignoreSSLCertificateErrors
	o Prevent unnecessary downloads of etags if we see 
	  unrecoverable download errors for single items like 404.
2015-02-25: Achim Königs <garfonso@mobo.info>

0.3.22:
	o fix for account creation and URL resolving that required username in URL.
2015-02-24: Achim Königs <garfonso@mobo.info>

0.3.21:
	o hot-fix for account creation with known-server-templates. Accounts created with 0.3.20 
	   might stop working after this version. So please consider recreation if you 
	   created an account with 0.3.20.
2015-02-23: Achim Königs <garfonso@mobo.info>

0.3.20:
	o changed reaction to connection close, will wait if something happens.
	o improved app to select urlSchems during account creation.
	o Fixed: In webOS 2.x OAuth based authentication could be sabotaged 
	   by change password dialog in account manager.
	o Added button in 2.x app to regain oauth token for accounts that use oauth authentification.
	o changed URI handling, should improve downloading from google?
	o Prevent sync of deleted folders and fixed deleting multiple folders at once
	o "uId" field got renamed to "uid" field for compability with Calendar.IO
	o Exit on uncaught exceptions, maybe prevents some service hanging issues.
	o Added statistics and status display to the apps and an assistant to the service to fill these
2015-02-23: Achim Königs <garfonso@mobo.info>