### PR TITLE
luna-next-conf: For tenderloin, $HOME/.cache can conflict with webOS one

### DIFF
--- a/meta-luneui/recipes-luneui/luna-next/luna-next-conf/tenderloin/environment.conf
+++ b/meta-luneui/recipes-luneui/luna-next/luna-next-conf/tenderloin/environment.conf
@@ -6,4 +6,4 @@ LUNA_NEXT_OPTIONS=-plugin evdevtouch:/dev/input/event6 -plugin evdevkeyboard
 QT_QPA_EGLFS_HIDECURSOR=1
 QT_COMPOSITOR_NEGATE_INVERTED_Y=0
 QT_IM_MODULE=Maliit
-HOME=/media/internal
+HOME=/var/home/root


### PR DESCRIPTION
This can cause gstreamer to crash, if the cached data can't be read
correctly.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>