### PR TITLE
sdl2-opengles-test: build only sdl2_opengles2_test for all rpi MACHINEs

### DIFF
--- a/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test_git.bb
+++ b/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test_git.bb
@@ -8,7 +8,7 @@ DEPENDS += "libsdl2"
 inherit webos_filesystem_paths pkgconfig
 
 TARGETS = "sdl2_opengles1_test sdl2_opengles2_test"
-TARGETS_raspberrypi3 = "sdl2_opengles2_test"
+TARGETS_rpi = "sdl2_opengles2_test"
 
 PV = "1.0.6+gitr${SRCPV}"
 SRC_URI = "git://github.com/thp/sdl2-opengles-test \


### PR DESCRIPTION
Together with
https://github.com/agherzan/meta-raspberrypi/pull/412
https://github.com/webOS-ports/meta-rpi-luneos/pull/7

fixes all current signatures issues detected with:
openembedded-core/scripts/sstate-diff-machines.sh --targets=luneos-dev-image --tmpdir=tmp-glibc/ --analyze --machines="raspberrypi2 raspberrypi3 mako"