### PR TITLE
nyx-conf: pinephone fix power key path

### DIFF
--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf/pinephone/nyx.conf
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf/pinephone/nyx.conf
@@ -1,2 +1,2 @@
 [module.keys]
-paths=/dev/input/by-path/platform-adc-keys-event;/dev/input/by-path/platform-gpio-key-power-event
+paths=/dev/input/by-path/platform-1f03400.rsb-platform-axp221-pek-event


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>