### PR TITLE
qtwayland: fix compilation with Pinephone's version of Mesa

### DIFF
--- a/meta-luneui/recipes-qt/qt5/qtwayland/0005-Fix-compilation-of-linuxdmabuf.patch
+++ b/meta-luneui/recipes-qt/qt5/qtwayland/0005-Fix-compilation-of-linuxdmabuf.patch
@@ -1,0 +1,27 @@
+From c2105d8b7e16cc934b886537968228f6300bf4bc Mon Sep 17 00:00:00 2001
+From: Johan Klokkhammer Helsing <johan.helsing@qt.io>
+Date: Fri, 08 Nov 2019 13:58:04 +0100
+Subject: [PATCH] Fix compilation of linuxdmabuf compositor plugin
+
+Mesa's eglext.h no longer includes eglmesaext.h, so copy over the typedefs we need.
+
+Fixes: QTBUG-79709
+Change-Id: I3190ef56e0e162636efea440dff7e760cf11fcd0
+Reviewed-by: Laszlo Agocs <laszlo.agocs@qt.io>
+---
+
+diff --git a/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h b/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
+index 8554721..02b5b6f 100644
+--- a/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
++++ b/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
+@@ -58,6 +58,10 @@
+ #define DRM_FORMAT_MOD_INVALID  fourcc_mod_code(NONE, DRM_FORMAT_RESERVED)
+ #endif
+ 
++// Copied from eglmesaext.h
++typedef EGLBoolean (EGLAPIENTRYP PFNEGLBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
++typedef EGLBoolean (EGLAPIENTRYP PFNEGLUNBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QWaylandCompositor;

--- a/meta-luneui/recipes-qt/qt5/qtwayland_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtwayland_git.bbappend
@@ -17,6 +17,7 @@ SRC_URI += " \
     file://0002-Fix-QtKeyExtensionGlobal-s-export.patch \
     file://0003-Revert-Remove-QWaylandExtendedSurface-from-the-priva.patch \
     file://0004-QWaylandXdgSurface-handle-ExtendedSurface-window-pro.patch \
+    file://0005-Fix-compilation-of-linuxdmabuf.patch \
 "
 
 FILES_${PN} += "${OE_QMAKE_PATH_PLUGINS}/wayland-graphics-integration"


### PR DESCRIPTION
For Pinephone we need a newer version of Mesa, and that breaks one of
the plugins of qtwayland.
Indeed, eglmesaext.h doesn't get indirectly included by eglext.h, and
some typedefs aren't defined anymore.

This patch will become useless when Mesa ships with an updated set of
Khronos headers, because https://github.com/KhronosGroup/EGL-Registry/pull/95
has now been merged.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>