### PR TITLE
initramfs-boot-android: Various fixes to init.sh

### DIFF
--- a/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/distro.conf
+++ b/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/distro.conf
@@ -1,3 +1,4 @@
+# Name of the distribution
 distro_name="luneos"
 
 # file that init script can expect to exist inside a valid rootfs


### PR DESCRIPTION
- Use FunctionFS for ADB instead of custom ADB gadget
- Mount system partition in order to be able to access build.prop for ADB
- Extract the SD card device name from the partition name. This allows booting on devices, like the i9300, where the SD card is not mmcblk0.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>