### PR TITLE
luneos-dev-image: tell Halium to mount rootfs rw

### DIFF
--- a/meta-luneos/recipes-core/images/luneos-dev-image.bb
+++ b/meta-luneos/recipes-core/images/luneos-dev-image.bb
@@ -8,6 +8,7 @@ webos_enable_devmode() {
     install -d ${IMAGE_ROOTFS}/var/luna
     touch ${IMAGE_ROOTFS}/var/luna/dev-mode-enabled
     touch ${IMAGE_ROOTFS}/var/usb-debugging-enabled
+    touch ${IMAGE_ROOTFS}/.writable_image
     echo "LUNA_NEXT_DEBUG=1" >> ${IMAGE_ROOTFS}${sysconfdir}/luna-next/environment.conf
 }
 


### PR DESCRIPTION
This PR creates the ".writable_image" at the root of luneos' rootfs, which will then be detected by Halium to skip remount of rootfs as read-only.
This concerns only the -dev images.

PS: I'm not sure if that file needs to be declared somewhere in the recipe, like with FILES_${PN} ?

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>