### PR TITLE
mobile-broadband-provider-info: Use Mer's version only for Halium tar…

### DIFF
--- a/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_git.bbappend
+++ b/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_git.bbappend
@@ -1,5 +1,7 @@
-SRC_URI  = "git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master"
-S = "${WORKDIR}/git/${PN}"
+#Mer uses their own version of MBPI which has some elements added. So we want to use their version only in case we're using their oFono version. In other cases where we use upstream oFono we want to use the regular MBPI from Yocto.
 
-SRCREV = "fe500f1b19e8525d09655a38ac111a0fe127b5f9"
-LIC_FILES_CHKSUM = "file://COPYING;md5=87964579b2a8ece4bc6744d2dc9a8b04"
+SRC_URI:halium  = "git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master"
+S:halium = "${WORKDIR}/git/${PN}"
+
+SRCREV:halium = "fe500f1b19e8525d09655a38ac111a0fe127b5f9"
+LIC_FILES_CHKSUM:halium = "file://COPYING;md5=87964579b2a8ece4bc6744d2dc9a8b04"


### PR DESCRIPTION
…gets

Mer uses their own version of MBPI which has some elements added. So we want to use their version only in case we're using their oFono version (Halium targets). In other cases (mainline) where we use upstream oFono we want to use the regular MBPI from Yocto.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>