### PR TITLE
packagegroup-luneos-extended: re-enable nyx-modules-hybris

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -121,6 +121,7 @@ LIBHYBRIS_RDEPENDS = " \
     qtscenegraph-adaptation \
     qtsensors-sensorfw-plugin \
     sensorfw \
+    nyx-modules-hybris \
     \
     exiv2 \
     libpulse-simple0 \
@@ -129,8 +130,6 @@ LIBHYBRIS_RDEPENDS = " \
     qtvideo-node \
     org.webosports.app.camera \
 "
-# Removed nyx-modules-hybris pending since it needs fixing for webOS OSE
-#    nyx-modules-hybris 
 
 MEMNOTIFY_RDEPENDS = " \
     memnotify-module \


### PR DESCRIPTION
Depends on https://github.com/webOS-ports/nyx-modules-hybris/pull/4

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>