### PR TITLE
packagegroup-luneos-extended: Add qtconnectivity

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -77,6 +77,7 @@ RDEPENDS_${PN} = " \
   qtsensors-qmlplugins \
   qtwayland \
   qtwayland-plugins \
+  qtconnectivity \
   \
   luna-appmanager \
   luna-next-cardshell \


### PR DESCRIPTION
Needed to QtBluetooth which we want to use in Luna-Next-Cardshell and QML version of Settings App.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>