### PR TITLE
webruntime: fix scaling

### DIFF
--- a/meta-luneos/recipes-webos/chromium/files/0041-DesktopNativeWidgetAura-donc-apply-DIP-for-SetBounds.patch
+++ b/meta-luneos/recipes-webos/chromium/files/0041-DesktopNativeWidgetAura-donc-apply-DIP-for-SetBounds.patch
@@ -1,0 +1,41 @@
+From aa2e7b1cd9c1732c65319ea2f66812c1682d06d2 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Thu, 10 Nov 2022 21:54:24 +0000
+Subject: [PATCH] DesktopNativeWidgetAura: donc apply DIP for SetBounds
+
+Also, donc scale Display bounds, only its content
+should be scaled
+---
+ src/ui/display/display.cc                                      | 2 +-
+ src/ui/views/widget/desktop_aura/desktop_native_widget_aura.cc | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ui/display/display.cc b/src/ui/display/display.cc
+index 96df627f10..2b40755835 100644
+--- a/src/ui/display/display.cc
++++ b/src/ui/display/display.cc
+@@ -317,7 +317,7 @@ void Display::SetScaleAndBounds(float device_scale_factor,
+   device_scale_factor_ = std::max(0.5f, device_scale_factor_);
+ 
+   gfx::RectF f(bounds_in_pixel);
+-  f.Scale(1.f / device_scale_factor_);
++  //f.Scale(1.f / device_scale_factor_);
+   bounds_ = gfx::ToEnclosedRectIgnoringError(f, kDisplaySizeAllowanceEpsilon);
+   size_in_pixels_ = bounds_in_pixel.size();
+   UpdateWorkAreaFromInsets(insets);
+diff --git a/src/ui/views/widget/desktop_aura/desktop_native_widget_aura.cc b/src/ui/views/widget/desktop_aura/desktop_native_widget_aura.cc
+index ec0114b16f..a6e4cb6ac5 100644
+--- a/src/ui/views/widget/desktop_aura/desktop_native_widget_aura.cc
++++ b/src/ui/views/widget/desktop_aura/desktop_native_widget_aura.cc
+@@ -769,7 +769,7 @@ std::string DesktopNativeWidgetAura::GetWorkspace() const {
+ void DesktopNativeWidgetAura::SetBounds(const gfx::Rect& bounds) {
+   if (!content_window_)
+     return;
+-  desktop_window_tree_host_->SetBoundsInDIP(bounds);
++  desktop_window_tree_host_->AsWindowTreeHost()->SetBoundsInPixels(bounds);
+ }
+ 
+ void DesktopNativeWidgetAura::SetBoundsConstrained(const gfx::Rect& bounds) {
+-- 
+2.34.1
+

--- a/meta-luneos/recipes-webos/chromium/webruntime-repo_91.inc
+++ b/meta-luneos/recipes-webos/chromium/webruntime-repo_91.inc
@@ -58,4 +58,5 @@ SRC_URI += " \
     file://0038-build-Convert-third_party-opus-BUILD.gn-to-py3.patch \
     file://0039-grit-Remove-usage-of-U-mode-bit-for-opening-files-in.patch \
     file://0040-metrics-ukm-fix-build-with-python3.patch \
+    file://0041-DesktopNativeWidgetAura-donc-apply-DIP-for-SetBounds.patch \
 "

--- a/meta-luneos/recipes-webos/configd-data/configd-data.bb
+++ b/meta-luneos/recipes-webos/configd-data/configd-data.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 inherit webos_ports_ose_repo
 
 PV = "1.0.0-2+git${SRCPV}"
-SRCREV = "a6fdb11205935f0679e6a0c4ac41f06e59762323"
+SRCREV = "0cb5ec400b56b8f2089f6483d8ed4504099332b2"
 
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/wam/wam.bb
+++ b/meta-luneos/recipes-webos/wam/wam.bb
@@ -17,7 +17,7 @@ VIRTUAL-RUNTIME_cpushareholder ?= "cpushareholder-stub"
 RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_cpushareholder}"
 
 PV = "1.0.2-55+git${SRCPV}"
-SRCREV = "fcb8afbfd94dc0a6eff2c4ed7003128429ec023d"
+SRCREV = "4561b51db7938c60a38543daa97622c8dfbc8bb1"
 PR = "r30"
 
 WAM_BUILD_SYSTEM = "webos_qmake6"


### PR DESCRIPTION
This patch a bit hacky, but the current management of the "device scale ratio" in Chromium/Wayland is quite unclear wether the scaling is applied to the web content, or to the wayland window/display. It looks like it is applied to both, which makes it useless for our use-case where cards have a specific size: in this case, the content is scaled up, in a bigger window, which is then scaled down to our card size, so the appearance is identical.

This fix consists mainly in disabling the scaling wayland-side, while keeping it for the web content.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>