### PR TITLE
ntp: Add an empty ntp-kod file

### DIFF
--- a/meta-luneos/recipes-support/ntp/ntp_%.bbappend
+++ b/meta-luneos/recipes-support/ntp/ntp_%.bbappend
@@ -1,0 +1,10 @@
+# In order to fix the warning message of non-existing ntp-kod file, simply create an empty file.
+
+do_install_append() {
+    # Technically we could use ${webos_db8datadir} as well, however since that's specific to webOS db8, prefer to not use it here in case of future changes to webOS db8.
+    mkdir -p ${D}/${localstatedir}/db/
+    touch ${D}/${localstatedir}/db/ntp-kod
+    chmod 666 ${D}/${localstatedir}/db/ntp-kod
+}
+
+FILES_${PN} += "${localstatedir}/db/ntp-kod"


### PR DESCRIPTION
Fixes: May 08 23:59:11 hammerhead sntp[2291]: kod_init_kod_db(): Cannot open KoD db file /var/db/ntp-kod: No such file or directory

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>