### PR TITLE
Fixes for qtubuntu-camera and qtsensors

### DIFF
--- a/meta-luneos/recipes-multimedia/qtubuntu-camera/qtubuntu-camera_bzr.bb
+++ b/meta-luneos/recipes-multimedia/qtubuntu-camera/qtubuntu-camera_bzr.bb
@@ -26,5 +26,6 @@ FILES_${PN} += "\
 "
 
 do_configure_prepend() {
-    rm ${S}/.qmake.conf
+    # Empty .qmake.conf, to avoid conflicts with pkgconfig from Yocto
+    echo "" > ${S}/.qmake.conf
 }

--- a/meta-luneos/recipes-qt/qt5/qtsensors-sensorfw-plugin_git.bb
+++ b/meta-luneos/recipes-qt/qt5/qtsensors-sensorfw-plugin_git.bb
@@ -21,10 +21,6 @@ inherit qmake5
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE};"
 S = "${WORKDIR}/git"
 
-do_install_append() {
-    mv ${D}/etc/xdg ${D}${OE_QMAKE_PATH_QT_SETTINGS}
-}
-
 FILES_${PN}-dbg += " \
   ${OE_QMAKE_PATH_PLUGINS}/sensors/.debug \
 "

--- a/meta-luneos/recipes-qt/qt5/qtsensors_git.bbappend
+++ b/meta-luneos/recipes-qt/qt5/qtsensors_git.bbappend
@@ -1,4 +1,6 @@
+DEPENDS += " sensorfw "
+
 EXTRA_QMAKEVARS_PRE += "\
-    DEFINES+=\"QTSENSORS_CONFIG_PATH=\\\\\\\"${OE_QMAKE_PATH_QT_SETTINGS}/QtProject/Sensors.conf\\\\\\\"\"\
+    SENSORS_CONFIG_PATH=/etc/xdg/QtProject/Sensors.conf\
     "
 


### PR DESCRIPTION
The bitbake error would happen when qtubuntu-camera recipe
is rebuilt without re-fetching the source

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>