### PR TITLE
qtwayland: Fix QtKeyExtensionGlobal's export

### DIFF
--- a/meta-luneui/recipes-qt/qt5/qtwayland/0003-QtKeyExtensionGlobal-fix-export.patch
+++ b/meta-luneui/recipes-qt/qt5/qtwayland/0003-QtKeyExtensionGlobal-fix-export.patch
@@ -1,0 +1,13 @@
+diff --git a/src/compositor/extensions/qwlqtkey_p.h b/src/compositor/extensions/qwlqtkey_p.h
+index fae02b0..d965eac 100644
+--- a/src/compositor/extensions/qwlqtkey_p.h
++++ b/src/compositor/extensions/qwlqtkey_p.h
+@@ -64,7 +64,7 @@ class QKeyEvent;
+ 
+ namespace QtWayland {
+ 
+-class QtKeyExtensionGlobal : public QWaylandCompositorExtensionTemplate<QtKeyExtensionGlobal>, public QtWaylandServer::qt_key_extension
++class Q_WAYLAND_COMPOSITOR_EXPORT QtKeyExtensionGlobal : public QWaylandCompositorExtensionTemplate<QtKeyExtensionGlobal>, public QtWaylandServer::qt_key_extension
+ {
+     Q_OBJECT
+ public:

--- a/meta-luneui/recipes-qt/qt5/qtwayland_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtwayland_git.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
            file://0001-Added-password-mask-delay.patch;patch=1 \
            file://0002-QWaylandWindow-reset-window-should-reset-mask.patch;patch=1 \
+           file://0003-QtKeyExtensionGlobal-fix-export.patch;patch=1 \
            "
 
 FILES_${PN} += "${OE_QMAKE_PATH_PLUGINS}/wayland-graphics-integration"


### PR DESCRIPTION
This extension, though experimental, lets luna-next send
easily Qt key strokes, without needing to set a native key code.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>