### PR TITLE
qtwebengine: add (unused) patch to disable some sandboxing

### DIFF
--- a/meta-luneui/recipes-qt/qt5/qtwebengine/0006-Disable-some-sandboxing-capabilities.patch
+++ b/meta-luneui/recipes-qt/qt5/qtwebengine/0006-Disable-some-sandboxing-capabilities.patch
@@ -1,0 +1,31 @@
+From 7ab0caa6451c12a352edefb4fb0ed1ff222fbb2e Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Mon, 24 Jul 2017 17:53:33 +0000
+Subject: [PATCH] Disable some sandboxing capabilities
+
+LuneOS is running on old kernels (< 3.8), so disable some sandboxing
+functionalities that can be problematic.
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/core/content_browser_client_qt.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/core/content_browser_client_qt.cpp b/src/core/content_browser_client_qt.cpp
+index 5f441f2..10ee72d 100644
+--- a/src/core/content_browser_client_qt.cpp
++++ b/src/core/content_browser_client_qt.cpp
+@@ -511,6 +511,10 @@ void ContentBrowserClientQt::AppendExtraCommandLineSwitches(base::CommandLine* c
+     std::string processType = command_line->GetSwitchValueASCII(switches::kProcessType);
+     if (processType == switches::kZygoteProcess)
+         command_line->AppendSwitchASCII(switches::kLang, GetApplicationLocale());
++
++    // LuneOS is running on old kernels (< 3.8), so disable some sandboxing functionalities that can be problematic
++    command_line->AppendSwitch(switches::kDisableSeccompFilterSandbox);
++    command_line->AppendSwitch(switches::kDisableNamespaceSandbox);
+ }
+ 
+ void ContentBrowserClientQt::GetAdditionalWebUISchemes(std::vector<std::string>* additional_schemes)
+-- 
+2.7.4
+

--- a/meta-luneui/recipes-qt/qt5/qtwebengine_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtwebengine_git.bbappend
@@ -13,6 +13,7 @@ SRC_URI += " \
     file://0003-WebEngineNewViewRequest-provide-the-requested-URL-as.patch \
     file://0004-Implement-Sync-IPC-messaging-through-qt.webChannelTr.patch \
     file://0005-Make-properties-for-some-settings-for-PalmBridgeServ.patch \
+    file://0006-Disable-some-sandboxing-capabilities.patch \
     file://0007-WebEngineSettings-Add-a-standardFontFamily-property-.patch \
     file://0008-WebEngineSettings-add-also-Serif-Fixed-and-Cursive-f.patch \
     file://0009-Store-the-additional-window-features-required-by-the.patch \


### PR DESCRIPTION
This can be an alternative to putting the switches on the command line everywhere

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>