### PR TITLE
luna-sysmgr: move /media/cryptofs/apps/var/lock creation back to pkg_…

### DIFF
--- a/meta-luneos/recipes-webos/luna-sysmgr/luna-sysmgr.bb
+++ b/meta-luneos/recipes-webos/luna-sysmgr/luna-sysmgr.bb
@@ -30,9 +30,6 @@ SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE};"
 S = "${WORKDIR}/git"
 
 do_install:append() {
-
-    install -d ${D}${webos_cryptofsdir}/apps/var/lock
-
     # install images & low-memory files
     install -d ${D}${webos_sysmgrdir}/images
     install -v -m 644 ${S}/images/* ${D}${webos_sysmgrdir}/images
@@ -88,6 +85,12 @@ do_install:append() {
         install -d ${D}${webos_sysconfdir}/pubsub_handlers
         install -v -m 0644 ${S}/files/sysbus/com.palm.appinstaller.pubsub ${D}${webos_sysconfdir}/pubsub_handlers/com.palm.appinstaller
     fi
+}
+
+pkg_postinst:${PN}() {
+￼    # We need the lock directory for the application installer which will fail if this
+￼    # directory does not exist
+￼    mkdir -p $D${webos_cryptofsdir}/apps/var/lock
 }
 
 FILES:${PN} += "${webos_sysmgrdir} ${webos_sysconfdir} ${webos_applicationsdir} ${webos_soundsdir} ${webos_cryptofsdir}"


### PR DESCRIPTION
…postinst

* it was moved to do_install:append in:
  https://github.com/webOS-ports/meta-webos-ports/commit/d08cb7011c3a00f16a874e5de0f121517eaaa1d4

* use $D prefix to fix postinst execution in do_rootfs

* now causes:
  ERROR: luna-sysmgr-3.0.0-3+gitAUTOINC+c18ff49155-r0 do_package_qa: QA Issue: luna-sysmgr installs files in /media, but it is expected to be empty [empty-dirs]
  ERROR: luna-sysmgr-3.0.0-3+gitAUTOINC+c18ff49155-r0 do_package_qa: Fatal QA errors were found, failing task.
  ERROR: Logfile of failure stored in: /OE/build/luneos-kirkstone/webos-ports/tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/temp/log.do_package_qa.606622

  webos-ports $ find tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/image/media/
  tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/image/media/
  tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/image/media/cryptofs
  tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/image/media/cryptofs/apps
  tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/image/media/cryptofs/apps/var
  tmp-glibc/work/core2-64-webos-linux/luna-sysmgr/3.0.0-3+gitAUTOINC+c18ff49155-r0/image/media/cryptofs/apps/var/lock

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>