### PR TITLE
Bump qt5-qpa-hwcomposer-plugin: bump SRCREV and reinclude mojomail

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -68,6 +68,8 @@ RDEPENDS_${PN} = " \
   fingerterm \
   \
   ca-certificates \
+  certmgrd \
+  pmcertificatemgr \
   \
   qtbase-plugins \
   qtmultimedia-plugins \

--- a/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
@@ -38,6 +38,9 @@ WEBOS_PACKAGESET_SYSTEMAPPS = " \
     luna-universalsearchmgr \
     app-services \
     core-apps \
+    mojomail-imap \
+    mojomail-pop \
+    mojomail-smtp \
 "
 
 # This packageset controls which time zone packages should be included in webOS.

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0001-Add-support-for-QScreen-orientation-based-on-QtSenso.patch
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0001-Add-support-for-QScreen-orientation-based-on-QtSenso.patch
@@ -1,21 +1,21 @@
-From b8764da3480e001bb004e326530b8613a3c7d150 Mon Sep 17 00:00:00 2001
+From a4d6d6c926a7afed0fb135b5ebdde7db7e1e2c57 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Fri, 3 Feb 2017 22:54:24 +0100
-Subject: [PATCH 1/3] Add support for QScreen::orientation, based on QtSensors.
+Subject: [PATCH] Add support for QScreen::orientation, based on QtSensors.
 
 ---
  hwcomposer/hwcomposer.pro   |  2 +-
- hwcomposer/qeglfsscreen.cpp | 59 +++++++++++++++++++++++++++++++++++++++++++++
- hwcomposer/qeglfsscreen.h   | 13 +++++++++-
+ hwcomposer/qeglfsscreen.cpp | 59 +++++++++++++++++++++++++++++++++++++
+ hwcomposer/qeglfsscreen.h   | 13 +++++++-
  3 files changed, 72 insertions(+), 2 deletions(-)
 
 diff --git a/hwcomposer/hwcomposer.pro b/hwcomposer/hwcomposer.pro
-index c394286..b2d216f 100644
+index 1d430ab..08db168 100644
 --- a/hwcomposer/hwcomposer.pro
 +++ b/hwcomposer/hwcomposer.pro
-@@ -28,7 +28,7 @@ SOURCES += hwcomposer_backend_v11.cpp
+@@ -27,7 +27,7 @@ HEADERS += hwcomposer_backend_v10.h
+ SOURCES += hwcomposer_backend_v11.cpp
  HEADERS += hwcomposer_backend_v11.h
- 
  
 -QT += core-private compositor-private gui-private platformsupport-private dbus
 +QT += core-private compositor-private gui-private platformsupport-private dbus sensors
@@ -155,6 +155,3 @@ index 5ccee4d..cc4a6c0 100644
  };
  
  QT_END_NAMESPACE
--- 
-2.10.2
-

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0002-Fix-4.4.2-hwcomposer-build.patch
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0002-Fix-4.4.2-hwcomposer-build.patch
@@ -1,15 +1,16 @@
-From 3efb6b376fd0ca2266076ebaa71d679d370b06f9 Mon Sep 17 00:00:00 2001
+From 9d0eefda67a352f8be49f57ad915ec18efbce5ee Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Fri, 3 Feb 2017 22:54:54 +0100
-Subject: [PATCH 2/3] Fix 4.4.2 hwcomposer build
+Subject: [PATCH] Fix 4.4.2 hwcomposer build
 
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
 ---
  hwcomposer/hwcomposer_backend_v0.cpp | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/hwcomposer/hwcomposer_backend_v0.cpp b/hwcomposer/hwcomposer_backend_v0.cpp
-index d40a6b3..6eed37c 100644
+index 22e2552..40d3d74 100644
 --- a/hwcomposer/hwcomposer_backend_v0.cpp
 +++ b/hwcomposer/hwcomposer_backend_v0.cpp
 @@ -40,8 +40,9 @@
@@ -22,7 +23,4 @@ index d40a6b3..6eed37c 100644
 +#include "hwcomposer_backend_v0.h"
  
  
- HwComposerBackend_v0::HwComposerBackend_v0(hw_module_t *hwc_module, hw_device_t *hw_device)
--- 
-2.10.2
-
+ HwComposerBackend_v0::HwComposerBackend_v0(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf)

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0003-Qt-5.8-support.patch
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0003-Qt-5.8-support.patch
@@ -1,9 +1,10 @@
-From 19767c31b3007545b83b148baf7ff5e76a376e00 Mon Sep 17 00:00:00 2001
+From 4f356e403457dca160703ea9814ab26569c04ce0 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Fri, 3 Feb 2017 23:29:57 +0100
-Subject: [PATCH 3/3] Qt 5.8 support
+Subject: [PATCH] Qt 5.8 support
 
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
 ---
  hwcomposer/hwcomposer.pro        |  2 +-
  hwcomposer/hwcomposer_context.h  |  2 +-
@@ -14,12 +15,12 @@ Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
  6 files changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/hwcomposer/hwcomposer.pro b/hwcomposer/hwcomposer.pro
-index b2d216f..c636588 100644
+index 08db168..34026fa 100644
 --- a/hwcomposer/hwcomposer.pro
 +++ b/hwcomposer/hwcomposer.pro
-@@ -28,7 +28,7 @@ SOURCES += hwcomposer_backend_v11.cpp
+@@ -27,7 +27,7 @@ HEADERS += hwcomposer_backend_v10.h
+ SOURCES += hwcomposer_backend_v11.cpp
  HEADERS += hwcomposer_backend_v11.h
- 
  
 -QT += core-private compositor-private gui-private platformsupport-private dbus sensors
 +QT += core-private gui-private egl_support-private waylandcompositor-private dbus sensors fontdatabase_support-private eventdispatcher_support-private theme_support-private
@@ -103,6 +104,3 @@ index c8bd9ce..97301b4 100644
  
  #include <QtDebug>
  
--- 
-2.10.2
-

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0004-Fix-hwcomposer-backend.patch
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0004-Fix-hwcomposer-backend.patch
@@ -1,4 +1,4 @@
-From 89a65020b22f79e187a47614a00d1aa327c87dfd Mon Sep 17 00:00:00 2001
+From adb9388ae5f897b962b9329595368bd169557fae Mon Sep 17 00:00:00 2001
 From: Herrie <Github.com@herrie.org>
 Date: Wed, 17 Jan 2018 06:13:14 +0100
 Subject: [PATCH] hwcomposer_backend.h: Fix cast from 'void*' to 'unsigned int'
@@ -7,12 +7,13 @@ Subject: [PATCH] hwcomposer_backend.h: Fix cast from 'void*' to 'unsigned int'
 hwcomposer_backend.h:67:81: error: cast from 'void*' to 'unsigned int' loses precision [-fpermissive]
 
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+
 ---
  hwcomposer/hwcomposer_backend.h | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/hwcomposer/hwcomposer_backend.h b/hwcomposer/hwcomposer_backend.h
-index 5c579aa..4f88183 100644
+index 6ff35c3..201fc32 100644
 --- a/hwcomposer/hwcomposer_backend.h
 +++ b/hwcomposer/hwcomposer_backend.h
 @@ -64,7 +64,7 @@ class QEglFSWindow;

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch
@@ -1,4 +1,4 @@
-From 84328712ac25c564deee748c683a4736391bb3ef Mon Sep 17 00:00:00 2001
+From 5fd2c26c68eb8c1903fb3550308fa8c22e50fc7f Mon Sep 17 00:00:00 2001
 From: Martin Jansa <Martin.Jansa@gmail.com>
 Date: Thu, 14 Feb 2019 10:50:37 +0000
 Subject: [PATCH] hwcomposer_backend_v11: fix compatibility with qtbase 5.12
@@ -7,14 +7,16 @@ Subject: [PATCH] hwcomposer_backend_v11: fix compatibility with qtbase 5.12
   https://codereview.qt-project.org/#/c/224219/
 
 Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
 ---
- hwcomposer/hwcomposer_backend_v11.cpp |  7 +++-
+ hwcomposer/hwcomposer_backend_v11.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
-index 94c8827..6f35abc 100644
+index 42e0eb7..5f0c446 100644
 --- a/hwcomposer/hwcomposer_backend_v11.cpp
 +++ b/hwcomposer/hwcomposer_backend_v11.cpp
-@@ -408,8 +408,11 @@ void HwComposerBackend_v11::handleVSyncEvent()
+@@ -490,8 +490,11 @@ void HwComposerBackend_v11::handleVSyncEvent()
      QSet<QWindow *> pendingWindows = m_pendingUpdate;
      m_pendingUpdate.clear();
      foreach (QWindow *w, pendingWindows) {

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0006-Revert-Add-systraces-to-v11.patch
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin/0006-Revert-Add-systraces-to-v11.patch
@@ -1,0 +1,69 @@
+From 3d8466817e1b0bd006eea2b41a5c65cf30231d09 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Fri, 10 May 2019 19:12:10 +0000
+Subject: [PATCH] Revert "[hwcomposer] Add systraces to v11. Contributes to
+ JB#37989."
+
+This reverts commit e3fb6d37c5afd76cf4862c0df9653570a571beb0.
+---
+ hwcomposer/hwcomposer_backend_v11.cpp | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/hwcomposer/hwcomposer_backend_v11.cpp b/hwcomposer/hwcomposer_backend_v11.cpp
+index 5f0c446..669c8c1 100644
+--- a/hwcomposer/hwcomposer_backend_v11.cpp
++++ b/hwcomposer/hwcomposer_backend_v11.cpp
+@@ -48,8 +48,6 @@
+ #include <QtCore/QCoreApplication>
+ #include <private/qwindow_p.h>
+ 
+-#include <private/qsystrace_p.h>
+-
+ #ifdef HWC_PLUGIN_HAVE_HWCOMPOSER1_API
+ 
+ // #define QPA_HWC_TIMING
+@@ -72,13 +70,6 @@ struct HwcProcs_v11 : public hwc_procs
+ 
+ static void hwc11_callback_vsync(const struct hwc_procs *procs, int, int64_t)
+ {
+-    static int counter = 0;
+-    ++counter;
+-    if (counter % 2)
+-        QSystrace::begin("graphics", "QPA::vsync", "");
+-    else
+-        QSystrace::end("graphics", "QPA::vsync", "");
+-
+     QCoreApplication::postEvent(static_cast<const HwcProcs_v11 *>(procs)->backend, new QEvent(QEvent::User));
+ }
+ 
+@@ -126,8 +117,6 @@ HWComposer::HWComposer(unsigned int width, unsigned int height, unsigned int for
+ 
+ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+ {
+-    QSystraceEvent trace("graphics", "QPA::present");
+-
+     QPA_HWC_TIMING_SAMPLE(presentTime);
+ 
+     fblayer->handle = buffer->handle;
+@@ -151,10 +140,8 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+ 
+     QPA_HWC_TIMING_SAMPLE(prepareTime);
+ 
+-    QSystrace::begin("graphics", "QPA::set", "");
+     err = hwcdevice->set(hwcdevice, num_displays, mlist);
+     HWC_PLUGIN_EXPECT_ZERO(err);
+-    QSystrace::end("graphics", "QPA::set", "");
+ 
+     QPA_HWC_TIMING_SAMPLE(setTime);
+ 
+@@ -486,7 +473,6 @@ bool HwComposerBackend_v11::event(QEvent *e)
+ 
+ void HwComposerBackend_v11::handleVSyncEvent()
+ {
+-    QSystraceEvent trace("graphics", "QPA::handleVsync");
+     QSet<QWindow *> pendingWindows = m_pendingUpdate;
+     m_pendingUpdate.clear();
+     foreach (QWindow *w, pendingWindows) {
+-- 
+2.17.0
+

--- a/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
+++ b/meta-luneos/recipes-qt/qt5/qt5-qpa-hwcomposer-plugin_git.bb
@@ -4,8 +4,8 @@ sometimes also SoC type (generic, qcom, exynos4, ...)."
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://hwcomposer_backend.cpp;beginline=1;endline=40;md5=09c08382077db2dbc01b1b5536ec6665"
 
-PV = "5.2.0+gitr${SRCPV}"
-SRCREV = "a85d3518550193aaee69a6a011f290a2859db5ca"
+PV = "5.6.0+gitr${SRCPV}"
+SRCREV = "df9bddc316a30ee46055c700a40d68bb73e7e87b"
 
 DEPENDS = "qtbase libhybris qtwayland virtual/android-headers qtsensors"
 
@@ -20,6 +20,7 @@ SRC_URI = " \
     file://0003-Qt-5.8-support.patch;striplevel=2 \
     file://0004-Fix-hwcomposer-backend.patch;striplevel=2 \
     file://0005-hwcomposer_backend_v11-fix-compatibility-with-qtbase.patch;striplevel=2 \
+    file://0006-Revert-Add-systraces-to-v11.patch;striplevel=2 \
 "
 S = "${WORKDIR}/git/hwcomposer"
 

--- a/meta-luneos/recipes-webos/libpalmsocket/libpalmsocket.bb
+++ b/meta-luneos/recipes-webos/libpalmsocket/libpalmsocket.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 DEPENDS = "pmloglib glib-2.0 openssl c-ares pmstatemachineengine"
 
-PV = "2.0.0-32+git${SRCPV}"
+PV = "2.0.0-33+git${SRCPV}"
 SRCREV = "0319a6fba4e81dd624ed22cff09a972df389f391"
 
 inherit webos_public_repo
@@ -17,6 +17,7 @@ inherit webos_machine_impl_dep
 
 SRC_URI = "${OPENWEBOS_GIT_REPO_COMPLETE} \
     file://0001-psl_build_config.h-don-t-use-extern-with-inline.patch \
+    file://0002-Fix-build-for-openssl-1.1.1.patch \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos/libpalmsocket/libpalmsocket/0002-Fix-build-for-openssl-1.1.1.patch
+++ b/meta-luneos/recipes-webos/libpalmsocket/libpalmsocket/0002-Fix-build-for-openssl-1.1.1.patch
@@ -1,0 +1,201 @@
+From 96c7941fd379b91c172f3034f39af93715da5d1d Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 11 May 2019 18:05:35 +0000
+Subject: [PATCH] Fix build for openssl-1.1.1
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/psl_channel_fsm_crypto.c | 29 +++++++++++++++--------------
+ src/psl_openssl_utils.c      | 20 ++++++++++----------
+ 2 files changed, 25 insertions(+), 24 deletions(-)
+
+diff --git a/src/psl_channel_fsm_crypto.c b/src/psl_channel_fsm_crypto.c
+index ffef8db..f5cb597 100644
+--- a/src/psl_channel_fsm_crypto.c
++++ b/src/psl_channel_fsm_crypto.c
+@@ -1558,7 +1558,7 @@ crypto_do_renegotiate(PslChanFsmCryptoRenegotiateState*     const pState,
+         "%s (fsm=%p): ENTERING: pState=%p, pFdWatch=%p, " \
+         "PslChanFsmCryptoRenegPhase=%d, pState->PslError=%d, openSSL state=%d (%s)",
+         __func__, pFsm, pState, pFdWatch, (int)pState->phase, pState->pslerr,
+-        SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++        SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+ 
+     #if 0
+     PSL_ASSERT(!pFdWatch || (pFdWatch->numrecs <= 1));
+@@ -1621,7 +1621,8 @@ crypto_do_renegotiate(PslChanFsmCryptoRenegotiateState*     const pState,
+                               "wait for completion of renegotiation " \
+                               "handshake per kPmSockRenegOpt_waitForClientHandshake",
+                               __func__, pFsm);
+-                sslInfo->ssl->state = SSL_ST_ACCEPT;
++                SSL_set_accept_state(sslInfo->ssl);
++                //sslInfo->ssl->state = SSL_ST_ACCEPT;
+                 pState->phase = kPslChanFsmCryptoRenegPhase_handshake;
+             }
+ 
+@@ -1659,7 +1660,7 @@ crypto_do_renegotiate(PslChanFsmCryptoRenegotiateState*     const pState,
+         "pState->PslError=%d (%s), openSSL state=%d (%s)",
+         __func__, pFsm, (int)isDone, (int)pState->phase, pState->pslerr,
+         PmSockErrStringFromError(pState->pslerr),
+-        SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++        SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+ 
+     return isDone;
+ }//crypto_do_renegotiate
+@@ -1683,7 +1684,7 @@ crypto_start_renegotiation(PslChanFsm* pFsm)
+     const PslChanFsmCryptoSharedInfo* const sslInfo = crypto_shared_info(pFsm);
+ 
+     PSL_LOG_DEBUG("%s (fsm=%p): ENTERING: openSSL state=%d (%s)", __func__, pFsm,
+-                  SSL_state(sslInfo->ssl),
++                  SSL_get_state(sslInfo->ssl),
+                   SSL_state_string_long(sslInfo->ssl));
+ 
+ 
+@@ -1709,7 +1710,7 @@ crypto_start_renegotiation(PslChanFsm* pFsm)
+ 
+     PSL_LOG_DEBUG("%s (fsm=%p): LEAVING: PslError=%d (%s), openSSL state=%d (%s)",
+                   __func__, pFsm, pslerr, PmSockErrStringFromError(pslerr),
+-                  SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++                  SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+     return pslerr;
+ }//crypto_start_renegotiation
+ 
+@@ -1728,7 +1729,7 @@ crypto_do_SSL_handshake(PslChanFsm*                const pFsm,
+     const PslChanFsmCryptoSharedInfo* const sslInfo = crypto_shared_info(pFsm);
+ 
+     PSL_LOG_DEBUG("%s (fsm=%p): ENTERING: connKind=%d, openSSL state=%d (%s)",
+-                  __func__, pFsm, (int)sslInfo->connKind, SSL_state(sslInfo->ssl),
++                  __func__, pFsm, (int)sslInfo->connKind, SSL_get_state(sslInfo->ssl),
+                   SSL_state_string_long(sslInfo->ssl));
+ 
+     *pPslErr = 0;
+@@ -1789,7 +1790,7 @@ crypto_do_SSL_handshake(PslChanFsm*                const pFsm,
+     PSL_LOG_DEBUG("%s (fsm=%p): LEAVING: handshakeFinished=%d, PslError=%d (%s), " \
+                   "openSSL state=%d (%s)",
+                   __func__, pFsm, (int)handshakeFinished, *pPslErr,
+-                  PmSockErrStringFromError(*pPslErr), SSL_state(sslInfo->ssl),
++                  PmSockErrStringFromError(*pPslErr), SSL_get_state(sslInfo->ssl),
+                   SSL_state_string_long(sslInfo->ssl));
+ 
+     return handshakeFinished;
+@@ -1831,7 +1832,7 @@ crypto_ssl_peer_verify_callback(int                   preverify_ok,
+             "%s (fsm=%p): Detected start of a new verification session: " \
+             "first_verify_session=%d, openSSL state=%d (%s)", __func__, pFsm,
+             (int)!sslInfo->pv.peerVerifyCalled,
+-            SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++            SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+         sslInfo->pv.verifyInProgress = true;
+     }
+ 
+@@ -1948,7 +1949,7 @@ crypto_ssl_peer_verify_callback(int                   preverify_ok,
+         PSL_LOG_DEBUG(
+             "%s (fsm=%p): Detected end of verification session: " \
+             "openSSL state=%d (%s)", __func__, pFsm,
+-            SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++            SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+     }
+ 
+     PSL_LOG_DEBUG("%s (fsm=%p): LEAVING: preverify_ok=%d, PslError=%d (%s), " \
+@@ -2018,7 +2019,7 @@ crypto_resolve_peer_cert_error(PslChanFsm*     const pFsm,
+ 
+         bool foundMatchingCert;
+         PslError const pslerr = PmSockOpensslMatchCertInStore(
+-            x509_ctx, x509_ctx->cert, 0/*opts*/, &foundMatchingCert);
++            x509_ctx, X509_STORE_CTX_get_current_cert(x509_ctx), 0/*opts*/, &foundMatchingCert);
+         if (pslerr) {
+             foundMatchingCert = false;
+         }
+@@ -3011,7 +3012,7 @@ crypto_read_low(PslChanFsm* const pFsm,
+ 
+     PSL_LOG_DEBUG("%s (fsm=%p): ENTERING: requested cnt=%d, deferredIOAllowed=%d, " \
+                   "openSSL state=%d (%s)", __func__, pFsm, cnt, (int)deferredIOAllowed,
+-                  SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++                  SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+ 
+     PSL_ASSERT(pDst || !cnt);
+     PSL_ASSERT(cnt >= 0);
+@@ -3170,7 +3171,7 @@ crypto_read_low(PslChanFsm* const pFsm,
+         "terminating PslError=%d (%s), openSSL state=%d (%s)",
+                   __func__, pFsm, cnt, *pNumRead, (int)ioAttempted, pslErrRes,
+                   PmSockErrStringFromError(pslErrRes), 
+-                  SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++                  SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+ 
+     return pslErrRes;
+ }// crypto_read_low
+@@ -3254,7 +3255,7 @@ crypto_write_low(PslChanFsm*    const pFsm,
+ 
+     PSL_LOG_DEBUG("%s (fsm=%p): ENTERING: requested cnt=%d, maxWrCnt=%d, " \
+                   "openSSL state=%d (%s)", __func__, pFsm, cnt, maxWriteCnt,
+-                  SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++                  SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+ 
+     PslError pslErrRes = 0; // result error code to be returned
+ 
+@@ -3348,7 +3349,7 @@ crypto_write_low(PslChanFsm*    const pFsm,
+         "terminating PslError=%d (%s), openSSL state=%d (%s)",
+         __func__, pFsm, *pNumWritten, *pDeferredWriteCnt, pslErrRes,
+         PmSockErrStringFromError(pslErrRes),
+-        SSL_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
++        SSL_get_state(sslInfo->ssl), SSL_state_string_long(sslInfo->ssl));
+ 
+     return pslErrRes;
+ }//crypto_write_low
+diff --git a/src/psl_openssl_utils.c b/src/psl_openssl_utils.c
+index e901916..0be5c04 100644
+--- a/src/psl_openssl_utils.c
++++ b/src/psl_openssl_utils.c
+@@ -150,18 +150,18 @@ PmSockOpensslMatchCertInStore(struct x509_store_ctx_st*  const x509StoreCtx,
+     /// @see X509_STORE_CTX_get1_issuer + X509_check_issued + X509_cmp
+ 
+     X509_NAME* const subjName = X509_get_subject_name(cert);
+-    X509_OBJECT installedObj;
++    X509_OBJECT *installedObj = NULL;
+     int const rc = X509_STORE_get_by_subject(x509StoreCtx, X509_LU_X509, subjName,
+-                                             &installedObj); 
++                                             installedObj); 
+     
+     bool matched = false;
+ 
+-    if (X509_LU_X509 == rc && installedObj.data.x509) {
+-        matched = (0 == X509_cmp(cert, installedObj.data.x509));
++    if (X509_LU_X509 == rc && X509_OBJECT_get0_X509(installedObj)) {
++        matched = (0 == X509_cmp(cert, X509_OBJECT_get0_X509(installedObj)));
+     }
+ 
+     if (X509_LU_FAIL != rc) {
+-        X509_OBJECT_free_contents(&installedObj);
++        X509_OBJECT_free(installedObj);
+     }
+ 
+     if (X509_LU_X509 != rc) {
+@@ -179,7 +179,7 @@ PmSockOpensslMatchCertInStore(struct x509_store_ctx_st*  const x509StoreCtx,
+     /**
+      * Look through all certs with matching subject names
+      */
+-    int i = X509_OBJECT_idx_by_subject(x509StoreCtx->ctx->objs, X509_LU_X509, subjName);
++    int i = X509_OBJECT_idx_by_subject(X509_STORE_get0_objects(X509_STORE_CTX_get0_store(x509StoreCtx)), X509_LU_X509, subjName);
+     if (-1 == i) {
+         PSL_LOG_WARNING("%s (cert=%p): ERROR: X509_OBJECT_idx_by_subject() " \
+                         "found no certs with matching subject" \
+@@ -188,14 +188,14 @@ PmSockOpensslMatchCertInStore(struct x509_store_ctx_st*  const x509StoreCtx,
+         return PSL_ERR_NONE;
+     }
+ 
+-    for (; i < sk_X509_OBJECT_num(x509StoreCtx->ctx->objs); i++) {
+-        X509_OBJECT* const pObj = sk_X509_OBJECT_value(x509StoreCtx->ctx->objs, i);
++    for (; i < sk_X509_OBJECT_num(X509_STORE_get0_objects(X509_STORE_CTX_get0_store(x509StoreCtx))); i++) {
++        X509_OBJECT* const pObj = sk_X509_OBJECT_value(X509_STORE_get0_objects(X509_STORE_CTX_get0_store(x509StoreCtx)), i);
+ 
+-        if (0 != X509_NAME_cmp(subjName, X509_get_subject_name(pObj->data.x509))) {
++        if (0 != X509_NAME_cmp(subjName, X509_get_subject_name(X509_OBJECT_get0_X509(pObj)))) {
+             continue;
+         }
+ 
+-        if (0 == X509_cmp(cert, pObj->data.x509)) {
++        if (0 == X509_cmp(cert, X509_OBJECT_get0_X509(pObj))) {
+             PSL_LOG_DEBUG("%s (cert=%p): cert found", __func__, cert);
+             *pMatchRes = true;
+             return PSL_ERR_NONE;
+-- 
+2.17.0
+

--- a/meta-luneos/recipes-webos/mojomail/mojomail.inc
+++ b/meta-luneos/recipes-webos/mojomail/mojomail.inc
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 DEPENDS = "jemalloc db8 boost curl libpalmsocket libsandbox pmloglib icu json-c glib-2.0 luna-service2"
 
-PV = "2.0.0-99+git${SRCPV}"
-SRCREV = "d093509e7666a27392419977a9577b751ffb6872"
+PV = "2.0.0-100+git${SRCPV}"
+SRCREV = "71274cdf36d66a029717f0a61133aa54861f9d1d"
 
 inherit webos_ports_fork_repo
 inherit webos_cmake

--- a/meta-luneos/recipes-webos/pmcertificatemgr/pmcertificatemgr.bb
+++ b/meta-luneos/recipes-webos/pmcertificatemgr/pmcertificatemgr.bb
@@ -9,8 +9,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 DEPENDS = "openssl glib-2.0"
 RDEPENDS_${PN} = "ca-certificates"
 
-PV = "2.0.0-29+git${SRCPV}"
-SRCREV = "dc711d0788cd782e543bfa4c82eb23aee238825d"
+PV = "2.0.0-30+git${SRCPV}"
+SRCREV = "5b176d25dcc5f8bf27c57414a027cd67fc6dd593"
 
 inherit webos_ports_repo
 inherit webos_cmake


### PR DESCRIPTION
* Remove the systraces commit, which depends on the patched Mer version
  of qtbase
* Also reinclude mojomail and libpalmsocket. The fixes are in https://github.com/webOS-ports/pmcertificatemgr/pull/2 and https://github.com/webOS-ports/mojomail/pull/4

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>