### PR TITLE
initramfs-boot-android: reset uevent_help when stopping mdev

### DIFF
--- a/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
+++ b/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
@@ -57,6 +57,7 @@ start_mdev() {
 
 stop_mdev() {
     killall mdev
+    echo "" > /sys/kernel/uevent_helper
 }
 
 process_bind_mounts() {


### PR DESCRIPTION
keeping a value for the hotplug uevent seems to conflict with
Android's ueventd daemon, and causes kernel crashes.
So cleanup this value when mdev isn't needed anymore, which is
what should be done anyway.