### PR TITLE
nyx-modules: Fix devices names in cmake files

### DIFF
--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/athene.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/athene.cmake
@@ -16,7 +16,7 @@
 #
 # LICENSE@@@
 
-# configuration file for hammerhead
+# configuration file for athene
 # specify all the modules to be compiled
 
 set(MODULE_SYSTEM_WEBOS_LINUX		NO)

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/mido.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/mido.cmake
@@ -16,7 +16,7 @@
 #
 # LICENSE@@@
 
-# configuration file for hammerhead
+# configuration file for mido
 # specify all the modules to be compiled
 
 set(MODULE_SYSTEM_WEBOS_LINUX		NO)

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/onyx.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/onyx.cmake
@@ -16,7 +16,7 @@
 #
 # LICENSE@@@
 
-# configuration file for hammerhead
+# configuration file for onyx
 # specify all the modules to be compiled
 
 set(MODULE_SYSTEM_WEBOS_LINUX		NO)

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/rosy.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/rosy.cmake
@@ -16,7 +16,7 @@
 #
 # LICENSE@@@
 
-# configuration file for hammerhead
+# configuration file for rosy
 # specify all the modules to be compiled
 
 set(MODULE_SYSTEM_WEBOS_LINUX		NO)


### PR DESCRIPTION
Wrong device names were used in the cmake files.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>