### PR TITLE
qtscenegraph-adaptation: fix URI

### DIFF
--- a/meta-luneos/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
+++ b/meta-luneos/recipes-qt/qt5/qtscenegraph-adaptation_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 PV = "5.8.0+gitr${SRCPV}"
-SRCREV = "de6a1d9339d698e47e2e229394031e813d025d12"
+SRCREV = "cfcaa70dc244207efb522e511be6ee5818efbe43"
 
 DEPENDS = "qtbase libhybris qtwayland virtual/android-headers qtdeclarative"
 
@@ -16,7 +16,7 @@ DEPENDS = "qtbase libhybris qtwayland virtual/android-headers qtdeclarative"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRC_URI = " \
-    git://git.merproject.org/mer-core/qtscenegraph-adaptation.git \
+    git://git.merproject.org/Tofe/qtscenegraph-adaptation.git;branch=tofe/qt5.8 \
 "
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The problematic commit has been forced out of 'master' branch,
as it didn't built with Qt 5.6. A fix has been provided in the
'Tofe' fork, but isn't merged yet.
In the meantime, use that 'Tofe' repository.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>