### PR TITLE
luna-surfacemanager: Fix permission issue

### DIFF
--- a/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager/0009-com.webos.surfacemanager.perm.json-Add-permissions-f.patch
+++ b/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager/0009-com.webos.surfacemanager.perm.json-Add-permissions-f.patch
@@ -8,13 +8,13 @@ Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 
 ---
  base/sysbus/com.webos.surfacemanager.perm.json | 19 +++++++++++++++----
- 1 file changed, 15 insertions(+), 4 deletions(-)
+ 1 file changed, 16 insertions(+), 4 deletions(-)
 
 diff --git a/base/sysbus/com.webos.surfacemanager.perm.json b/base/sysbus/com.webos.surfacemanager.perm.json
 index b9bfd12..e25c073 100644
 --- a/base/sysbus/com.webos.surfacemanager.perm.json
 +++ b/base/sysbus/com.webos.surfacemanager.perm.json
-@@ -3,17 +3,28 @@
+@@ -3,17 +3,29 @@
          "account.query",
          "application.launcher",
          "application.operation",
@@ -40,6 +40,7 @@ index b9bfd12..e25c073 100644
 -        "media.displayInfo",
 -        "notification.management",
 -        "notification.operation"
++        "systemsettings.management",
 +        "systemsettings.query",
 +        "telephony.management",
 +        "tweaks-service.operation",


### PR DESCRIPTION
Fixes: Dec 15 09:39:46 qemux86-64 LunaSysService[472]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.webos.surfacemanager-cardshell","CATEGORY":"/","METHOD":"setPreferences"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>