### PR TITLE
systemd: fix boot for old kernels

### DIFF
--- a/meta-luneos/recipes-core/systemd/systemd/Reroute-chase_symlinks-to-canonicalize_file_name-for.patch
+++ b/meta-luneos/recipes-core/systemd/systemd/Reroute-chase_symlinks-to-canonicalize_file_name-for.patch
@@ -1,0 +1,41 @@
+From 817f41157915d9d882a1b93f6342b970c8c6e68b Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Wed, 6 Mar 2019 21:01:14 +0000
+Subject: [PATCH] Reroute chase_symlinks to canonicalize_file_name for old
+ kernels
+
+For older kernel (<3.10), fstat doesn't behave correctly, making
+chase_symlinks return an error. So use GNU's canonicalize_file_name instead.
+
+This should be fine as long as no root prefix is needed, i.e. when we
+are not using nspawn.
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/basic/fs-util.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/basic/fs-util.c b/src/basic/fs-util.c
+index a8e50d4c78..4a2a21e458 100644
+--- a/src/basic/fs-util.c
++++ b/src/basic/fs-util.c
+@@ -660,6 +660,16 @@ int chase_symlinks(const char *path, const char *original_root, unsigned flags,
+          * function what to do when encountering a symlink with an absolute path as directory: prefix it by the
+          * specified path. */
+ 
++        /*
++         * For older kernel (<3.10), fstat doesn't behave correctly, making chase_symlinks return an error.
++         * So use GNU's canonicalize_file_name instead. This should be fine as long as no root prefix is needed,
++         * i.e. when we are not using nspawn.
++         */
++        *ret = canonicalize_file_name(path);
++        if(NULL == *ret)
++            return -EINVAL;
++        return exists;
++
+         /* A root directory of "/" or "" is identical to none */
+         if (isempty(original_root) || path_equal(original_root, "/"))
+                 original_root = NULL;
+-- 
+2.17.0
+

--- a/meta-luneos/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-luneos/recipes-core/systemd/systemd_%.bbappend
@@ -5,3 +5,7 @@ SRC_URI += " \
     file://fd_fdinfo_mnt_id_disablefdinfostat.patch \
     file://Disable-ProtectHome-and-ProtectSystem-for-old-kernel.patch \
 "
+
+SRC_URI_append_arm = " \
+    file://Reroute-chase_symlinks-to-canonicalize_file_name-for.patch \
+"


### PR DESCRIPTION
For LuneOS, it means all ARM 32bit targets.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>