### PR TITLE
qtwebengine: fix chromium patches's patchdir

### DIFF
--- a/meta-luneui/recipes-qt/qt5/qtwebengine/chromium/0001-Add-PalmServiceBridge-to-WebEngine.patch
+++ b/meta-luneui/recipes-qt/qt5/qtwebengine/chromium/0001-Add-PalmServiceBridge-to-WebEngine.patch
@@ -1,7 +1,7 @@
-From 9134aaf91f81047474a95937a325009b3795e2a8 Mon Sep 17 00:00:00 2001
+From 40516d3645fe408ee5191ebebc2c891251fd0c6d Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Sat, 26 Sep 2015 22:26:24 +0200
-Subject: [PATCH 01/10] Add PalmServiceBridge to WebEngine
+Subject: [PATCH] Add PalmServiceBridge to WebEngine
 
 * Adapt PalmServiceBridge IDL for Chromium
 * Propagate PalmBridgeService related settings from host
@@ -12,33 +12,33 @@ Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
 ---
  .../public/common/common_param_traits_macros.h     |   3 +
- chromium/content/public/common/web_preferences.cc  |   4 +
- chromium/content/public/common/web_preferences.h   |   4 +
+ chromium/content/public/common/web_preferences.cc  |   5 +-
+ chromium/content/public/common/web_preferences.h   |   5 +
  chromium/content/renderer/render_view_impl.cc      |   3 +
- chromium/third_party/WebKit/Source/modules/BUILD.gn        |  1 +
  .../WebKit/Source/core/frame/Settings.in           |  11 +
- .../WebKit/Source/modules/modules_idl_files.gni            |  6 ++++++
+ .../third_party/WebKit/Source/modules/BUILD.gn     |   1 +
+ .../WebKit/Source/modules/modules_idl_files.gni    |   1 +
+ .../WebKit/Source/modules/webos/BUILD.gn           |  13 +
  .../WebKit/Source/modules/webos/Logging.h          |  11 +
  .../WebKit/Source/modules/webos/LunaServiceMgr.cpp | 316 +++++++++++++++++++++
  .../WebKit/Source/modules/webos/LunaServiceMgr.h   |  53 ++++
- chromium/third_party/WebKit/Source/modules/webos/BUILD.gn  | 14 ++++++++++++++
  .../Source/modules/webos/PalmServiceBridge.cpp     | 300 +++++++++++++++++++
  .../Source/modules/webos/PalmServiceBridge.h       |  90 ++++++
  .../Source/modules/webos/PalmServiceBridge.idl     |  14 +
- .../WebKit/Source/web/WebSettingsImpl.cpp          |  14 +
+ .../WebKit/Source/web/WebSettingsImpl.cpp          |  16 ++
  .../WebKit/Source/web/WebSettingsImpl.h            |   3 +
  .../third_party/WebKit/public/web/WebSettings.h    |   3 +
- 17 files changed, 850 insertions(+)
+ 17 files changed, 847 insertions(+), 1 deletion(-)
+ create mode 100644 chromium/third_party/WebKit/Source/modules/webos/BUILD.gn
  create mode 100644 chromium/third_party/WebKit/Source/modules/webos/Logging.h
  create mode 100644 chromium/third_party/WebKit/Source/modules/webos/LunaServiceMgr.cpp
  create mode 100644 chromium/third_party/WebKit/Source/modules/webos/LunaServiceMgr.h
  create mode 100644 chromium/third_party/WebKit/Source/modules/webos/PalmServiceBridge.cpp
  create mode 100644 chromium/third_party/WebKit/Source/modules/webos/PalmServiceBridge.h
  create mode 100644 chromium/third_party/WebKit/Source/modules/webos/PalmServiceBridge.idl
- create mode 100644 chromium/third_party/WebKit/Source/modules/webos/BUILD.gn
 
 diff --git a/chromium/content/public/common/common_param_traits_macros.h b/chromium/content/public/common/common_param_traits_macros.h
-index 9b2e0ff792..c4568af7fb 100644
+index 9b2e0ff..c4568af 100644
 --- a/chromium/content/public/common/common_param_traits_macros.h
 +++ b/chromium/content/public/common/common_param_traits_macros.h
 @@ -245,6 +245,9 @@ IPC_STRUCT_TRAITS_BEGIN(content::WebPreferences)
@@ -52,7 +52,7 @@ index 9b2e0ff792..c4568af7fb 100644
  
  IPC_STRUCT_TRAITS_BEGIN(blink::WebWindowFeatures)
 diff --git a/chromium/content/public/common/web_preferences.cc b/chromium/content/public/common/web_preferences.cc
-index 2e9e0361ac..cb187544d5 100644
+index 2e9e036..cb18754 100644
 --- a/chromium/content/public/common/web_preferences.cc
 +++ b/chromium/content/public/common/web_preferences.cc
 @@ -222,7 +222,10 @@ WebPreferences::WebPreferences()
@@ -68,7 +68,7 @@ index 2e9e0361ac..cb187544d5 100644
        base::ASCIIToUTF16("Times New Roman");
    fixed_font_family_map[kCommonScript] = base::ASCIIToUTF16("Courier New");
 diff --git a/chromium/content/public/common/web_preferences.h b/chromium/content/public/common/web_preferences.h
-index 44ff927dfd..fbdeae81dd 100644
+index 44ff927..fbdeae8 100644
 --- a/chromium/content/public/common/web_preferences.h
 +++ b/chromium/content/public/common/web_preferences.h
 @@ -264,6 +264,11 @@ struct CONTENT_EXPORT WebPreferences {
@@ -84,7 +84,7 @@ index 44ff927dfd..fbdeae81dd 100644
    // chrome, except for the cases where it would require lots of extra work for
    // the embedder to use the same default value.
 diff --git a/chromium/content/renderer/render_view_impl.cc b/chromium/content/renderer/render_view_impl.cc
-index a32fe585b6..512f6216e1 100644
+index a32fe58..512f621 100644
 --- a/chromium/content/renderer/render_view_impl.cc
 +++ b/chromium/content/renderer/render_view_impl.cc
 @@ -1031,6 +1031,9 @@ void RenderView::ApplyWebPreferences(const WebPreferences& prefs,
@@ -97,20 +97,8 @@ index a32fe585b6..512f6216e1 100644
  
    settings->setAutoplayExperimentMode(
        blink::WebString::fromUTF8(prefs.autoplay_experiment_mode));
-diff --git a/chromium/third_party/WebKit/Source/modules/BUILD.gn b/chromium/third_party/WebKit/Source/modules/BUILD.gn
-index ab332ef618..4e8e58d85f 100644
---- a/chromium/third_party/WebKit/Source/modules/BUILD.gn
-+++ b/chromium/third_party/WebKit/Source/modules/BUILD.gn
-@@ -150,6 +150,7 @@ target(modules_target_type, "modules") {
-     "//third_party/WebKit/Source/modules/vr",
-     "//third_party/WebKit/Source/modules/wake_lock",
-     "//third_party/WebKit/Source/modules/webaudio",
-+    "//third_party/WebKit/Source/modules/webos",
-     "//third_party/WebKit/Source/modules/webdatabase",
-     "//third_party/WebKit/Source/modules/webgl",
-     "//third_party/WebKit/Source/modules/webmidi",
 diff --git a/chromium/third_party/WebKit/Source/core/frame/Settings.in b/chromium/third_party/WebKit/Source/core/frame/Settings.in
-index b66cff7112..5a50982b91 100644
+index b66cff7..5a50982 100644
 --- a/chromium/third_party/WebKit/Source/core/frame/Settings.in
 +++ b/chromium/third_party/WebKit/Source/core/frame/Settings.in
 @@ -405,6 +405,17 @@ useDefaultImageInterpolationQuality initial=false
@@ -131,33 +119,20 @@ index b66cff7112..5a50982b91 100644
  # Variant of the ParseHTMLOnMainThread experiment. This is designed to coalesce
  # TokenizedChunks when the experiment is running in threaded mode.
  parseHTMLOnMainThreadCoalesceChunks initial=false
-#FIXME, needs updating for GN
-#diff --git a/chromium/third_party/WebKit/Source/modules/modules.gyp b/chromium/third_party/WebKit/Source/modules/modules.gyp
-#index 800a41e..a7c32d4 100644
-#--- a/chromium/third_party/WebKit/Source/modules/modules.gyp
-#+++ b/chromium/third_party/WebKit/Source/modules/modules.gyp
-#@@ -98,6 +98,19 @@
-#             'msvs_shard': 4,
-#           }],
-#         ],
-#+      }],
-#+      ['enable_palmbridge==1', {
-#+        'cflags_cc': [
-#+          '<!@(pkg-config --cflags-only-I luna-service2)',
-#+          '<!@(pkg-config --cflags-only-I glib-2.0)',
-#+        ],
-#+        'link_settings': {
-#+          'libraries': [
-#+            '<!@(pkg-config --libs luna-service2)',
-#+            '<!@(pkg-config --libs glib-2.0)',
-#+            '-lPmLogLib',
-#+          ]
-#+        },
-#       }]
-#     ],
-#     # Disable c4267 warnings until we fix size_t to int truncations.
+diff --git a/chromium/third_party/WebKit/Source/modules/BUILD.gn b/chromium/third_party/WebKit/Source/modules/BUILD.gn
+index ab332ef..4e8e58d 100644
+--- a/chromium/third_party/WebKit/Source/modules/BUILD.gn
++++ b/chromium/third_party/WebKit/Source/modules/BUILD.gn
+@@ -150,6 +150,7 @@ target(modules_target_type, "modules") {
+     "//third_party/WebKit/Source/modules/vr",
+     "//third_party/WebKit/Source/modules/wake_lock",
+     "//third_party/WebKit/Source/modules/webaudio",
++    "//third_party/WebKit/Source/modules/webos",
+     "//third_party/WebKit/Source/modules/webdatabase",
+     "//third_party/WebKit/Source/modules/webgl",
+     "//third_party/WebKit/Source/modules/webmidi",
 diff --git a/chromium/third_party/WebKit/Source/modules/modules_idl_files.gni b/chromium/third_party/WebKit/Source/modules/modules_idl_files.gni
-index e9dd62f17e..de487bf597 100644
+index e9dd62f..a7bae9b 100644
 --- a/chromium/third_party/WebKit/Source/modules/modules_idl_files.gni
 +++ b/chromium/third_party/WebKit/Source/modules/modules_idl_files.gni
 @@ -368,6 +368,7 @@ modules_idl_files =
@@ -168,24 +143,12 @@ index e9dd62f17e..de487bf597 100644
                      "websockets/CloseEvent.idl",
                      "websockets/WebSocket.idl",
                      "webusb/USB.idl",
-@@ -923,6 +924,11 @@ generated_modules_dictionary_files = [
-   "$blink_modules_output_dir/webmidi/MIDIMessageEventInit.cpp",
-   "$blink_modules_output_dir/webmidi/MIDIOptions.cpp",
-   "$blink_modules_output_dir/webmidi/MIDIOptions.h",
-+  "$blink_modules_output_dir/webos/Logging.h",
-+  "$blink_modules_output_dir/webos/LunaServiceMgr.cpp",
-+  "$blink_modules_output_dir/webos/LunaServiceMgr.h",
-+  "$blink_modules_output_dir/webos/PalmServiceBridge.h",
-+  "$blink_modules_output_dir/webos/PalmServiceBridge.cpp",
-   "$blink_modules_output_dir/webshare/ShareData.cpp",
-   "$blink_modules_output_dir/webshare/ShareData.h",
-   "$blink_modules_output_dir/websockets/CloseEventInit.cpp",
 diff --git a/chromium/third_party/WebKit/Source/modules/webos/BUILD.gn b/chromium/third_party/WebKit/Source/modules/webos/BUILD.gn
 new file mode 100644
-index 0000000000..b1819f0e63
+index 0000000..effd211
 --- /dev/null
 +++ b/chromium/third_party/WebKit/Source/modules/webos/BUILD.gn
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,13 @@
 +# Copyright 2017 Herman van Hazendonk. All rights reserved.
 +
 +import("//third_party/WebKit/Source/modules/modules.gni")
@@ -197,7 +160,6 @@ index 0000000000..b1819f0e63
 +    "LunaServiceMgr.h",
 +    "PalmServiceBridge.cpp",
 +    "PalmServiceBridge.h",
-+    "PalmServiceBridge.idl"
 +  ]
 +}
 diff --git a/chromium/third_party/WebKit/Source/modules/webos/Logging.h b/chromium/third_party/WebKit/Source/modules/webos/Logging.h
@@ -1021,7 +983,7 @@ index 0000000..43e1fdd
 +    attribute ServiceCallback onservicecallback;
 +};
 diff --git a/chromium/third_party/WebKit/Source/web/WebSettingsImpl.cpp b/chromium/third_party/WebKit/Source/web/WebSettingsImpl.cpp
-index 65d5d91f13..c3afa5b407 100644
+index 65d5d91..c3afa5b 100644
 --- a/chromium/third_party/WebKit/Source/web/WebSettingsImpl.cpp
 +++ b/chromium/third_party/WebKit/Source/web/WebSettingsImpl.cpp
 @@ -714,4 +714,20 @@ void WebSettingsImpl::setExpensiveBackgroundThrottlingMaxDelay(float maxDelay) {
@@ -1046,7 +1008,7 @@ index 65d5d91f13..c3afa5b407 100644
 +
  }  // namespace blink
 diff --git a/chromium/third_party/WebKit/Source/web/WebSettingsImpl.h b/chromium/third_party/WebKit/Source/web/WebSettingsImpl.h
-index dab96e4f55..f493abe8ed 100644
+index dab96e4..f493abe 100644
 --- a/chromium/third_party/WebKit/Source/web/WebSettingsImpl.h
 +++ b/chromium/third_party/WebKit/Source/web/WebSettingsImpl.h
 @@ -118,6 +118,8 @@ class WEB_EXPORT WebSettingsImpl final
@@ -1067,7 +1029,7 @@ index dab96e4f55..f493abe8ed 100644
    void setPasswordEchoDurationInSeconds(double) override;
    void setPasswordEchoEnabled(bool) override;
 diff --git a/chromium/third_party/WebKit/public/web/WebSettings.h b/chromium/third_party/WebKit/public/web/WebSettings.h
-index 124be313b2..769a64cf61 100644
+index 124be31..769a64c 100644
 --- a/chromium/third_party/WebKit/public/web/WebSettings.h
 +++ b/chromium/third_party/WebKit/public/web/WebSettings.h
 @@ -197,6 +197,8 @@ class WebSettings {

--- a/meta-luneui/recipes-qt/qt5/qtwebengine_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtwebengine_git.bbappend
@@ -24,15 +24,15 @@ SRC_URI += " \
     file://0013-Implement-RequestQuotePermission.patch \
     file://0014-WebEngineView-re-introduce-devicePixelRatio-property.patch \
     file://0015-WebEngineView-add-extraContextMenuEntriesComponent-p.patch \
-    file://chromium/0001-Add-PalmServiceBridge-to-WebEngine.patch;patchdir=./src/3rdparty \
-    file://chromium/0002-WebContents-provide-additional-features-from-window..patch;patchdir=./src/3rdparty \
-    file://chromium/0003-Store-the-additional-window-features-related-to-Lune.patch;patchdir=./src/3rdparty \
-    file://chromium/0004-Fix-JSON-additional-window-features-parsing.patch;patchdir=./src/3rdparty \
-    file://chromium/0005-WindowFeatures-Chrome-lower-the-minimum-height-to-5.patch;patchdir=./src/3rdparty \
-    file://chromium/0006-Enable-password-echo.patch;patchdir=./src/3rdparty \
-    file://chromium/0007-storage-browser-quota-workaround-for-crash-on-cache-.patch;patchdir=./src/3rdparty \
-    file://chromium/0008-html.css-themeWin.css-Add-Prelude-as-default-font-in.patch;patchdir=./src/3rdparty \
-    file://chromium/0010-PalmServiceBridge-adapt-to-Chromium-53-code-base.patch;patchdir=./src/3rdparty \
-    file://chromium/0011-Disable-some-sandboxing-capabilities.patch;patchdir=./src/3rdparty \
-    file://chromium/0012-Update-additional-params-from-Chromium-53-56.patch;patchdir=./src/3rdparty \
+    file://chromium/0001-Add-PalmServiceBridge-to-WebEngine.patch;patchdir=src/3rdparty \
+    file://chromium/0002-WebContents-provide-additional-features-from-window..patch;patchdir=src/3rdparty \
+    file://chromium/0003-Store-the-additional-window-features-related-to-Lune.patch;patchdir=src/3rdparty \
+    file://chromium/0004-Fix-JSON-additional-window-features-parsing.patch;patchdir=src/3rdparty \
+    file://chromium/0005-WindowFeatures-Chrome-lower-the-minimum-height-to-5.patch;patchdir=src/3rdparty \
+    file://chromium/0006-Enable-password-echo.patch;patchdir=src/3rdparty \
+    file://chromium/0007-storage-browser-quota-workaround-for-crash-on-cache-.patch;patchdir=src/3rdparty \
+    file://chromium/0008-html.css-themeWin.css-Add-Prelude-as-default-font-in.patch;patchdir=src/3rdparty \
+    file://chromium/0010-PalmServiceBridge-adapt-to-Chromium-53-code-base.patch;patchdir=src/3rdparty \
+    file://chromium/0011-Disable-some-sandboxing-capabilities.patch;patchdir=src/3rdparty \
+    file://chromium/0012-Update-additional-params-from-Chromium-53-56.patch;patchdir=src/3rdparty \
     "


### PR DESCRIPTION
we had "patchdir=./src/3rdparty", while meta-qt5 had
"patchdir=src/3rdparty"; both point to the same directory, but bitbake
thinks its two separate things, so it teats them separately. When
creating the "patches/series" file for our patches, it then overwrites
by mistake the one that was created for meta-qt5 in the same directory.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>