### PR TITLE
enyo-1.0: Add symlink for tellurium

### DIFF
--- a/meta-luneos/recipes-webos/frameworks/enyo-1.0.bb
+++ b/meta-luneos/recipes-webos/frameworks/enyo-1.0.bb
@@ -24,6 +24,8 @@ do_install() {
 
     # Create symlink for enyo/1.0 (points to enyo/0.10)
     ln -vs 0.10 ${D}${webos_frameworksdir}/enyo/1.0
+    # Create symlink for tellurium (so the inspector doesn't give errors)
+    ln -vs enyo/0.10/framework/build/palm/tellurium ${D}${webos_frameworksdir}/tellurium
 }
 
 FILES:${PN} += "${webos_frameworksdir}"


### PR DESCRIPTION
Fixes the following in the webinspector in Enyo 1.0 apps:
Access is blocked to resource: file:///usr/palm/frameworks/tellurium/tellurium_config.json
enyo-build.js:1756 GET chrome-error://chromeillegalwebdata/ net::ERR_ACCESS_DENIED

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>