### PR TITLE
rng-tools: Speed up boot time

### DIFF
--- a/meta-luneos/conf/layer.conf
+++ b/meta-luneos/conf/layer.conf
@@ -18,6 +18,7 @@ LAYERDEPENDS_meta-luneos = "\
 
 SIGGEN_EXCLUDERECIPES_ABISAFE += " \
   ofono-conf \
+  rng-tools \
 "
 
 SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += " \

--- a/meta-luneos/recipes-support/rng-tools/rng-tools/tenderloin/rngd.service
+++ b/meta-luneos/recipes-support/rng-tools/rng-tools/tenderloin/rngd.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Hardware RNG Entropy Gatherer Daemon
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=sysinit.target shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+EnvironmentFile=-@SYSCONFDIR@/default/rng-tools
+ExecStart=@SBINDIR@/rngd -f $EXTRA_ARGS
+CapabilityBoundingSet=CAP_SYS_ADMIN
+IPAddressDeny=any
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=sysinit.target

--- a/meta-luneos/recipes-support/rng-tools/rng-tools_%.bbappend
+++ b/meta-luneos/recipes-support/rng-tools/rng-tools_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+SRC_URI += " \
+file://rngd.service \
+"


### PR DESCRIPTION
By reverting: https://github.com/openembedded/openembedded-core/commit/e9715d4234eb7b45dee8b323799014646f0a1b07

Reduces boot time by about 2 minutes from 210 seconds to 90 seconds.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>