### PR TITLE
ofono-conf: Make sure we don't use RIL on qemu

### DIFF
--- a/meta-luneos/recipes-connectivity/ofono/ofono-conf/qemux86-64/environment.conf
+++ b/meta-luneos/recipes-connectivity/ofono/ofono-conf/qemux86-64/environment.conf
@@ -1,0 +1,1 @@
+OFONO_OPTIONS=--noplugin=hfp_bluez5,ril

--- a/meta-luneos/recipes-connectivity/ofono/ofono-conf/qemux86/environment.conf
+++ b/meta-luneos/recipes-connectivity/ofono/ofono-conf/qemux86/environment.conf
@@ -1,0 +1,1 @@
+OFONO_OPTIONS=--noplugin=hfp_bluez5,ril


### PR DESCRIPTION
Disable RIL modem driver for qemux86 and qemux86-64 to avoid log spamming.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>