### PR TITLE
libhyrbis: Drop --with-default-hybris-ld-library-path and bump SRCREV

### DIFF
--- a/meta-luneos/recipes-core/libhybris/libhybris_git.bbappend
+++ b/meta-luneos/recipes-core/libhybris/libhybris_git.bbappend
@@ -6,9 +6,8 @@ EXTRA_OECONF += " \
     --with-default-egl-platform=wayland \
     --enable-trace \
     --enable-debug \
-    --with-default-hybris-ld-library-path=/usr/libexec/hal-droid/system/lib \
 "
 EXTRA_OECONF_append_aarch64 += " \ 
     --enable-arch=arm64 \
 "
-SRCREV = "36dc78baa0a3a006b39266014787f96458b301da"
+SRCREV = "3cda04985dab5f46d4c0f2067d2aab61362ee4b7"


### PR DESCRIPTION
--with-default-hybris-ld-library-path is not needed anymore with Halium based builds, so dropping it. 
Bumping SRCREV so libhyrbis doesn't look in /system/lib anymore for libhardware.so, so it will work on aarch64 as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>