### PR TITLE
systemd-serialgetty: disable SERIAL_CONSOLES on LuneOS's qemu

### DIFF
--- a/meta-luneos/recipes-core/systemd/systemd-serialgetty.bbappend
+++ b/meta-luneos/recipes-core/systemd/systemd-serialgetty.bbappend
@@ -1,0 +1,4 @@
+# serial consoles are not very useful in VirtualBox emulator and generates lots of logs
+# so let's diable them for LuneOS
+SERIAL_CONSOLES_qemux86 = ""
+SERIAL_CONSOLES_qemux86-64 = ""


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>