### PR TITLE
sensorfw: reorganize recipe to have more common code

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -81,6 +81,9 @@ RDEPENDS_${PN} = " \
   qtwayland \
   qtwayland-plugins \
   qtconnectivity \
+  qtsensors-sensorfw-plugin \
+  \
+  sensorfw \
   \
   luna-appmanager \
   luna-next-cardshell \
@@ -121,8 +124,6 @@ LIBHYBRIS_RDEPENDS = " \
     pulseaudio-modules-droid \
     qt5-qpa-hwcomposer-plugin \
     qtscenegraph-adaptation \
-    qtsensors-sensorfw-plugin \
-    sensorfw \
     \
     exiv2 \
     libpulse-simple0 \

--- a/meta-luneos/recipes-support/sensorfw/sensorfw/sensord-iiosensors.conf
+++ b/meta-luneos/recipes-support/sensorfw/sensorfw/sensord-iiosensors.conf
@@ -1,6 +1,0 @@
-[plugins]
-accelerometeradaptor = iiosensorsadaptor
-orientationadaptor = iiosensorsadaptor
-alsadaptor = iiosensorsadaptor
-magnetometeradaptor = iiosensorsadaptor
-gyroscopeadaptor = iiosensorsadaptor

--- a/meta-luneos/recipes-support/sensorfw/sensorfw/sensord-pinephone.conf
+++ b/meta-luneos/recipes-support/sensorfw/sensorfw/sensord-pinephone.conf
@@ -1,3 +1,10 @@
+[plugins]
+accelerometeradaptor = iiosensorsadaptor
+orientationadaptor = iiosensorsadaptor
+alsadaptor = iiosensorsadaptor
+magnetometeradaptor = iiosensorsadaptor
+gyroscopeadaptor = iiosensorsadaptor
+
 [accelerometer]
 input_match=mpu6050
 intervals = "200=>2000"


### PR DESCRIPTION
To have sensorfw recipe use a machine-dedicated configuration file, it
is now only needed to provide the sensord-${MACHINE}.conf file.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>