### PR TITLE
maliit-framework-qt5: set QT_QPA_PLATFORM=wayland

### DIFF
--- a/meta-luneos/recipes-qt/maliit/maliit-framework-qt5/maliit-env.conf
+++ b/meta-luneos/recipes-qt/maliit/maliit-framework-qt5/maliit-env.conf
@@ -1,3 +1,4 @@
 LANGUAGE=en_US
 HOME=/var/lib/maliit
 XDG_RUNTIME_DIR=/tmp/luna-session
+QT_QPA_PLATFORM=wayland


### PR DESCRIPTION
Fixes the display of maliit on qemux86 target

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>