### PR TITLE
luneos.inc: Fix invalid WEBOS_TARGET_MACHINE_IMPL value

### DIFF
--- a/meta-luneos/conf/distro/include/luneos.inc
+++ b/meta-luneos/conf/distro/include/luneos.inc
@@ -140,7 +140,7 @@ ERROR_QA_remove = " version-going-backwards"
 
 # Default WEBOS_TARGET_* values (see webos_cmake.bbclass)
 WEBOS_TARGET_CORE_OS ?= "rockhopper"
-WEBOS_TARGET_MACHINE_IMPL ?= "device"
+WEBOS_TARGET_MACHINE_IMPL ?= "hardware"
 # For qemu we build for the emulator but for all other targets for a real device
 WEBOS_TARGET_MACHINE_IMPL_qemuall = "emulator"
 


### PR DESCRIPTION
There is no such value as "device", only "hardware", "emulator" or "guest".

Seeing our default targets are actually devices, we should be using "hardware".

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>