### PR TITLE
mesa: do not move around libGLESv2.so

### DIFF
--- a/meta-luneui/recipes-graphics/mesa/mesa_%.bbappend
+++ b/meta-luneui/recipes-graphics/mesa/mesa_%.bbappend
@@ -6,12 +6,3 @@ PACKAGECONFIG_append = " gallium gallium-llvm"
 # http://lists.openembedded.org/pipermail/openembedded-core/2015-August/108949.html
 #EGL_PLATFORMS_append = ",fbdev"
 
-# ------------------------------------------------------------------------------
-# Move the /usr/lib/libGLESv2.so symlink into the runtime package as workaround
-# for issues seem with Qt 5.4.1, which seems to try to dlopen libGLESv2.so using
-# a hardcoded filename (instead of relying on the dynamic linker and therefore
-# loading libGLESv2.so via it's soname).
-# ------------------------------------------------------------------------------
-FILES_libgles2-mesa = "${libdir}/libGLESv2.so.* ${libdir}/libGLESv2.so"
-FILES_SOLIBSDEV_libgles2-mesa = ""
-INSANE_SKIP_libgles2-mesa += "dev-so"


### PR DESCRIPTION
Starting Qt-X11 sessions will complain with

| Failed to create display (No such file or directory)

Tested with Qt5.8 on RaspiPi/Mesa/VC4 with lxqt-x11 and liri-wayland

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>