### PR TITLE
initramfs-boot-android: init.sh: be less verbose for initial user dat…

### DIFF
--- a/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
+++ b/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
@@ -63,12 +63,12 @@ process_bind_mounts() {
             mkdir -p $datadir/$dir
 
             # Copy initial content to new location outside rootfs
-            cp -rav ${rootmnt}/$dir/* $datadir/$dir
+            cp -ra ${rootmnt}/$dir/* $datadir/$dir
         done
 
         mkdir -p $datadir/userdata
         # Copy initial media to userdata
-        cp -rav ${rootmnt}/media/internal/* $datadir/userdata/
+        cp -ra ${rootmnt}/media/internal/* $datadir/userdata/
 
         # setup cryptofs which is not a real cryptofs yet
         if [ -d $datadir/userdata/.cryptofs ] ; then


### PR DESCRIPTION
…a copy

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>