### PR TITLE
libhybris: Set --enable-arch=arm64 for aarch64

### DIFF
--- a/meta-luneos/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-luneos/recipes-core/libhybris/libhybris_git.bbappend
@@ -8,5 +8,7 @@ EXTRA_OECONF += " \
     --enable-debug \
     --with-default-hybris-ld-library-path=/usr/libexec/hal-droid/system/lib \
 "
-
+EXTRA_OECONF_append_aarch64 += " \ 
+    --enable-arch=arm64 \
+"
 SRCREV = "4aa3379de1d911f00a86cb5643f7ff63dd48d7a6"


### PR DESCRIPTION
To make sure build works correctly.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>