### PR TITLE
nodejs-module-webos-{dynaload,sysbus}: bump SRCREV

### DIFF
--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-dynaload.bb
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-dynaload.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 DEPENDS = "boost node-gyp-native"
 
 PV = "3.0.1-14+git${SRCPV}"
-SRCREV = "4eedb88e6eea69c88d30f5519d91113419cb7e71"
+SRCREV = "fa4a170707229011c4eb551792c2310ee4526809"
 
 inherit webos_ports_fork_repo
 inherit webos_filesystem_paths

--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-sysbus.bb
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-sysbus.bb
@@ -17,7 +17,7 @@ inherit webos_system_bus
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE};branch=webosose"
 S = "${WORKDIR}/git"
 
-SRCREV = "d00dafb9ab774b3dab97e915688c6a282b2cd64e"
+SRCREV = "ffd3a8d0b073bd6c102053e48ef70d598f44c1de"
 do_configure() {
     export HOME=${WORKDIR}
     export LD="${CXX}"


### PR DESCRIPTION
* fix build with nodejs 10.0

Depends on https://github.com/webOS-ports/nodejs-module-webos-dynaload/pull/2 and https://github.com/webOS-ports/nodejs-module-webos-sysbus/pull/2

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>