### PR TITLE
webruntime: fix app_shell wrapper

### DIFF
--- a/meta-luneos/recipes-webos/chromium/files/0034-run_app_shell-fix-XDG_RUNTIME_DIR-for-LuneOS.patch
+++ b/meta-luneos/recipes-webos/chromium/files/0034-run_app_shell-fix-XDG_RUNTIME_DIR-for-LuneOS.patch
@@ -1,0 +1,37 @@
+From 633c14c9d5907a84065f3913fb420a9831eb5851 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Wed, 16 Mar 2022 18:48:35 +0000
+Subject: [PATCH] run_app_shell: fix XDG_RUNTIME_DIR for LuneOS
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/webos/install/app_shell/run_app_shell | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/webos/install/app_shell/run_app_shell b/src/webos/install/app_shell/run_app_shell
+index 7ac65702b1..b34863bb35 100644
+--- a/src/webos/install/app_shell/run_app_shell
++++ b/src/webos/install/app_shell/run_app_shell
+@@ -21,6 +21,8 @@ export MAX_GPU_MEM_LIMIT=60
+ # setup 32Mb maximum for DiskCache
+ export APPSHELL_DISKCACHE_MAXSIZE=33554432
+ 
++export XDG_RUNTIME_DIR=/tmp/luna-session
++
+ while [[ "$1" != ""  &&  "$2" != "" ]]; do
+     PARAM=$1
+     VALUE=$2
+@@ -53,8 +55,8 @@ if [ -z ${BROWSER_APP_ID} ]; then
+     exit 1
+ fi
+ 
+-if test -d ${XDG_RUNTIME_DIR}; then
+-  export XDG_RUNTIME_DIR="${TMPDIR}/xdg"
++if ! test -d ${XDG_RUNTIME_DIR}; then
++  export XDG_RUNTIME_DIR="${TMPDIR}/luna-session"
+ fi
+ 
+ DEPLOY_DIR=$(dirname $(readlink -f $0))
+-- 
+2.17.1
+

--- a/meta-luneos/recipes-webos/chromium/webruntime-repo_91.inc
+++ b/meta-luneos/recipes-webos/chromium/webruntime-repo_91.inc
@@ -51,4 +51,5 @@ SRC_URI += " \
     file://0031-Py2-Py3-for-third_party-dom_distiller_js.patch \
     file://0032-Py2-Py3-fixup-for-dom_distiller_js.patch \
     file://0033-catapult-use-python3-for-rcssmin.patch \
+    file://0034-run_app_shell-fix-XDG_RUNTIME_DIR-for-LuneOS.patch \
 "


### PR DESCRIPTION
Fix XDG_RUNTIME_DIR value, leading to app_shell crashing on startup

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>