### PR TITLE
Use Prelude system wide for LuneOS

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
@@ -9,7 +9,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
-#VIRTUAL-RUNTIME_webappmanager ?= "luna-webappmanager"
 VIRTUAL-RUNTIME_webappmanager ?= "wam"
 VIRTUAL-RUNTIME_initscripts ?= "initscripts"
 VIRTUAL-RUNTIME_webos-compositor ?= "luna-surfacemanager"
@@ -129,9 +128,10 @@ RDEPENDS:${PN} = " \
     settingsservice \
     sleepd \
     webos-connman-adapter \
+    webos-fontconfig-files \
     com.webos.service.pdm \
     com.webos.service.mediaindexer \
-    ${VIRTUAL-RUNTIME_appinstalld} \    
+    ${VIRTUAL-RUNTIME_appinstalld} \
     ${VIRTUAL-RUNTIME_event-monitor-network} \
     ${VIRTUAL-RUNTIME_initscripts} \
     ${VIRTUAL-RUNTIME_pdm} \

--- a/meta-luneos/recipes-graphics/fontconfig/fontconfig_%.bbappend
+++ b/meta-luneos/recipes-graphics/fontconfig/fontconfig_%.bbappend
@@ -1,0 +1,10 @@
+# Copyright (c) 2013-2020 LG Electronics, Inc.
+
+AUTHOR = "Bhooshan Supe <bhooshan.supe@lge.com>"
+#EXTENDPRAUTO_append = "webos1"
+
+do_install:append() {
+    # remove the links to the config files from the fontconfig
+    # component that conflict with the webOS config files
+    rm -f ${D}${sysconfdir}/fonts/conf.d/*.conf
+}

--- a/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager.bb
+++ b/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager.bb
@@ -29,6 +29,7 @@ SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE} \
     file://0002-Add-capability-to-pass-extra-options-to-surface-mana.patch \
     file://0003-WebOSShellSurface-add-setClientSize.patch \
     file://0004-webosscreenshot-respect-QT_OPENGL_ES.patch \
+    file://0005-DefaultSettings.qml-Use-Prelude-for-LuneOS.patch \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager/0005-DefaultSettings.qml-Use-Prelude-for-LuneOS.patch
+++ b/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager/0005-DefaultSettings.qml-Use-Prelude-for-LuneOS.patch
@@ -1,0 +1,66 @@
+From 0fb8d768145447b9eadd9064024d2e5bd847a7f7 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Fri, 22 Jul 2022 12:15:58 +0200
+Subject: [PATCH] DefaultSettings.qml: Use Prelude for LuneOS
+
+To give a more uniform experience in LuneOS.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ base/qml/WebOSCompositorBase/DefaultSettings.qml | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/base/qml/WebOSCompositorBase/DefaultSettings.qml b/base/qml/WebOSCompositorBase/DefaultSettings.qml
+index 9c7c082..1ccf0e1 100644
+--- a/base/qml/WebOSCompositorBase/DefaultSettings.qml
++++ b/base/qml/WebOSCompositorBase/DefaultSettings.qml
+@@ -88,7 +88,7 @@ QtObject {
+                 "height": 85,
+                 "backgroundColor": "#ffffff",
+                 "activatedColor": "#cf0652",
+-                "fontName": "Miso",
++                "fontName": "Prelude",
+                 "fontSize": 52,
+                 "textColor": "#4b4b4b",
+                 "textActivatedColor": "#ffffff"
+@@ -105,8 +105,8 @@ QtObject {
+                 "buttonMargins": 40,
+                 "foregroundColor": "#ffffff",
+                 "backgroundColor": "#4d4d4d",
+-                "headerFont": "Miso",
+-                "fontName": "Museo Sans",
++                "headerFont": "Prelude",
++                "fontName": "Prelude",
+                 "fontSize": 82,
+                 "fontWeight": Font.Bold,
+                 "descriptionFontSize": 26,
+@@ -127,7 +127,7 @@ QtObject {
+                 "backgroundColor": "#4d4d4d",
+                 "activatedColor": "#cf0652",
+                 "iconSize": 80,
+-                "fontName": "Museo Sans",
++                "fontName": "Prelude",
+                 "fontSize": 26,
+                 "fontWeight": Font.Bold,
+                 "textLineHeight": 40,
+@@ -140,7 +140,7 @@ QtObject {
+                 "height": 320,
+                 "backgroundColor": "#4d4d4d",
+                 "titleColor": "#d0d0d0",
+-                "titleFontFamilyName": "Miso",
++                "titleFontFamilyName": "Prelude",
+                 "titleFontSize": 73,
+                 "titleTextHeight": 86,
+                 "titleTextLeftMargin": 36,
+@@ -169,7 +169,7 @@ QtObject {
+                 "numPadNormalFontColor": "#eeeeee",
+                 "numPadFontActiveColor": "#ffffff",
+                 "numPadFontDisabledColor": "#8b8b8b",
+-                "numPadFontFamilyName": "Museo Sans",
++                "numPadFontFamilyName": "Prelude",
+                 "numPadFontSize": 28,
+                 "slideAnimationDuration": 500
+             }
+-- 
+2.31.0.windows.1
+

--- a/meta-luneos/recipes-webos/qml-app-components/qml-app-components.bb
+++ b/meta-luneos/recipes-webos/qml-app-components/qml-app-components.bb
@@ -19,7 +19,10 @@ inherit pkgconfig
 #inherit webos_enhanced_submissions
 inherit webos_public_repo
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+           file://0001-FontStyle.qml-Use-Prelude-on-LuneOS-instead-of-Museo.patch \
+"
+
 S = "${WORKDIR}/git"
 
 QMAKE_PROFILES = "${S}/qml-app-components.pro"

--- a/meta-luneos/recipes-webos/qml-app-components/qml-app-components/0001-FontStyle.qml-Use-Prelude-on-LuneOS-instead-of-Museo.patch
+++ b/meta-luneos/recipes-webos/qml-app-components/qml-app-components/0001-FontStyle.qml-Use-Prelude-on-LuneOS-instead-of-Museo.patch
@@ -1,0 +1,28 @@
+From 7b6281711943de58a1a8cc0d7e77a36c9d28b944 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Fri, 22 Jul 2022 10:42:58 +0200
+Subject: [PATCH] FontStyle.qml: Use Prelude on LuneOS instead of Museo Sans
+
+In order to have a more consistent usage of fonts.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ plugin/QmlAppComponents/AppStyle/FontStyle.qml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugin/QmlAppComponents/AppStyle/FontStyle.qml b/plugin/QmlAppComponents/AppStyle/FontStyle.qml
+index 70ca980..16fd8dc 100644
+--- a/plugin/QmlAppComponents/AppStyle/FontStyle.qml
++++ b/plugin/QmlAppComponents/AppStyle/FontStyle.qml
+@@ -21,7 +21,7 @@ import QtQuick 2.4
+ QtObject {
+     id: root
+ 
+-    property string mainFont: "Museo Sans"
++    property string mainFont: "Prelude"
+     property font chrome: mainFont35
+     property font title: mainFont60
+     property font subTitle: mainFont36
+-- 
+2.31.0.windows.1
+

--- a/meta-luneos/recipes-webos/webos-fontconfig-files/webos-fontconfig-files.bb
+++ b/meta-luneos/recipes-webos/webos-fontconfig-files/webos-fontconfig-files.bb
@@ -1,0 +1,39 @@
+# Copyright (c) 2017-2020 LG Electronics, Inc.
+
+SUMMARY = "Private configuration files for fontconfig"
+AUTHOR = "Seonmi Jin <seonmi1.jin@lge.com>"
+SECTION = "webos/fonts"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
+    file://oss-pkg-info.yaml;md5=704f5c65b7aa0484b9e3f01c09e74b58 \
+"
+
+#WEBOS_VERSION = "1.0.0-5_e3b8d5297c20edd8fc73ee3ac8729094159942ec"
+PR = "r4"
+
+PV = "1.0.0-5+git${SRCPV}"
+SRCREV = "e3b8d5297c20edd8fc73ee3ac8729094159942ec"
+
+
+#inherit webos_enhanced_submissions
+inherit fontcache
+inherit webos_public_repo
+
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+           file://0001-31-webos-aliases.conf-Use-Prelude-for-LuneOS.patch \
+"
+S = "${WORKDIR}/git"
+
+# Skip the unwanted tasks
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${datadir}/fontconfig/conf.avail
+    install -v -m 644 ${S}/31-webos-aliases.conf ${D}${datadir}/fontconfig/conf.avail
+    install -d ${D}${sysconfdir}/fonts/conf.d
+    ln -vsf /usr/share/fontconfig/conf.avail/31-webos-aliases.conf ${D}${sysconfdir}/fonts/conf.d/31-webos-aliases.conf
+}
+
+FILES:${PN} += "${sysconfdir}/fonts/conf.d/ ${datadir}/fontconfig/"

--- a/meta-luneos/recipes-webos/webos-fontconfig-files/webos-fontconfig-files/0001-31-webos-aliases.conf-Use-Prelude-for-LuneOS.patch
+++ b/meta-luneos/recipes-webos/webos-fontconfig-files/webos-fontconfig-files/0001-31-webos-aliases.conf-Use-Prelude-for-LuneOS.patch
@@ -1,0 +1,213 @@
+From 24b00c5cee9fe47c749e63d282dda02383355205 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Fri, 22 Jul 2022 12:28:03 +0200
+Subject: [PATCH] 31-webos-aliases.conf: Use Prelude for LuneOS
+
+---
+ 31-webos-aliases.conf | 43 ++++++++++++++++++++++---------------------
+ 1 file changed, 22 insertions(+), 21 deletions(-)
+
+diff --git a/31-webos-aliases.conf b/31-webos-aliases.conf
+index e428a85..5bef18d 100644
+--- a/31-webos-aliases.conf
++++ b/31-webos-aliases.conf
+@@ -5,8 +5,7 @@
+     <!-- webOS default fallback font -->
+     <match>
+         <edit mode="append" name="family">
+-            <string>Museo Sans</string>
+-            <string>Noto Sans</string>
++            <string>Prelude</string>
+         </edit>
+     </match>
+ 
+@@ -15,7 +14,7 @@
+             <string>Museo SansLight</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>thin</const>
+@@ -26,7 +25,7 @@
+             <string>Museo SansNormal</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>light</const>
+@@ -37,7 +36,7 @@
+             <string>Museo SansDemiBold</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>medium</const>
+@@ -48,7 +47,7 @@
+             <string>Museo SansBold</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>bold</const>
+@@ -59,7 +58,7 @@
+             <string>Museo SansBlack</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>black</const>
+@@ -70,7 +69,7 @@
+             <string>Museo SansDemiBoldItalic</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>medium</const>
+@@ -84,7 +83,7 @@
+             <string>Museo SansBoldItalic</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>bold</const>
+@@ -98,7 +97,7 @@
+             <string>Museo SansBlackItalic</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>black</const>
+@@ -108,6 +107,7 @@
+         </edit>
+     </match>
+ 
++<!-- FIXME: Disable language specific fonts for now for LuneOS
+     <match target="pattern">
+         <test name="lang" compare="contains" qual="any">
+             <string>ar</string>
+@@ -396,6 +396,7 @@
+             <string>Noto Sans CJK KR</string>
+         </edit>
+     </match>
++-->
+ 
+     <!--
+     Edit the fonts that are matched by the patterns above
+@@ -481,7 +482,7 @@
+             <string>Moon Miso Bold</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Miso</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>bold</const>
+@@ -492,7 +493,7 @@
+             <string>Moon Miso Light</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Miso</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>light</const>
+@@ -503,7 +504,7 @@
+             <string>Moon Miso Medium</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Miso</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>regular</const>
+@@ -514,7 +515,7 @@
+             <string>Moon Museo Sans Thin</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>thin</const>
+@@ -525,7 +526,7 @@
+             <string>Moon Museo Sans Light</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>light</const>
+@@ -536,7 +537,7 @@
+             <string>Moon Museo Sans Medium</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>medium</const>
+@@ -547,7 +548,7 @@
+             <string>Moon Museo Sans Medium Italic</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>medium</const>
+@@ -561,7 +562,7 @@
+             <string>Moon Museo Sans Bold</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>bold</const>
+@@ -572,7 +573,7 @@
+             <string>Moon Museo Sans Bold Italic</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>bold</const>
+@@ -586,7 +587,7 @@
+             <string>Moon Museo Sans Black</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>black</const>
+@@ -597,7 +598,7 @@
+             <string>Moon Museo Sans Black Italic</string>
+         </test>
+         <edit name="family" mode="assign" binding="same">
+-            <string>Museo Sans</string>
++            <string>Prelude</string>
+         </edit>
+         <edit name="weight" mode="assign" binding="same">
+             <const>black</const>
+-- 
+2.31.0.windows.1
+


### PR DESCRIPTION
Use fontconfig for setting Prelude system wide for LuneOS and patch places where it uses other fonts from OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>