### PR TITLE
org.webosports.cdav: bump SRCREV

### DIFF
--- a/meta-luneos/recipes-luneos/services/org.webosports.cdav.bb
+++ b/meta-luneos/recipes-luneos/services/org.webosports.cdav.bb
@@ -8,8 +8,8 @@ inherit allarch
 inherit webos_filesystem_paths
 inherit webos_system_bus
 
-PV = "0.3.23+gitr${SRCPV}"
-SRCREV = "c15259df0561aecf43c83728bab3181a9390032d"
+PV = "0.3.25+gitr${SRCPV}"
+SRCREV = "98bfff98a700354658649cfd801b4a77392dc688"
 
 WEBOS_REPO_NAME = "org.webosports.service.contacts.carddav"
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"


### PR DESCRIPTION
0.3.25:
	o fixed: recurring events with exceptions could be added multiple times. 
           Deleting one of them deleted the server event.
	o change: (BIG CHANGE!) Now using event timezone id, again. 
            Solves issues with daylight saving times and recurrences.
2015-03-03: Achim Königs <garfonso@mobo.info>

0.3.24:
	o fixed issue with event exceptions not being upsynced properly and possibly lost afterwards.
2015-03-03: Achim Königs <garfonso@mobo.info>