### PR TITLE
memnotify: Add patch for 3.12+ kernels

### DIFF
--- a/meta-luneos/recipes-kernel/memnotify/memnotify-module_git.bb
+++ b/meta-luneos/recipes-kernel/memnotify/memnotify-module_git.bb
@@ -11,6 +11,9 @@ PV = "1.0.0+gitr${SRCPV}"
 SRCREV = "1bf57fd7b5df155b3a43d9fd80fcc615e9216c28"
 
 SRC_URI = "git://github.com/webOS-ports/memnotify-module.git;branch=master;protocol=git"
+
+SRC_URI_append_mido = "file://0001-Change-shrink-into-scan_objects-for-3.12-kernels.patch"
+
 S = "${WORKDIR}/git"
 
 do_install_append() {

--- a/meta-luneos/recipes-kernel/memnotify/memnotify/0001-Change-shrink-into-scan_objects-for-3.12-kernels.patch
+++ b/meta-luneos/recipes-kernel/memnotify/memnotify/0001-Change-shrink-into-scan_objects-for-3.12-kernels.patch
@@ -1,0 +1,28 @@
+From f19c0248d6b93c3f88b305bff20312710207d9e0 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 18 Jan 2018 10:11:44 +0100
+Subject: [PATCH] Change shrink into scan_objects for 3.12+ kernels
+
+As per https://patchwork.kernel.org/patch/1813061/ the API has been changed and the  call needs to be updated for 3.12+ kernels using memnotify.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ memnotify.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/memnotify.c b/memnotify.c
+index bb19786..b14f358 100644
+--- a/memnotify.c
++++ b/memnotify.c
+@@ -293,7 +293,7 @@ static int vm_shrink(struct shrinker __always_unused *sh,
+ }
+ 
+ static struct shrinker vm_shrinker = {
+-	.shrink = vm_shrink,
++	.scan_objects = vm_shrink,
+ 	.seeks = DEFAULT_SEEKS
+ };
+ 
+-- 
+2.13.2.windows.1
+


### PR DESCRIPTION
Shrink API has been changed as per https://patchwork.kernel.org/patch/1813061/ so for 3.12+ kernels memnotify needs to call .scan_objects instead of .shrink.

Currently only mido is using 3.12+ kernel.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>