### PR TITLE
packagegroup-luneos-extended: Fix RDEPENDS for qemux86-64

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -175,7 +175,7 @@ QEMU_RDEPENDS = " \
 "
 
 RDEPENDS:${PN}:append:qemux86 = " ${QEMU_RDEPENDS}"
-#RDEPENDS:${PN}:append:qemux86-64 = " ${QEMU_RDEPENDS} waydroid"
+RDEPENDS:${PN}:append:qemux86-64 = " ${QEMU_RDEPENDS}"
 
 RDEPENDS:${PN}:append:arm = " \
     crash-handler \


### PR DESCRIPTION
Dropped the ${QEMU_RDEPENDS} by mistake when trying to disable the build of waydroid by default.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>