### PR TITLE
nyx-modules: tenderloin: use haptics modules from OSE

### DIFF
--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin.cmake
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/tenderloin.cmake
@@ -24,12 +24,12 @@ set(NYXMOD_OW_CHARGER			TRUE)
 set(NYXMOD_OW_KEYS			TRUE)
 set(NYXMOD_OW_TOUCHPANEL		FALSE)
 set(NYXMOD_OW_TOUCHPANEL_MTDEV		TRUE)
+set(NYXMOD_OW_HAPTICS			TRUE)
 
 # provided by nyx-modules-hybris
 set(NYXMOD_OW_DEVICEINFO		FALSE)
 set(NYXMOD_OW_SYSTEM			FALSE)
 set(NYXMOD_OW_LED			FALSE)
-set(NYXMOD_OW_HAPTICS			FALSE)
 
 add_definitions(-DBATTERY_SYSFS_PATH=\"/sys/class/power_supply/battery/\")
 add_definitions(-DTOUCHPANEL_DEVICE=\"/dev/input/event6\")


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>