### PR TITLE
ofono: revert back to 1.17

### DIFF
--- a/meta-luneos/recipes-connectivity/ofono/ofono_git.bbappend
+++ b/meta-luneos/recipes-connectivity/ofono/ofono_git.bbappend
@@ -1,7 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRCREV = "ca1d06c37a90fe4a1ccd95ee965030a6afd98b60"
-PV = "1.19+gitr${SRCPV}"
+# Beware, upgrading to 1.19 breaks ofono at least on hammerhead
+# SRCREV = "ca1d06c37a90fe4a1ccd95ee965030a6afd98b60"
+# PV = "1.19+gitr${SRCPV}"
+SRCREV = "403f29320c68ead8b93ca422b1c3c509f8bff482"
+PV = "1.17+gitr${SRCPV}"
 
 RDEPENDS_${PN} += "mobile-broadband-provider-info ofono-conf"
 


### PR DESCRIPTION
Upgrading to 1.19 breaks ofono on hammerhead (at least)

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>