### PR TITLE
busybox: pmlogdaemon RCONFLICTS with busybox-syslog

### DIFF
--- a/meta-luneos/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-luneos/recipes-core/busybox/busybox_%.bbappend
@@ -1,0 +1,2 @@
+# PmLogDaemon is also a syslog provider
+RCONFLICTS_${PN}-syslog += "pmlogdaemon"


### PR DESCRIPTION
They both provide a syslog daemon, but there can only be one.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>