### PR TITLE
webos_app_generate_security_files: Add private bus access for org.web…

### DIFF
--- a/meta-luneos/classes/webos_app_generate_security_files.bbclass
+++ b/meta-luneos/classes/webos_app_generate_security_files.bbclass
@@ -48,7 +48,7 @@ def webos_app_generate_security_files_write_permission_file(d, app_info):
             bb.fatal("Unexpected trustLevel: " + trust_level)
 
         if type == "web":
-            if "com.palm." in app_id or "com.webos." in app_id:
+            if "com.palm." in app_id or "com.webos." in app_id or "org.webosports." in app_id:
                 prv_bus = True
         elif type == "qml":
             prv_bus = True


### PR DESCRIPTION
…osports as well

Giving our own apps the same permissions like com.palm and com.webos apps.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>