### PR TITLE
Use upstream wayland-egl for our devices

### DIFF
--- a/meta-luneos/recipes-graphics/wayland/wayland_%.bbappend
+++ b/meta-luneos/recipes-graphics/wayland/wayland_%.bbappend
@@ -1,9 +1,0 @@
-
-# remove provided `libwayland-egl` library in favour of the version in `libhybris`
-
-do_install_append_class-target() {
-    if ${@oe.utils.conditional('PREFERRED_PROVIDER_virtual/egl', 'libhybris', 'true', 'false', d)} ; then
-        rm -rvf ${D}${libdir}/libwayland-egl*
-        rm -rvf ${D}${libdir}/pkgconfig/wayland-egl.pc
-    fi
-}

--- a/meta-luneui/recipes-qt/qt5/qtbase/0002-QThreadData-use-libpthread-instead-of-gcc-TLS.patch
+++ b/meta-luneui/recipes-qt/qt5/qtbase/0002-QThreadData-use-libpthread-instead-of-gcc-TLS.patch
@@ -1,0 +1,51 @@
+From 9f2d205d3e92483c45c20da28c6fb30eb86275ed Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sun, 5 Jul 2020 08:39:55 +0000
+Subject: [PATCH] QThreadData: use libpthread instead of gcc TLS
+
+At least on old armv7 devices (hammerhead, tenderloin...) is seems that using
+gcc TLS (with thread_local variables) is being corrupted by the TLS usage of
+the libhybris libraries.
+So don't use gcc's TLS at all in Qt and go through pthread_get/setspecific API.
+It's a bit slower, but at least it doesn't get corrupted.
+---
+ src/corelib/thread/qthread_unix.cpp | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/src/corelib/thread/qthread_unix.cpp b/src/corelib/thread/qthread_unix.cpp
+index 1da68b3130..8758930689 100644
+--- a/src/corelib/thread/qthread_unix.cpp
++++ b/src/corelib/thread/qthread_unix.cpp
+@@ -109,8 +109,6 @@ Q_STATIC_ASSERT(sizeof(pthread_t) <= sizeof(Qt::HANDLE));
+ enum { ThreadPriorityResetFlag = 0x80000000 };
+ 
+ 
+-static thread_local QThreadData *currentThreadData = nullptr;
+-
+ static pthread_once_t current_thread_data_once = PTHREAD_ONCE_INIT;
+ static pthread_key_t current_thread_data_key;
+ 
+@@ -170,19 +168,18 @@ Q_DESTRUCTOR_FUNCTION(destroy_current_thread_data_key)
+ // Utility functions for getting, setting and clearing thread specific data.
+ static QThreadData *get_thread_data()
+ {
+-    return currentThreadData;
++    pthread_once(&current_thread_data_once, create_current_thread_data_key);
++    return (QThreadData *)pthread_getspecific(current_thread_data_key);
+ }
+ 
+ static void set_thread_data(QThreadData *data)
+ {
+-    currentThreadData = data;
+     pthread_once(&current_thread_data_once, create_current_thread_data_key);
+     pthread_setspecific(current_thread_data_key, data);
+ }
+ 
+ static void clear_thread_data()
+ {
+-    currentThreadData = nullptr;
+     pthread_setspecific(current_thread_data_key, nullptr);
+ }
+ 
+-- 
+2.17.0

--- a/meta-luneui/recipes-qt/qt5/qtbase_git.bbappend
+++ b/meta-luneui/recipes-qt/qt5/qtbase_git.bbappend
@@ -8,6 +8,13 @@ SRC_URI += " \
     file://0001-Determine-devicePixelRatio-from-environment-variable.patch \
 "
 
+# Fix a crash on armv7 devices. A similar commit (https://github.com/qt/qtbase/commit/78665d8a0cc06aa17a0dc3987afb6d2f3d86e6af) has been since reverted in Qt due to other issues, but this fixes
+# annoying crashes (std::bad_alloc) on Qt apps in LuneOS for old armv7 devices.
+
+SRC_URI_append_halium_armv7a += " \
+    file://0002-QThreadData-use-libpthread-instead-of-gcc-TLS.patch \
+"
+
 QPA ?= "-qpa wayland-egl"
 QPA_rpi = "-qpa wayland"
 QPA_qemuall = "-qpa eglfs"


### PR DESCRIPTION
Instead of wayland-egl provided by libhybris, should be merged together with https://github.com/shr-distribution/meta-smartphone/pull/116

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>