### PR TITLE
luna-next and cardshell: bump SRCREV

### DIFF
--- a/meta-luneos/recipes-luneos/cardshell/luna-next-cardshell.bb
+++ b/meta-luneos/recipes-luneos/cardshell/luna-next-cardshell.bb
@@ -14,8 +14,8 @@ RDEPENDS_${PN} += " \
     luna-next \
 "
 
-PV = "0.4.0-1+git${SRCPV}"
-SRCREV = "f4a140e64ee9972323a0ed1fbf259bcbe762affb"
+PV = "0.5.0-3+git${SRCPV}"
+SRCREV = "22a8a88ab6ba8b5d2b3761027faac565b880517b"
 
 inherit webos_ports_repo
 inherit webos_cmake

--- a/meta-luneos/recipes-luneos/cardshell/luna-next-cardshell.bb
+++ b/meta-luneos/recipes-luneos/cardshell/luna-next-cardshell.bb
@@ -15,14 +15,14 @@ RDEPENDS_${PN} += " \
 "
 
 PV = "0.5.0-3+git${SRCPV}"
-SRCREV = "22a8a88ab6ba8b5d2b3761027faac565b880517b"
+SRCREV = "987c4b392ad2442948cf6d575c345538300ba38f"
 
 inherit webos_ports_repo
 inherit webos_cmake
 inherit webos_tweaks
 inherit webos_filesystem_paths
 
-SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE};branch=herrie/webosose"
+SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
 # inheriting webos_application requires the appinfo.json file, which we don't have here.

--- a/meta-luneui/recipes-luneui/luna-next/luna-next.bb
+++ b/meta-luneui/recipes-luneui/luna-next/luna-next.bb
@@ -12,8 +12,8 @@ DEPENDS = "qtbase qtdeclarative qtwayland luna-sysmgr-common extra-cmake-modules
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE};branch=webosose"
 S = "${WORKDIR}/git"
 
-PV = "0.5.0-2+git${SRCPV}"
-SRCREV = "b2b6ead87ce95cf1f8ce409e66cbff681510cc9d"
+PV = "0.5.0-3+git${SRCPV}"
+SRCREV = "29fb9b2a0a7e79b5ef6c80d0a702d09137e751b8"
 
 # Otherwise there is conflict between None defined in Xlib.h and
 # qtdeclarative's /usr/include/qt5/QtQuick/qsgtexture.h:59


### PR DESCRIPTION
NB: Depends on https://github.com/webOS-ports/luna-next/pull/141 and https://github.com/webOS-ports/luna-next-cardshell/pull/315!

* Fix window activation handling, preventing vkb to show up
* Fix JustTypeLauncher focus
