### PR TITLE
mojo: Switch to webOS-ports/webOS-OSE branches

### DIFF
--- a/meta-luneos/recipes-luneos/services/org.webosports.cdav.bb
+++ b/meta-luneos/recipes-luneos/services/org.webosports.cdav.bb
@@ -9,9 +9,10 @@ inherit webos_filesystem_paths
 inherit webos_system_bus
 
 PV = "0.3.33+git${SRCPV}"
-SRCREV = "e9e585be16d0201c8f9084640fd506e09c884718"
+SRCREV = "4642548f77e15c9d0908d40b1e49e6a1d5d39276"
 
 WEBOS_REPO_NAME = "org.webosports.service.contacts.carddav"
+WEBOS_GIT_PARAM_BRANCH = "webOS-ports/webOS-OSE"
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-luneos/services/org.webosports.service.update.bb
+++ b/meta-luneos/recipes-luneos/services/org.webosports.service.update.bb
@@ -8,9 +8,10 @@ inherit webos_filesystem_paths
 inherit webos_system_bus
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "d9729fb1ee19aea45e630b8877cd2bbcc36b3c60"
+SRCREV = "38730c840cf80c92bb4e6594f442dc3227db102f"
 
 WEBOS_REPO_NAME = "org.webosports.update"
+WEBOS_GIT_PARAM_BRANCH = "webOS-ports/webOS-OSE"
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git/service"
 

--- a/meta-luneos/recipes-webos/frameworks/mojoservice-frameworks.bb
+++ b/meta-luneos/recipes-webos/frameworks/mojoservice-frameworks.bb
@@ -6,13 +6,14 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 PV = "1.1-3+git${SRCPV}"
-SRCREV = "0baa0cd1bcd7c2182718a4927efcff9dbf901812"
+SRCREV = "9d725d8cf390b1771644b73f3ededbedb48cb22b"
 
 inherit webos_ports_fork_repo
 inherit webos_filesystem_paths
 #inherit webos_cmake
 inherit allarch
 
+WEBOS_GIT_PARAM_BRANCH = "webOS-ports/webOS-OSE"
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos/mojomail/mojomail.inc
+++ b/meta-luneos/recipes-webos/mojomail/mojomail.inc
@@ -7,14 +7,15 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 DEPENDS = "jemalloc db8 boost curl libpalmsocket libsandbox pmloglib icu json-c glib-2.0 luna-service2"
 
 PV = "2.0.0-99+git${SRCPV}"
-SRCREV = "2ad76b33b6d0a355baca1dacf65ddb66b49d7f6e"
+SRCREV = "77572e8ede86d077ce6fd8e2e1576b3777b5cbaa"
 
 inherit webos_ports_fork_repo
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_machine_impl_dep
 
+WEBOS_GIT_PARAM_BRANCH = "webOS-ports/webOS-OSE"
 WEBOS_REPO_NAME = "mojomail"
-SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE};branch=webosose;"
+SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 
 CXXFLAGS += "-fpermissive"


### PR DESCRIPTION
Which include the changes for internetConfidence = fair to internet = true to allow working with new ActivityManager in OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>