### PR TITLE
meta-webos-ports: Fix various permission issues

### DIFF
--- a/meta-luneos/recipes-webos/configurator/configurator.bb
+++ b/meta-luneos/recipes-webos/configurator/configurator.bb
@@ -35,6 +35,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
 file://0001-configurator-Add-service-file-for-systemd-script.patch \
 file://0002-configurator-Fix-permission-issue-for-com.palm.filec.patch \
 file://0003-com.webos.service.configurator.perm.json-Add-permiss.patch \
+file://0004-com.palm.configurator.role.json.in-Add-fixes-for-var.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/configurator/configurator/0004-com.palm.configurator.role.json.in-Add-fixes-for-var.patch
+++ b/meta-luneos/recipes-webos/configurator/configurator/0004-com.palm.configurator.role.json.in-Add-fixes-for-var.patch
@@ -1,0 +1,76 @@
+From aeb33b071b1e2cc53851322fe41efd358c4dfd47 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Mon, 12 Dec 2022 13:03:53 +0100
+Subject: [PATCH] com.palm.configurator.role.json.in: Add fixes for various
+ permission issues
+
+Solves:
+
+2022-12-09T22:31:11.633364Z [4.946651635] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.imlibpurple" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:11.731384Z [5.044671657] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:11.732398Z [5.045685809] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "org.webosports.service.messaging" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:11.733725Z [5.047012721] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts.linker" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:11.736186Z [5.049472690] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "*" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:11.738608Z [5.051896281] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "*" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:11.774231Z [5.087518171] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts.linker" permissions for executable "/usr/sbin/configurator"
+2022-12-09T22:31:12.949996Z [6.263283706] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts.linker" permissions for executable "/usr/sbin/configurator"
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ .../sysbus/com.palm.configurator.role.json.in | 40 +++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/files/sysbus/com.palm.configurator.role.json.in b/files/sysbus/com.palm.configurator.role.json.in
+index 9613c70..94f8056 100644
+--- a/files/sysbus/com.palm.configurator.role.json.in
++++ b/files/sysbus/com.palm.configurator.role.json.in
+@@ -7,6 +7,46 @@
+         {
+             "service":"com.palm.configurator",
+             "outbound":["com.palm.activitymanager", "com.palm.db", "com.palm.filecache", "com.palm.tempdb", "com.webos.mediadb", "com.webos.lunasend-*"]
++        },
++        {
++            "service": "com.palm.service.accounts",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "com.palm.service.calendar.reminders",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "com.palm.service.contacts",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "com.palm.service.contacts.linker",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "org.webosports.service.update",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "org.webosports.service.messaging",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "com.palm.imlibpurple",
++            "inbound": ["*"],
++            "outbound": ["*"]
++        },
++        {
++            "service": "*",
++            "inbound": ["*"],
++            "outbound": ["*"]
+         }
+     ]
+ }
+-- 
+2.37.3.windows.1
+

--- a/meta-luneos/recipes-webos/core-apps/core-apps.bb
+++ b/meta-luneos/recipes-webos/core-apps/core-apps.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 PV = "3.0.0-2+git${SRCPV}"
-SRCREV = "e1ad99170a87f2752e8dc88c4a5f81ceb6070f2b"
+SRCREV = "b14468d9ff26051290e32eb273ea5a3c54454fe0"
 
 inherit webos_ports_fork_repo
 inherit webos_filesystem_paths

--- a/meta-luneos/recipes-webos/sam/sam/0003-com.webos.sam.role.json.in-Fix-various-outbound-perm.patch
+++ b/meta-luneos/recipes-webos/sam/sam/0003-com.webos.sam.role.json.in-Fix-various-outbound-perm.patch
@@ -1,4 +1,4 @@
-From 0a71a91e2c3b525bb36edf53ee3a7dd65494cc0a Mon Sep 17 00:00:00 2001
+From a321744d805874f983c884b83d8f8c804c99153e Mon Sep 17 00:00:00 2001
 From: Herman van Hazendonk <github.com@herrie.org>
 Date: Fri, 29 Apr 2022 23:30:14 +0200
 Subject: [PATCH] com.webos.sam.role.json.in: Fix various outbound permission
@@ -15,16 +15,15 @@ Apr 29 20:38:56 qemux86-64 ls-hubd[241]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {
 Apr 29 20:38:55 qemux86-64 ls-hubd[241]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.palm.applicationManager","SRC_APP_ID":"com.webos.service.applicationManager","EXE":"/usr/sbin/sam","PID":639} "com.webos.service.applicationManager" does not have sufficient outbound permissions to communicate with "com.palm.applicationManager" (cmdline: /usr/sbin/sam)
 
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
-
 ---
- files/sysbus/com.webos.sam.role.json.in | 35 ++++++++++++++++++++++++-
- 1 file changed, 34 insertions(+), 1 deletion(-)
+ files/sysbus/com.webos.sam.role.json.in | 44 ++++++++++++++++++++++++-
+ 1 file changed, 43 insertions(+), 1 deletion(-)
 
 diff --git a/files/sysbus/com.webos.sam.role.json.in b/files/sysbus/com.webos.sam.role.json.in
-index d4a24ce..db68762 100644
+index d4a24ce..ab145b4 100644
 --- a/files/sysbus/com.webos.sam.role.json.in
 +++ b/files/sysbus/com.webos.sam.role.json.in
-@@ -29,7 +29,40 @@
+@@ -29,7 +29,49 @@
                  "com.webos.service.tvpower",
                  "com.palm.webappmanager",
                  "com.webos.settingsservice",
@@ -63,6 +62,15 @@ index d4a24ce..db68762 100644
 +                "com.palm.applicationManager",
 +                "com.palm.universalsearch",
 +                "com.palm.systemui-*"
++            ]
++        },
++        {
++            "service":"*",
++            "inbound":[
++                "*"
++            ],
++            "outbound":[
++                "*"
              ]
          }
      ]


### PR DESCRIPTION
Fixes:
2022-12-09T22:31:10.923812Z [4.237099157] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "*" permissions for executable "/usr/sbin/sam"

2022-12-09T22:31:11.633364Z [4.946651635] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.imlibpurple" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:11.731384Z [5.044671657] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:11.732398Z [5.045685809] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "org.webosports.service.messaging" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:11.733725Z [5.047012721] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts.linker" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:11.736186Z [5.049472690] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "*" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:11.738608Z [5.051896281] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "*" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:11.774231Z [5.087518171] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts.linker" permissions for executable "/usr/sbin/configurator"

2022-12-09T22:31:12.949996Z [6.263283706] kern.warning ls-hubd [] ls-hubd LSHUB_ROLE_FILE {} Can not find service "com.palm.service.contacts.linker" permissions for executable "/usr/sbin/configurator"

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>