### PR TITLE
luna-appmanager: replace qtquick1 dependency with qtdeclarative

### DIFF
--- a/meta-luneos/recipes-webos/luna-appmanager/luna-appmanager.bb
+++ b/meta-luneos/recipes-webos/luna-appmanager/luna-appmanager.bb
@@ -9,7 +9,7 @@ DEPENDS = " \
     json-c luna-service2 sqlite3 luna-sysmgr-ipc luna-sysmgr-ipc-messages \
     pmloglib librolegen nyx-lib openssl luna-webkit-api luna-prefs \
     libpbnjson freetype luna-sysmgr-common \
-    qtbase qtquick1 serviceinstaller \
+    qtbase qtdeclarative serviceinstaller \
 "
 
 RDEPENDS_${PN} += " \


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>