### PR TITLE
nyx-conf: add event0 to the keys managed by nyx.

### DIFF
--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf/tenderloin/nyx.conf
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf/tenderloin/nyx.conf
@@ -1,2 +1,2 @@
 [module.keys]
-paths=/dev/input/event1
+paths=/dev/input/event0;/dev/input/event1


### PR DESCRIPTION
This re-enables the Power key to work correctly.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>