### PR TITLE
initramfs-boot-android: disable busybox extreme symlink checks

### DIFF
--- a/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
+++ b/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
@@ -122,6 +122,8 @@ fi
 # Start udev
 . udev-start.sh
 
+# Disable busybox's over-restrictive behavior with cpio extraction
+export EXTRACT_UNSAFE_SYMLINKS=1 
 # Call Halium's mount script
 mountroot
 


### PR DESCRIPTION
These checks break android's ramdisk extraction with busybox's cpio.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>