### PR TITLE
Revert "libhybris: bump SRCREV"

### DIFF
--- a/meta-luneos/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-luneos/recipes-core/libhybris/libhybris_git.bbappend
@@ -7,4 +7,4 @@ EXTRA_OECONF += " \
     --with-default-hybris-ld-library-path=/usr/libexec/hal-droid/system/lib \
 "
 
-SRCREV = "a37a36b98eab7b4eeb82e87a77910327e3355578"
+SRCREV = "085cd7e06058708104c4d4244266881fd1757585"


### PR DESCRIPTION
This reverts commit 076b2c0cca5f7e812b62e8f757e1281e7eb4f4b5.
The merge of Ubuntu's changes for Android 6 and aarch64 are leading
to issues when used with our CM12.1 HAL. So let's delay this bump
until we solve those problems.