### PR TITLE
packagegroup-luneos-extended: include libpci for qemux86

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -154,6 +154,7 @@ QEMU_RDEPENDS = " \
     phonesim \
     qt5-plugin-generic-vboxtouch \
     kernel-module-snd-intel8x0 \
+    libpci \
 "
 
 RDEPENDS_${PN}_append_qemux86 = " ${QEMU_RDEPENDS}"

--- a/meta-luneui/recipes-qt/qt5/qtwebengine_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtwebengine_git.bbappend
@@ -2,6 +2,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 DEPENDS += "luna-service2 pmloglib qtlocation"
 
+# Chromium uses libpci to determine which optimizations/workarounds to apply
+RDEPENDS_${PN}_append_x86 = " libpci"
+
 # Enable proprietary codecs (for MP3 etc), pepper-plugins (Flash & WideVine), Print to PDF, spellchecker, WebRTC & embedded build
 EXTRA_QMAKEVARS_CONFIGURE += "-proprietary-codecs -pepper-plugins -printing-and-pdf -spellchecker -webrtc -embedded"
 # Activate some more detailed debug info


### PR DESCRIPTION
Having libpci lets Chromium better determine which
optimizations/workarounds to apply for the GPU. This fixes
a crash with Qt 5.9.4.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>