### PR TITLE
nyx-modules-hybris: fix install path for tenderloin

### DIFF
--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
@@ -60,6 +60,10 @@ do_configure_prepend() {
     fi
 }
 
+do_install_append_tenderloin() {
+    install -d ${D}${systemd_system_unitdir}/nyx.target.d/
+    install -m 0644 ${S}/files/systemd/nyx.target.d/wait-touchscreen.conf ${D}${systemd_system_unitdir}/nyx.target.d/
+}
 
 PACKAGES += "${PN}-tests"
 FILES_${PN} += "${libdir}/nyx/modules/*"

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin.cmake
@@ -33,5 +33,3 @@ set(NYXMOD_OW_HAPTICS			FALSE)
 
 add_definitions(-DBATTERY_SYSFS_PATH=\"/sys/class/power_supply/battery/\")
 add_definitions(-DTOUCHPANEL_DEVICE=\"/dev/input/event6\")
-
-install(FILES files/systemd/nyx.target.d/wait-touchscreen.conf DESTINATION ${WEBOS_INSTALL_ROOT}/lib/systemd/system/nyx.target.d/)


### PR DESCRIPTION
* WEBOS_INSTALL_ROOT is '/':
  meta-luneui/classes/webos_cmake.bbclass:EXTRA_OECMAKE += "-DWEBOS_INSTALL_ROOT:PATH=/"

  and ${WEBOS_INSTALL_ROOT}/lib/systemd/system
  then starts with // which CMake doesn't like:

| CMake Error at cmake_install.cmake:54 (file):
|   file called with network path DESTINATION.  This does not make sense when
|   using DESTDIR.  Specify local absolute path or remove DESTDIR environment
|   variable.
|
|   DESTINATION=
|
|   //lib/systemd/system/nyx.target.d

* now both nyx-modules and nyx-modules-hybris would try to install this
  files/systemd/nyx.target.d/wait-touchscreen.conf
  but it only exists in nyx-modules repo since:
  commit 2332bec773c4660d9fc6df56efd0bbf38f84604d
  Author: Nikolay Nizov <nizovn@gmail.com>
  Date:   Sat Sep 10 15:27:45 2016 +0300

    tenderloin: wait for touchscreen device before reaching nyx.target

  and it doesn't make sense to install it by 2 packages (which would fail
  anyway), add 2nd tenderloin.cmake to nyx-modules-hybris/tenderloin so
  that it's found first in FILESPATH thanks to MACHINE override:

$ grep FILESPATH= env.nyx-modules-hybris | sed "s/:/\n/g"
FILESPATH="/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/luneos
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/luneos
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/luneos
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/luneos
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/tenderloin
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/halium
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/halium
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/halium
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/halium
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/armv7a
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/armv7a
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/armv7a
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/armv7a
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/arm
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/arm
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/arm
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/arm
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules/
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris-0.1.0-1+gitAUTOINC+6197796c17/
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/nyx-modules-hybris/
/OE/build/luneos-hardknott/webos-ports/meta-webos-ports/meta-luneos/recipes-webos/nyx-modules/files/"

  and the only difference in this tenderloin.cmake is that it doesn't install wait-touchscreen.conf

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>