### PR TITLE
nyx-conf: do not let keys module watch over the touchpanel

### DIFF
--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf/hammerhead/nyx.conf
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf/hammerhead/nyx.conf
@@ -1,2 +1,2 @@
 [module.keys]
-paths=/dev/input/event0;/dev/input/event1
+paths=/dev/input/event0


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>