### PR TITLE
qtbase: Add patch to fix quirks with newer Adreno GPU's

### DIFF
--- a/meta-luneui/recipes-qt/qt5/qtbase/0002-Add-additional-Adreno-targets-for-needsWorkaround.patch
+++ b/meta-luneui/recipes-qt/qt5/qtbase/0002-Add-additional-Adreno-targets-for-needsWorkaround.patch
@@ -1,0 +1,40 @@
+From 5fff87b294d885ea667fe9f81acc68a11da414df Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Tue, 27 Feb 2018 10:36:48 +0100
+Subject: [PATCH] Add needsWorkaround for additional Adreno targets
+
+Seems this issue is still there with Adreno 5xx and 6xx is suspected to have it as well (no device to test though), so added both 5xx and 6xx to cover these. Updated 30x to 3xx in order to cover Adreno 320 and 330 as per https://en.wikipedia.org/wiki/Adreno.
+
+Previous commit addressing this issue for earlier targets:
+https://git.qt.io/consulting-usa/qtbase-xcb-rendering/commit/9ae028f507a22bd03c861e9d14c2efc4aa2efeda
+
+Change-Id: I6ce3f6499d3ff9da884be45039e5f5e0990f7e1f
+Task-number: QTBUG-66702
+---
+ src/gui/kernel/qopenglcontext.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/gui/kernel/qopenglcontext.cpp b/src/gui/kernel/qopenglcontext.cpp
+index 6f332c8ad6..4efa5a40f3 100644
+--- a/src/gui/kernel/qopenglcontext.cpp
++++ b/src/gui/kernel/qopenglcontext.cpp
+@@ -1005,10 +1005,14 @@ bool QOpenGLContext::makeCurrent(QSurface *surface)
+                             || qstrcmp(rendererString, "Mali-T880") == 0
+                             || qstrncmp(rendererString, "Adreno (TM) 2xx", 13) == 0 // Adreno 200, 203, 205
+                             || qstrncmp(rendererString, "Adreno 2xx", 8) == 0 // Same as above but without the '(TM)'
+-                            || qstrncmp(rendererString, "Adreno (TM) 30x", 14) == 0 // Adreno 302, 305
+-                            || qstrncmp(rendererString, "Adreno 30x", 9) == 0 // Same as above but without the '(TM)'
++                            || qstrncmp(rendererString, "Adreno (TM) 3xx", 13) == 0 // Adreno 302, 305, 320, 330
++                            || qstrncmp(rendererString, "Adreno 3xx", 8) == 0 // Same as above but without the '(TM)'
+                             || qstrncmp(rendererString, "Adreno (TM) 4xx", 13) == 0 // Adreno 405, 418, 420, 430
+                             || qstrncmp(rendererString, "Adreno 4xx", 8) == 0 // Same as above but without the '(TM)'
++                            || qstrncmp(rendererString, "Adreno (TM) 5xx", 13) == 0 // Adreno 505, 506, 510, 530, 540
++                            || qstrncmp(rendererString, "Adreno 5xx", 8) == 0 // Same as above but without the '(TM)'
++                            || qstrncmp(rendererString, "Adreno (TM) 6xx", 13) == 0 // Adreno 610, 620, 630
++                            || qstrncmp(rendererString, "Adreno 6xx", 8) == 0 // Same as above but without the '(TM)'
+                             || qstrcmp(rendererString, "GC800 core") == 0
+                             || qstrcmp(rendererString, "GC1000 core") == 0
+                             || strstr(rendererString, "GC2000") != 0
+-- 
+2.13.2.windows.1
+

--- a/meta-luneui/recipes-qt/qt5/qtbase_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtbase_git.bbappend
@@ -4,6 +4,7 @@ PACKAGECONFIG_DISTRO += "sql-sqlite icu glib accessibility mtdev examples fontco
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
     file://0001-Determine-devicePixelRatio-from-environment-variable.patch \
+    file://0002-Add-additional-Adreno-targets-for-needsWorkaround.patch \
 "
 
 QT_CONFIG_FLAGS += "-qpa wayland-egl"


### PR DESCRIPTION
mido uses Snapdragon 625 with Adreno 506 GPU which isn't patched yet into QT as needing "needsWorkaround". This has been submitted upstream with https://bugreports.qt.io/browse/QTBUG-66702 and https://codereview.qt-project.org/#/c/221471/

Once merged upstream this can be dropped.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>