### PR TITLE
qtwayland: fix QWaylandShellPrivate inheritance

### DIFF
--- a/meta-luneui/recipes-qt/qt5/qtwayland/0004-compositor-fix-private-objects-inheritance.patch
+++ b/meta-luneui/recipes-qt/qt5/qtwayland/0004-compositor-fix-private-objects-inheritance.patch
@@ -1,0 +1,101 @@
+From e56700f158211f3461fed15515d6aa2408741056 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 16 Mar 2019 11:41:42 +0000
+Subject: [PATCH] compositor: fix QWaylandShell private objects inheritance
+
+If the public API has inheritance relationships, this should be
+reflected in the private classes too.
+Otherwise the d_func will cast to a wrong type, leading to crashes.
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/compositor/extensions/qwaylandshell.h        | 4 ++--
+ src/compositor/extensions/qwaylandwlshell_p.h    | 3 ++-
+ src/compositor/extensions/qwaylandxdgshellv5_p.h | 3 ++-
+ src/compositor/extensions/qwaylandxdgshellv6_p.h | 3 ++-
+ 4 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/src/compositor/extensions/qwaylandshell.h b/src/compositor/extensions/qwaylandshell.h
+index a8693821..9241b866 100644
+--- a/src/compositor/extensions/qwaylandshell.h
++++ b/src/compositor/extensions/qwaylandshell.h
+@@ -96,11 +96,11 @@ public:
+     }
+ 
+ protected:
+-    QWaylandShellTemplate(QWaylandCompositorExtensionPrivate &dd)
++    QWaylandShellTemplate(QWaylandShellPrivate &dd)
+         : QWaylandShell(dd)
+     { }
+ 
+-    QWaylandShellTemplate(QWaylandObject *container, QWaylandCompositorExtensionPrivate &dd)
++    QWaylandShellTemplate(QWaylandObject *container, QWaylandShellPrivate &dd)
+         : QWaylandShell(container,dd)
+     { }
+ };
+diff --git a/src/compositor/extensions/qwaylandwlshell_p.h b/src/compositor/extensions/qwaylandwlshell_p.h
+index e8d568fc..b2beca16 100644
+--- a/src/compositor/extensions/qwaylandwlshell_p.h
++++ b/src/compositor/extensions/qwaylandwlshell_p.h
+@@ -43,6 +43,7 @@
+ #include <QtWaylandCompositor/qtwaylandcompositorglobal.h>
+ #include <QtWaylandCompositor/qwaylandsurface.h>
+ #include <QtWaylandCompositor/private/qwaylandcompositorextension_p.h>
++#include <QtWaylandCompositor/private/qwaylandshell_p.h>
+ #include <QtWaylandCompositor/QWaylandWlShellSurface>
+ #include <QtWaylandCompositor/QWaylandSeat>
+ 
+@@ -67,7 +68,7 @@
+ QT_BEGIN_NAMESPACE
+ 
+ class Q_WAYLAND_COMPOSITOR_EXPORT QWaylandWlShellPrivate
+-                                        : public QWaylandCompositorExtensionPrivate
++                                        : public QWaylandShellPrivate
+                                         , public QtWaylandServer::wl_shell
+ {
+     Q_DECLARE_PUBLIC(QWaylandWlShell)
+diff --git a/src/compositor/extensions/qwaylandxdgshellv5_p.h b/src/compositor/extensions/qwaylandxdgshellv5_p.h
+index b0b51698..4814eb75 100644
+--- a/src/compositor/extensions/qwaylandxdgshellv5_p.h
++++ b/src/compositor/extensions/qwaylandxdgshellv5_p.h
+@@ -41,6 +41,7 @@
+ #define QWAYLANDXDGSHELLV5_P_H
+ 
+ #include <QtWaylandCompositor/private/qwaylandcompositorextension_p.h>
++#include <QtWaylandCompositor/private/qwaylandshell_p.h>
+ #include <QtWaylandCompositor/private/qwayland-server-xdg-shell.h>
+ 
+ #include <QtWaylandCompositor/QWaylandXdgShellV5>
+@@ -61,7 +62,7 @@
+ QT_BEGIN_NAMESPACE
+ 
+ class Q_WAYLAND_COMPOSITOR_EXPORT QWaylandXdgShellV5Private
+-        : public QWaylandCompositorExtensionPrivate
++        : public QWaylandShellPrivate
+         , public QtWaylandServer::xdg_shell
+ {
+     Q_DECLARE_PUBLIC(QWaylandXdgShellV5)
+diff --git a/src/compositor/extensions/qwaylandxdgshellv6_p.h b/src/compositor/extensions/qwaylandxdgshellv6_p.h
+index e763f6ab..f43decf1 100644
+--- a/src/compositor/extensions/qwaylandxdgshellv6_p.h
++++ b/src/compositor/extensions/qwaylandxdgshellv6_p.h
+@@ -38,6 +38,7 @@
+ #define QWAYLANDXDGSHELLV6_P_H
+ 
+ #include <QtWaylandCompositor/private/qwaylandcompositorextension_p.h>
++#include <QtWaylandCompositor/private/qwaylandshell_p.h>
+ #include <QtWaylandCompositor/private/qwayland-server-xdg-shell-unstable-v6.h>
+ 
+ #include <QtWaylandCompositor/QWaylandXdgShellV6>
+@@ -71,7 +72,7 @@ struct Q_WAYLAND_COMPOSITOR_EXPORT QWaylandXdgPositionerV6Data {
+ };
+ 
+ class Q_WAYLAND_COMPOSITOR_EXPORT QWaylandXdgShellV6Private
+-        : public QWaylandCompositorExtensionPrivate
++        : public QWaylandShellPrivate
+         , public QtWaylandServer::zxdg_shell_v6
+ {
+     Q_DECLARE_PUBLIC(QWaylandXdgShellV6)
+-- 
+2.17.0
+

--- a/meta-luneui/recipes-qt/qt5/qtwayland_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtwayland_git.bbappend
@@ -14,6 +14,7 @@ SRC_URI += " \
     file://0001-Added-password-mask-delay.patch \
     file://0002-Fix-QtKeyExtensionGlobal-s-export.patch \
     file://0003-Revert-Remove-QWaylandExtendedSurface-from-the-priva.patch \
+    file://0004-compositor-fix-private-objects-inheritance.patch \
 "
 
 FILES_${PN} += "${OE_QMAKE_PATH_PLUGINS}/wayland-graphics-integration"


### PR DESCRIPTION
This could cause crashes when using QWaylandWlShell API.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>