### PR TITLE
 initramfs-boot-android: put .firstboot_done in a rw folder

### DIFF
--- a/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
+++ b/meta-luneos/recipes-core/initrdscripts/initramfs-boot-android/init.sh
@@ -69,7 +69,7 @@ process_bind_mounts() {
     # initial data
     datadir=${rootmnt}/userdata/$distro_name-data
     tell_kmsg "Preparing $datadir"
-    if [ ! -e ${rootmnt}/.firstboot_done ] ; then
+    if [ ! -e $datadir/.firstboot_done ] ; then
         for dir in var home ; do
             rm -rf $datadir/$dir
             mkdir -p $datadir/$dir
@@ -89,7 +89,7 @@ process_bind_mounts() {
         mkdir -p $datadir/userdata/.cryptofs
 
         # We're done with our first boot actions
-        touch ${rootmnt}/.firstboot_done
+        touch $datadir/.firstboot_done
     fi
 
     tell_kmsg "Bind-mount the directories"


### PR DESCRIPTION
Putting this flag directly in ${rootmnt} doesn't make sense if we intend
to have our rootfs read-only... so put the flag in the data folder.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>