### PR TITLE
nyx-modules: fix wait-touchscreen.conf installation for tenderloin

### DIFF
--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
@@ -60,6 +60,10 @@ do_configure_prepend() {
     fi
 }
 
+do_install_append_tenderloin() {
+    install -d ${D}${systemd_system_unitdir}/nyx.target.d/
+    install -m 0644 ${S}/files/systemd/nyx.target.d/wait-touchscreen.conf ${D}${systemd_system_unitdir}/nyx.target.d/
+}
 
 PACKAGES += "${PN}-tests"
 FILES_${PN} += "${libdir}/nyx/modules/*"

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin.cmake
@@ -33,5 +33,3 @@ set(NYXMOD_OW_HAPTICS			FALSE)
 
 add_definitions(-DBATTERY_SYSFS_PATH=\"/sys/class/power_supply/battery/\")
 add_definitions(-DTOUCHPANEL_DEVICE=\"/dev/input/event6\")
-
-install(FILES files/systemd/nyx.target.d/wait-touchscreen.conf DESTINATION ${WEBOS_INSTALL_ROOT}/lib/systemd/system/nyx.target.d/)


### PR DESCRIPTION
* move the /lib/systemd/system/nyx.target.d/wait-touchscreen.conf installation
  from tenderloin.cmake to do_install_append_tenderloin, because tenderloin.cmake
  is reused also by nyx-modules-hybris

* also make it to respect systemd_system_unitdir variable

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>