### PR TITLE
systemd: reenable timesyncd

### DIFF
--- a/meta-luneos/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-luneos/recipes-core/systemd/systemd_%.bbappend
@@ -10,6 +10,5 @@ PACKAGECONFIG_remove = " \
     networkd    \
     resolved    \
     timedated   \
-    timesyncd   \
     nss-resolve \
 "


### PR DESCRIPTION
luna-sysservice needs timedatectl to work properly.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>