### PR TITLE
Remove old and add new ICQ/AOL plugin

### DIFF
--- a/meta-luneos/recipes-luneos/services/imaccountvalidator.bb
+++ b/meta-luneos/recipes-luneos/services/imaccountvalidator.bb
@@ -35,10 +35,8 @@ RRECOMMENDS_${PN} += " \
     libpurple-plugin-ssl \
     libpurple-plugin-ssl-gnutls \
     libpurple-plugin-statenotify \
-    libpurple-protocol-aim \
     libpurple-protocol-bonjour \
     libpurple-protocol-gg \
-    libpurple-protocol-icq \
     libpurple-protocol-irc \
     libpurple-protocol-novell \
     libpurple-protocol-simple \

--- a/meta-luneos/recipes-luneos/services/imaccountvalidator.bb
+++ b/meta-luneos/recipes-luneos/services/imaccountvalidator.bb
@@ -24,6 +24,7 @@ RRECOMMENDS_${PN} += " \
     pidgin-sipe \
     purple-skypeweb \
     funyahoo-plusplus \
+    icyque \
     libpurple-plugin-autoaccept \
     libpurple-plugin-buddynote \
     libpurple-plugin-idle \

--- a/meta-luneos/recipes-luneos/services/imlibpurpleservice.bb
+++ b/meta-luneos/recipes-luneos/services/imlibpurpleservice.bb
@@ -35,10 +35,8 @@ RRECOMMENDS_${PN} += " \
     libpurple-plugin-ssl \
     libpurple-plugin-ssl-gnutls \
     libpurple-plugin-statenotify \
-    libpurple-protocol-aim \
     libpurple-protocol-bonjour \
     libpurple-protocol-gg \
-    libpurple-protocol-icq \
     libpurple-protocol-irc \
     libpurple-protocol-novell \
     libpurple-protocol-simple \

--- a/meta-luneos/recipes-luneos/services/imlibpurpleservice.bb
+++ b/meta-luneos/recipes-luneos/services/imlibpurpleservice.bb
@@ -24,6 +24,7 @@ RRECOMMENDS_${PN} += " \
     pidgin-sipe \
     purple-skypeweb \
     funyahoo-plusplus \
+    icyque \
     libpurple-plugin-autoaccept \
     libpurple-plugin-buddynote \
     libpurple-plugin-idle \

--- a/meta-luneos/recipes-support/pidgin/icyque_git.bb
+++ b/meta-luneos/recipes-support/pidgin/icyque_git.bb
@@ -1,0 +1,27 @@
+SUMMARY = "WIM Protocol plugin for ICQ for Adium, Pidgin, Miranda and Telepathy IM Framework"
+SECTION = "webos/services"
+LICENSE = "GPLv3.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+DEPENDS = "pidgin json-glib"
+
+PV = "0.1+gitr${SRCPV}"
+
+inherit pkgconfig
+
+SRC_URI = "git://github.com/EionRobb/icyque"
+SRCREV = "513fc162d5d1a201c2b044e2b42941436d1069d5"
+
+S = "${WORKDIR}/git"
+
+do_compile() {
+    oe_runmake;
+}
+
+do_install() {
+    oe_runmake DESTDIR="${D}" install;
+}
+
+FILES_${PN} += " \
+    ${libdir} \
+"


### PR DESCRIPTION
Old ICQ/AOL plugin is no longer working, therefore remove them. 

Add new icyque plugin that supports the new WIM protocol.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>