### PR TITLE
libconnman-qt5: fix initial value of "connected" property

### DIFF
--- a/meta-luneos/recipes-connectivity/connman/libconnman-qt5/0001-Fix-initial-value-of-connected-property.patch
+++ b/meta-luneos/recipes-connectivity/connman/libconnman-qt5/0001-Fix-initial-value-of-connected-property.patch
@@ -1,0 +1,29 @@
+From 828f781e959ae89d0d63bafb26491e3cc9ffac38 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Fri, 3 Nov 2017 20:53:27 +0000
+Subject: [PATCH] Fix initial value of "connected" property
+
+In case the "State" property is directly given to the
+property cache in NetworkService constructor, the
+"connected" property will not be updated properly.
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ libconnman-qt/networkservice.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libconnman-qt/networkservice.cpp b/libconnman-qt/networkservice.cpp
+index c2333a1..b8a0c96 100644
+--- a/libconnman-qt/networkservice.cpp
++++ b/libconnman-qt/networkservice.cpp
+@@ -415,6 +415,7 @@ NetworkService::Private::Private(const QString &path, const QVariantMap &props,
+ 
+     reconnectServiceInterface();
+     updateManaged();
++    updateConnected();
+     DBG_(m_path << "managed:" << m_managed);
+ 
+     // Reset the signal mask (the above calls may have set some bits)
+-- 
+2.7.4
+

--- a/meta-luneos/recipes-connectivity/connman/libconnman-qt5_git.bbappend
+++ b/meta-luneos/recipes-connectivity/connman/libconnman-qt5_git.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://0001-Fix-initial-value-of-connected-property.patch"


### PR DESCRIPTION
Note: This patch has also been to upstream.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>