### PR TITLE
webos-connman-adapter, wca-supplicant, connman: Move to OSE versions

### DIFF
--- a/meta-luneos/recipes-connectivity/connman/connman-conf.bbappend
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf.bbappend
@@ -1,15 +1,28 @@
+# Copyright (c) 2017-2022 LG Electronics, Inc.
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += " \
-    file://environment.conf \
+    file://connman.service \
+    file://connman.sh.in \
     file://main.conf \
 "
+do_configure:append () {
+    sed -e 's/@WEBOS_CONNMAN_PREACTIVATE_INTERFACE_LIST@/${WEBOS_CONNMAN_PREACTIVATE_INTERFACE_LIST}/g; s%@DATADIR@%${datadir}%g' \
+    ${WORKDIR}/connman.sh.in > ${WORKDIR}/connman.sh
+}
 
 do_install:append() {
     install -d ${D}${sysconfdir}/connman
-    install -m 0644 ${WORKDIR}/environment.conf ${D}${sysconfdir}/connman/
     install -m 0644 ${WORKDIR}/main.conf ${D}${sysconfdir}/connman/
+
+    install -d ${D}${sysconfdir}/systemd/system
+    install -v -m 644 ${WORKDIR}/connman.service ${D}${sysconfdir}/systemd/system/
+    install -d ${D}${sysconfdir}/systemd/system/scripts
+    install -v -m 755 ${WORKDIR}/connman.sh ${D}${sysconfdir}/systemd/system/scripts/
 }
 
-FILES:${PN} += "${sysconfdir}/connman"
+FILES:${PN} += " \
+    ${sysconfdir}/connman \
+    ${sysconfdir} \
+"

--- a/meta-luneos/recipes-connectivity/connman/connman-conf/connman.service
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf/connman.service
@@ -1,0 +1,34 @@
+# Copyright (c) 2019-2022 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# start the network connection manager service
+
+[Unit]
+Description=webos - "%n"
+# When qemu mode, only connman service is enabled.
+Wants=wpa-supplicant.service
+After=wpa-supplicant.service
+
+[Service]
+Type=simple
+OOMScoreAdjust=-500
+EnvironmentFile=-/var/systemd/system/env/connman.env
+ExecStart=/etc/systemd/system/scripts/connman.sh
+# Restart also wpa-supplicant in order to bring back everything into a sane state.
+# This will disconnect any available connection but that will be also the case when
+# connman comes up again and reinitializes everything.
+ExecStopPost=-/usr/sbin/wpa_cli terminate
+Restart=on-failure

--- a/meta-luneos/recipes-connectivity/connman/connman-conf/connman.sh.in
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf/connman.sh.in
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Copyright (c) 2019-2022 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if [ -f /etc/default/connman ] ; then
+    . /etc/default/connman
+fi
+
+set -e
+
+if [ -f @DATADIR@/connman/wired-setup ] ; then
+    . @DATADIR@/connman/wired-setup
+fi
+
+if [ -f /var/lib/connman/debug-mode ] ; then
+    EXTRA_PARAM="-d"
+    export CONNMAN_SUPPLICANT_DEBUG=1
+    export CONNMAN_DHCP_DEBUG=1
+    TEST_CONF="/var/lib/connman/custom-main.conf"
+    if [ -f $TEST_CONF ] ; then
+         EXTRA_PARAM="$EXTRA_PARAM -c $TEST_CONF"
+    fi
+    CUSTOM_CONFIG="/var/lib/connman/custom-wired-config"
+    WIRED_CONFIG="/var/lib/connman/wired.config"
+    if [ -f $CUSTOM_CONFIG ] ; then
+         cp $CUSTOM_CONFIG $WIRED_CONFIG
+    fi
+fi
+
+#
+# Unconditionally activate these network interfaces before starting
+# connmand. Rely on it to deactivate them if they not supposed to stay
+# activated.
+#
+# An example of when an interface should be added to this list is when
+# its hardware (MAC) address changes between the time when it is first
+# detected by the kernel during boot and when it is first activated (say
+# because during initial detection, the driver attempts to read its
+# hardware address from a filesystem that has not yet been mounted).
+#
+# It is assumed that the state into which the kernel places an interface
+# that does RF transmissions allows it to be activated legally in any
+# country before any further configuration of it is done by connmand.
+#
+for iface in @WEBOS_CONNMAN_PREACTIVATE_INTERFACE_LIST@; do
+    ifconfig $iface up || :
+done
+
+# Send DAD(Duplicate Address Detection) packet for link-local address in IPv6
+# there is a timing issue with creating the link-local address and bringing up
+# the eth0 interface to send out the packet.
+# Also We don't use this change in NFS for developer.
+if [ $IS_NFS = "NO" ] ; then
+     ifconfig eth0 up || :
+     ifconfig eth0 down || :
+fi
+
+sysctl -w net.core.rmem_max=524288
+
+exec /usr/sbin/connmand -n --nobacktrace ${EXTRA_PARAM} --noplugin=bluetooth,bluetooth_legacy

--- a/meta-luneos/recipes-connectivity/connman/connman-conf/environment.conf
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf/environment.conf
@@ -1,1 +1,0 @@
-EXTRA_PARAM=

--- a/meta-luneos/recipes-connectivity/connman/connman-conf/main.conf
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf/main.conf
@@ -1,4 +1,107 @@
 [General]
+
+# Set input request timeout. Default is 120 seconds
+# The request for inputs like passphrase will timeout
+# after certain amount of time. Use this setting to
+# increase the value in case of different user
+# interface designs.
+# InputRequestTimeout = 120
+
+# Set browser launch timeout. Default is 300 seconds
+# The request for launching a browser for portal pages
+# will timeout after certain amount of time. Use this
+# setting to increase the value in case of different
+# user interface designs.
+# BrowserLaunchTimeout = 300
+
+# Enable background scanning. Default is true.
+# Background scanning will start every 5 minutes unless
+# the scan list is empty. In that case, a simple backoff
+# mechanism starting from 10s up to 5 minutes will run.
+# BackgroundScanning = true
+
+# List of Fallback timeservers separated by ",".
+# These timeservers are used for NTP sync when there are
+# no timeserver set by the user or by the service.
+# These can contain mixed combination of fully qualified
+# domain names, IPv4 and IPv6 addresses.
+# FallbackTimeservers =
+
+# List of fallback nameservers separated by "," used if no
+# nameservers are otherwise provided by the service. The
+# nameserver entries must be in numeric format, host
+# names are ignored.
+# FallbackNameservers =
+
+# List of technologies that are marked autoconnectable
+# by default, separated by commas ",". The default value
+# for this entry when empty is ethernet,wifi,cellular.
+# Services that are automatically connected must have been
+# set up and saved to storage beforehand.
 DefaultAutoConnectTechnologies=ethernet,wifi,cellular
+
+# List of preferred technologies from the most preferred
+# one to the least preferred one separated by commas ",".
+# Services of the listed technology type will be tried one
+# by one in the order given, until one of them gets connected
+# or they are all tried. A service of a preferred technology
+# type in state 'ready' will get the default route when
+# compared to another preferred type further down the list
+# with state 'ready' or with a non-preferred type; a service
+# of a preferred technology type in state 'online' will get
+# the default route when compared to either a non-preferred
+# type or a preferred type further down in the list.
 PreferredTechnologies=ethernet,wifi,cellular
-NetworkInterfaceBlacklist = p2p,usb,rndis,rmnet,ifb
+
+# List of blacklisted network interfaces separated by ",".
+# Found interfaces will be compared to the list and will
+# not be handled by connman, if their first characters
+# match any of the list entries. Default value is
+# vmnet,vboxnet,virbr,ifb,ve-,vb-.
+# NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb,ve-,vb-
+
+# Allow connman to change the system hostname. This can
+# happen for example if we receive DHCP hostname option.
+# Default value is true.
+# AllowHostnameUpdates = true
+
+# Keep only a single connected technology at any time. When a new
+# service is connected by the user or a better one is found according
+# to PreferredTechnologies, the new service is kept connected and all
+# the other previously connected services are disconnected. With this
+# setting it does not matter whether the previously connected services
+# are in 'online' or 'ready' states, the newly connected service is
+# the only one that will be kept connected. A service connected by the
+# user will be used until going out of network coverage. With this
+# setting enabled applications will notice more network breaks than
+# normal. Default value is false.
+# SingleConnectedTechnology = false
+
+# List of technologies for which tethering is allowed separated by ",".
+# The default value is wifi,bluetooth,gadget. Only those technologies
+# listed here are used for tethering. If ethernet tethering is desired,
+# then ethernet should be added to the list. The technologies listed here
+# have to support tethering, currently tethering is implemented for wifi,
+# bluetooth, gadget and ethernet.
+# NOTE that if ethernet tethering is enabled, then a DHCP server is
+# started on all ethernet interfaces. Tethered ethernet should
+# never be connected to corporate or home network as it will disrupt
+# normal operation of these networks. Due to this ethernet is not
+# tethered by default. Do not activate ethernet tethering unless you
+# really know what you are doing.
+# TetheringTechnologies = wifi,bluetooth,gadget
+
+# Restore earlier tethering status when returning from offline mode,
+# re-enabling a technology, and after restarts and reboots.
+# Default value is false.
+# PersistentTetheringMode = false
+
+# Automatically enable Anycast 6to4 if possible. This is not recommended, as
+# the use of 6to4 will generally lead to a severe degradation of connection
+# quality. See RFC6343. Default value is false (as recommended by RFC6343
+# section 4.1).
+# Enable6to4 = false
+
+# We're supplying our own wpa-supplicant configuration file here which adds some tweaks
+# for running wpa-supplicant like enabling the cli interface on startup etc.
+WpaSupplicantConfigFile=/etc/wpa_supplicant.conf

--- a/meta-luneos/recipes-connectivity/connman/connman/0001-Add-Changes-for-p2p-setState-api.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0001-Add-Changes-for-p2p-setState-api.patch
@@ -1,0 +1,486 @@
+From a393dc35bb283e91b780b55179f97372b9aca5d8 Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Tue, 25 Oct 2022 13:35:13 +0530
+Subject: [PATCH] Add Changes for p2p setState api
+
+:Release Notes:
+Add Changes for p2p setState api
+
+:Detailed Notes:
+Add Changes for p2p setState api
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11078] - Add Changes for p2p setState api
+
+Change-Id: I0d2daf9ecb2aa899817813d92e355facb5e4188e
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/337863
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: Ban Word Checker <ban_word@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ include/technology.h |  18 ++
+ src/technology.c     | 394 +++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 412 insertions(+)
+
+diff --git a/include/technology.h b/include/technology.h
+index fcd658e8..3ea7589f 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -49,6 +49,12 @@ bool connman_technology_get_wifi_tethering(const struct connman_technology *tech
+ 					const char **ssid, const char **psk, int *freq);
+ 
+ bool connman_technology_is_tethering_allowed(enum connman_service_type type);
++bool connman_technology_get_p2p_listen(struct connman_technology *technology);
++void connman_technology_set_p2p_listen(struct connman_technology *technology,
++							bool enabled);
++unsigned int connman_technology_get_p2p_listen_channel(struct connman_technology *technology);
++void connman_technology_set_p2p_listen_channel(struct connman_technology *technology,
++									unsigned int listen_channel);
+ 
+ struct connman_technology_driver {
+ 	const char *name;
+@@ -65,6 +71,18 @@ struct connman_technology_driver {
+ 				const char *bridge, bool enabled);
+ 	int (*set_regdom) (struct connman_technology *technology,
+ 						const char *alpha2);
++	int (*set_p2p_identifier) (struct connman_technology *technology,
++						const char *p2p_identifier);
++	int (*set_p2p_persistent) (struct connman_technology *technology,
++						bool persistent_reconnect);
++	int (*set_p2p_listen_channel) (struct connman_technology *technology,
++						unsigned int listen_channel);
++	int (*set_p2p_go_intent) (struct connman_technology *technology,
++						unsigned int go_intent);
++	int (*set_p2p_listen) (struct connman_technology *technology,
++						bool enable);
++	int (*set_p2p_listen_params) (struct connman_technology *technology,
++						int period, int interval);
+ };
+ 
+ int connman_technology_driver_register(struct connman_technology_driver *driver);
+diff --git a/src/technology.c b/src/technology.c
+index 5c469111..d8c265b1 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -68,6 +68,14 @@ struct connman_technology {
+ 	char *tethering_passphrase;
+ 	int tethering_freq;
+ 
++	int period;
++	int interval;
++	bool enable_p2p_listen_persistent;	/* Save the tech p2p listen state by p2p/setstate API */
++	bool p2p_listen;
++	unsigned int p2p_listen_channel;
++
++	char *p2p_identifier;
++	bool p2p_persistent;
+ 	bool enable_persistent; /* Save the tech state */
+ 
+ 	GSList *driver_list;
+@@ -885,6 +893,324 @@ make_reply:
+ 
+ 	return reply;
+ }
++bool connman_technology_get_p2p_listen(struct connman_technology *technology)
++{
++	return technology->p2p_listen;
++}
++
++void connman_technology_set_p2p_listen(struct connman_technology *technology, bool enabled)
++{
++	dbus_bool_t listen_enabled;
++
++	if (enabled == technology->p2p_listen)
++		return;
++
++	technology->p2p_listen = enabled;
++	listen_enabled = enabled;
++
++	connman_dbus_property_changed_basic(technology->path,
++			CONNMAN_TECHNOLOGY_INTERFACE,
++			"P2PListen",
++			DBUS_TYPE_BOOLEAN,
++			&listen_enabled);
++}
++static DBusMessage *set_p2p_listen(struct connman_technology *technology,
++				DBusMessage *msg, bool enable)
++{
++	DBusMessage *reply = NULL;
++	int err = 0;
++	GSList *tech_drivers = NULL;
++
++	__sync_synchronize();
++	if (!technology->enabled) {
++		err = -EOPNOTSUPP;
++		goto make_reply;
++	}
++
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P) {
++		err = -EOPNOTSUPP;
++		goto make_reply;
++	}
++
++	if (technology->p2p_listen && enable)
++		return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++	for (tech_drivers = technology->driver_list; tech_drivers;
++	     tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_listen)
++			continue;
++
++		err = driver->set_p2p_listen(technology, enable);
++		if (!err) {
++			technology->enable_p2p_listen_persistent = enable;
++			technology_save(technology);
++		}
++	}
++
++make_reply:
++	if (err == -EINPROGRESS)
++		reply = g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++	else if (err == -EALREADY) {
++		if (enable)
++			reply = __connman_error_already_enabled(msg);
++		else
++			reply = __connman_error_already_disabled(msg);
++	} else if (err < 0)
++		reply = __connman_error_failed(msg, -err);
++	else
++		reply = g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++	return reply;
++}
++void connman_technology_set_p2p_listen_params(struct connman_technology *technology,
++						int period, int interval)
++{
++	if (!technology)
++		return;
++
++	technology->period = period;
++	technology->interval = interval;
++}
++unsigned int connman_technology_get_p2p_listen_channel(struct connman_technology *technology)
++{
++	return technology->p2p_listen_channel;
++}
++void connman_technology_set_p2p_listen_channel(struct connman_technology *technology,
++						unsigned int listen_channel)
++{
++	if (!connman_technology_get_p2p_listen(technology))
++		return;
++
++	if (connman_technology_get_p2p_listen_channel(technology) != listen_channel)
++	{
++		technology->p2p_listen_channel = listen_channel;
++		connman_dbus_property_changed_basic(technology->path,
++				CONNMAN_TECHNOLOGY_INTERFACE,
++				"P2PListenChannel",
++				DBUS_TYPE_UINT32,
++				&technology->p2p_listen_channel);
++	}
++}
++static DBusMessage *set_p2p_persistent(struct connman_technology *technology,
++													DBusMessage *msg, bool enabled)
++{
++	DBusMessage *reply = NULL;
++	int err = 0;
++	GSList *tech_drivers = NULL;
++	dbus_bool_t persistent_enabled;
++
++	__sync_synchronize();
++
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P || !technology->enabled) {
++		err = -EOPNOTSUPP;
++		goto make_reply;
++	}
++
++	if(technology->p2p_persistent == enabled)
++		return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++	technology->p2p_persistent = enabled;
++
++	for (tech_drivers = technology->driver_list; tech_drivers != NULL;
++	     tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (driver == NULL || driver->set_p2p_persistent == NULL)
++			continue;
++
++		err = driver->set_p2p_persistent(technology, enabled);
++	}
++make_reply:
++	if (err < 0)
++		reply = __connman_error_failed(msg, -err);
++	else {
++		reply = g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++		persistent_enabled = technology->p2p_persistent;
++		connman_dbus_property_changed_basic(technology->path,
++				CONNMAN_TECHNOLOGY_INTERFACE,
++				"P2PPersistent",
++				DBUS_TYPE_BOOLEAN,
++				&persistent_enabled);
++	}
++
++	return reply;
++}
++static int set_p2p_identifier(struct connman_technology *technology,
++											const char *p2p_identifier)
++{
++	int result = -EOPNOTSUPP;
++	int err = 0;
++	GSList *tech_drivers = NULL;
++
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++		return -EINVAL;
++
++	for (tech_drivers = technology->driver_list; tech_drivers;
++	     tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_identifier)
++			continue;
++
++		err = driver->set_p2p_identifier(technology, p2p_identifier);
++
++		if (result == -EINPROGRESS)
++			continue;
++
++		if (err == -EINPROGRESS || err == 0) {
++			result = err;
++			continue;
++		}
++	}
++
++	return result;
++}
++static DBusMessage *set_p2p_listen_params(struct connman_technology *technology,
++				DBusMessage *msg, DBusMessageIter *array)
++{
++	DBusMessage *reply = NULL;
++	int err = 0;
++	GSList *tech_drivers = NULL;
++	int period = 0, interval = 0;
++	DBusMessageIter dict;
++
++	if (dbus_message_iter_get_arg_type(array) != DBUS_TYPE_ARRAY)
++		return NULL;
++
++	dbus_message_iter_recurse(array, &dict);
++
++	while (dbus_message_iter_get_arg_type(&dict) == DBUS_TYPE_DICT_ENTRY) {
++		DBusMessageIter entry, value;
++		const char *key;
++		int type;
++
++		dbus_message_iter_recurse(&dict, &entry);
++
++		if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING)
++			return NULL;
++
++		dbus_message_iter_get_basic(&entry, &key);
++		dbus_message_iter_next(&entry);
++
++		if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT)
++			return NULL;
++
++		dbus_message_iter_recurse(&entry, &value);
++
++		type = dbus_message_iter_get_arg_type(&value);
++
++		if (g_str_equal(key, "Period")) {
++			if (type != DBUS_TYPE_INT32)
++				return NULL;
++
++			dbus_message_iter_get_basic(&value, &period);
++		} else if (g_str_equal(key, "Interval")) {
++			if (type != DBUS_TYPE_INT32)
++				return NULL;
++
++			dbus_message_iter_get_basic(&value, &interval);
++		}
++
++		dbus_message_iter_next(&dict);
++	}
++
++	for (tech_drivers = technology->driver_list; tech_drivers;
++			tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_listen_params)
++			continue;
++
++		err = driver->set_p2p_listen_params(technology, period, interval);
++
++		if (err == 0)
++			connman_technology_set_p2p_listen_params(technology, period, interval);
++	}
++
++	if (err < 0)
++		reply = __connman_error_failed(msg, -err);
++	else
++		reply = g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++	return reply;
++}
++static DBusMessage *set_p2p_listen_channel(struct connman_technology *technology,
++													DBusMessage *msg, unsigned int listen_channel)
++{
++	DBusMessage *reply = NULL;
++	int err = 0;
++	GSList *tech_drivers = NULL;
++
++	__sync_synchronize();
++	if (!technology->enabled) {
++		err = -EOPNOTSUPP;
++		goto make_reply;
++	}
++
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P) {
++		err = -EINVAL;
++		goto make_reply;
++	}
++
++	for (tech_drivers = technology->driver_list; tech_drivers;
++			tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver|| !driver->set_p2p_listen_channel)
++			continue;
++
++		err = driver->set_p2p_listen_channel(technology, listen_channel);
++
++		if (err == 0)
++			connman_technology_set_p2p_listen_channel(technology, listen_channel);
++	}
++make_reply:
++	if (err < 0)
++		reply = __connman_error_failed(msg, -err);
++	else
++		reply = g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++	return reply;
++}
++static DBusMessage *set_p2p_go_intent(struct connman_technology *technology,
++				   DBusMessage *msg, unsigned int go_intent)
++{
++	DBusMessage *reply = NULL;
++	int err = 0;
++	GSList *tech_drivers = NULL;
++
++	__sync_synchronize();
++	if (!technology->enabled) {
++		err = -EOPNOTSUPP;
++		goto make_reply;
++	}
++
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P) {
++		err = -EOPNOTSUPP;
++		goto make_reply;
++	}
++
++	for (tech_drivers = technology->driver_list; tech_drivers != NULL;
++			tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_go_intent)
++			continue;
++
++		err = driver->set_p2p_go_intent(technology, go_intent);
++	}
++
++make_reply:
++	if (err < 0)
++		reply = __connman_error_failed(msg, -err);
++	else
++		reply = g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++	return reply;
++}
+ 
+ static DBusMessage *set_property(DBusConnection *conn,
+ 					DBusMessage *msg, void *data)
+@@ -1011,6 +1337,74 @@ static DBusMessage *set_property(DBusConnection *conn,
+ 					DBUS_TYPE_INT32,
+ 					&technology->tethering_freq);
+ 		}
++	} else if (g_str_equal(name, "P2PListen")) {
++		bool enable;
++
++		if (type != DBUS_TYPE_BOOLEAN)
++			return __connman_error_invalid_arguments(msg);
++
++		if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++			return __connman_error_not_supported(msg);
++
++		dbus_message_iter_get_basic(&value, &enable);
++
++		return set_p2p_listen(technology, msg, enable);
++	} else if (g_str_equal(name, "P2PPersistent")) {
++		bool enable;
++
++		if (type != DBUS_TYPE_BOOLEAN)
++			return __connman_error_invalid_arguments(msg);
++
++		if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++			return __connman_error_not_supported(msg);
++
++		dbus_message_iter_get_basic(&value, &enable);
++
++		return set_p2p_persistent(technology, msg, enable);
++	} else if (g_str_equal(name, "P2PIdentifier")) {
++		int err;
++		const char *p2p_identifier;
++
++		if (type != DBUS_TYPE_STRING)
++			return __connman_error_invalid_arguments(msg);
++
++		dbus_message_iter_get_basic(&value, &p2p_identifier);
++
++		if(strlen(p2p_identifier) > 32)
++			return __connman_error_invalid_arguments(msg);
++
++		err = set_p2p_identifier(technology, p2p_identifier);
++		if (err < 0)
++			return __connman_error_failed(msg, -err);
++	} else if (g_str_equal(name, "P2PListenParams")) {
++		if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++			return __connman_error_not_supported(msg);
++
++		return set_p2p_listen_params(technology, msg, &value);
++	} else if (g_str_equal(name, "P2PListenChannel")) {
++		dbus_uint32_t listen_channel;
++
++		if (type != DBUS_TYPE_UINT32)
++			return __connman_error_invalid_arguments(msg);
++
++		dbus_message_iter_get_basic(&value, &listen_channel);
++
++		if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++			return __connman_error_not_supported(msg);
++
++		return set_p2p_listen_channel(technology, msg, listen_channel);
++	} else if (g_str_equal(name, "P2PGOIntent")) {
++		dbus_uint32_t go_intent;
++
++		if (type != DBUS_TYPE_UINT32)
++			return __connman_error_invalid_arguments(msg);
++
++		dbus_message_iter_get_basic(&value, &go_intent);
++
++		if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++			return __connman_error_not_supported(msg);
++
++		return set_p2p_go_intent(technology, msg, go_intent);
+ 	} else if (g_str_equal(name, "Powered")) {
+ 		dbus_bool_t enable;
+ 

--- a/meta-luneos/recipes-connectivity/connman/connman/0002-Add-Changes-for-p2p-getDeviceName-api.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0002-Add-Changes-for-p2p-getDeviceName-api.patch
@@ -1,0 +1,21390 @@
+From d638abc341d6b08d71d073a2429f720c6e77a962 Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Tue, 25 Oct 2022 15:53:39 +0530
+Subject: [PATCH] Add Changes for p2p getDeviceName api
+
+:Release Notes:
+Add Changes for p2p getDeviceName api
+
+:Detailed Notes:
+Add Changes for p2p getDeviceName api
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11076] - Add Changes for p2p getDeviceName api
+
+Change-Id: I8738d03eb487f00fa4c5a3b62d84374313215f2e
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/337884
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ Makefile.am               |   10 +-
+ gsupplicant/dbus.c        |   96 +-
+ gsupplicant/dbus.h        |   10 +
+ gsupplicant/gsupplicant.h |  277 +-
+ gsupplicant/supplicant.c  | 7092 ++++++++++++++++++++++++++++--------
+ include/dbus.h            |    3 +
+ include/device.h          |   19 +
+ include/group.h           |   74 +
+ include/network.h         |   16 +
+ include/option.h          |   35 +
+ include/peer.h            |   18 +-
+ include/sd.h              |   25 +
+ include/technology.h      |   15 +
+ include/types.h           |   45 +
+ plugins/wifi.c            | 7115 +++++++++++++++++++++++++------------
+ src/connman.h             |   43 +-
+ src/device.c              |  120 +
+ src/group.c               |  798 +++++
+ src/ippool.c              |   53 +-
+ src/main.c                |   15 +
+ src/manager.c             |    1 +
+ src/network.c             |  101 +
+ src/p2pgo.c               |  286 ++
+ src/peer.c                |  384 +-
+ src/peer_service.c        |   23 +-
+ src/sd.c                  |  382 ++
+ src/service.c             |    6 +
+ src/storage.c             |  161 +-
+ src/technology.c          |  551 ++-
+ src/tethering.c           |   75 +
+ src/util.c                |  105 +
+ 31 files changed, 14159 insertions(+), 3795 deletions(-)
+ create mode 100644 include/group.h
+ create mode 100644 include/option.h
+ create mode 100644 include/sd.h
+ create mode 100644 include/types.h
+ create mode 100644 src/group.c
+ create mode 100644 src/p2pgo.c
+ create mode 100644 src/sd.c
+
+diff --git a/Makefile.am b/Makefile.am
+index e5718b19..04777b0e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -11,13 +11,13 @@ include_HEADERS = include/log.h include/plugin.h \
+ 			include/device.h include/network.h include/inet.h \
+ 			include/storage.h include/provision.h \
+ 			include/session.h include/ipaddress.h include/agent.h \
+-			include/inotify.h include/peer.h include/machine.h \
+-			include/acd.h include/tethering.h
++			include/inotify.h include/peer.h include/sd.h include/machine.h include/types.h \
++			include/acd.h include/group.h include/tethering.h
+ 
+ nodist_include_HEADERS = include/version.h
+ 
+ noinst_HEADERS = include/rtnl.h include/task.h \
+-			include/dbus.h \
++			include/dbus.h include/option.h\
+ 			include/provider.h include/vpn-dbus.h \
+ 			include/utsname.h include/timeserver.h include/proxy.h \
+ 			include/technology.h include/setting.h \
+@@ -128,9 +128,9 @@ src_connmand_SOURCES = $(gdhcp_sources) $(gweb_sources) $(stats_sources) \
+ 			src/technology.c src/counter.c src/ntp.c \
+ 			src/session.c src/tethering.c src/wpad.c src/wispr.c \
+ 			src/6to4.c src/ippool.c src/bridge.c src/nat.c \
+-			src/ipaddress.c src/inotify.c src/ipv6pd.c src/peer.c \
++			src/ipaddress.c src/inotify.c src/ipv6pd.c src/sd.c src/peer.c \
+ 			src/peer_service.c src/machine.c src/util.c \
+-			src/acd.c
++			src/p2pgo.c src/group.c src/acd.c
+ 
+ if INTERNAL_DNS_BACKEND
+ src_connmand_SOURCES += src/dnsproxy.c
+diff --git a/gsupplicant/dbus.c b/gsupplicant/dbus.c
+index 2957979a..c28b835c 100644
+--- a/gsupplicant/dbus.c
++++ b/gsupplicant/dbus.c
+@@ -66,12 +66,14 @@ struct property_call_data {
+ 	DBusPendingCall *pending_call;
+ 	supplicant_dbus_property_function function;
+ 	void *user_data;
++	char *interface_path;
+ };
+ 
+ static void property_call_free(void *pointer)
+ {
+ 	struct property_call_data *property_call = pointer;
+ 	property_calls = g_slist_remove(property_calls, property_call);
++	g_free(property_call->interface_path);
+ 	g_free(property_call);
+ }
+ 
+@@ -239,6 +241,7 @@ int supplicant_dbus_property_get_all(const char *path, const char *interface,
+ 	property_call->pending_call = call;
+ 	property_call->function = function;
+ 	property_call->user_data = user_data;
++	property_call->interface_path = NULL;
+ 
+ 	property_calls = g_slist_prepend(property_calls, property_call);
+ 
+@@ -270,7 +273,7 @@ static void property_get_reply(DBusPendingCall *call, void *user_data)
+ 		dbus_message_iter_recurse(&iter, &variant);
+ 
+ 		if (property_call->function)
+-			property_call->function(NULL, &variant,
++			property_call->function(property_call->interface_path, &variant,
+ 						property_call->user_data);
+ 	}
+ done:
+@@ -328,6 +331,7 @@ int supplicant_dbus_property_get(const char *path, const char *interface,
+ 	property_call->pending_call = call;
+ 	property_call->function = function;
+ 	property_call->user_data = user_data;
++	property_call->interface_path = g_strdup(path);
+ 
+ 	property_calls = g_slist_prepend(property_calls, property_call);
+ 
+@@ -422,6 +426,7 @@ int supplicant_dbus_property_set(const char *path, const char *interface,
+ 	property_call->pending_call = call;
+ 	property_call->function = function;
+ 	property_call->user_data = user_data;
++	property_call->interface_path = NULL;
+ 
+ 	property_calls = g_slist_prepend(property_calls, property_call);
+ 
+@@ -494,7 +499,7 @@ int supplicant_dbus_method_call(const char *path,
+ 	if (!connection)
+ 		return -EINVAL;
+ 
+-	if (!path || !interface || !method)
++	if (!path || (strlen(path) == 0)|| !interface || !method)
+ 		return -EINVAL;
+ 
+ 	method_call = g_try_new0(struct method_call_data, 1);
+@@ -648,3 +653,90 @@ void supplicant_dbus_property_append_array(DBusMessageIter *iter,
+ 
+ 	dbus_message_iter_close_container(iter, &value);
+ }
++
++bool dbus_message_get_args_from_array_of_sv(DBusMessageIter *iter, int first_arg_type, ...)
++{
++	va_list var_args;
++	bool result = false;
++	int arg_type = first_arg_type;
++
++	va_start(var_args, first_arg_type);
++
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_ARRAY)
++		goto cleanup;
++
++	while(arg_type != DBUS_TYPE_INVALID)
++	{
++		const char* arg_name = NULL;
++		bool mandatory = false;
++		void* arg_location = NULL;
++		bool found = false;
++		DBusMessageIter dict;
++		DBusMessageIter value;
++
++		arg_name = va_arg(var_args, const char*);
++		arg_location = va_arg(var_args, void *);
++		mandatory = va_arg(var_args, int);
++
++		if (arg_name == NULL || arg_location == NULL){
++			goto cleanup;
++		}
++
++		/* Find the entry for the name in message */
++		dbus_message_iter_recurse(iter, &dict);
++		while (dbus_message_iter_get_arg_type(&dict) == DBUS_TYPE_DICT_ENTRY) {
++			DBusMessageIter entry;
++			const char *key;
++
++			dbus_message_iter_recurse(&dict, &entry);
++			if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING)
++				goto cleanup;
++
++			dbus_message_iter_get_basic(&entry, &key);
++
++			if (g_strcmp0(arg_name, key) == 0)
++			{
++				/* found the key */
++				dbus_message_iter_next(&entry);
++				if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT)
++					goto cleanup;
++
++				dbus_message_iter_recurse(&entry, &value);
++				found = true;
++				break;
++			}
++			dbus_message_iter_next(&dict);
++		}
++
++		if (found)
++		{
++			/* Parse the value */
++			if (arg_type != dbus_message_iter_get_arg_type(&value))
++			{
++				goto cleanup;
++			}
++
++			if (dbus_type_is_basic(arg_type))
++			{
++				dbus_message_iter_get_basic(&value, arg_location);
++			}
++			else
++			{
++				// Unsupported type
++				goto cleanup;
++			}
++		}
++		else if (mandatory)
++		{
++			goto cleanup;
++		}
++
++        /* Move to next entry */
++		arg_type = va_arg(var_args, int);
++	}
++
++	result = true;
++cleanup:
++	va_end(var_args);
++	return result;
++}
+diff --git a/gsupplicant/dbus.h b/gsupplicant/dbus.h
+index 3a904069..071d19f4 100644
+--- a/gsupplicant/dbus.h
++++ b/gsupplicant/dbus.h
+@@ -20,6 +20,7 @@
+  */
+ 
+ #include <dbus/dbus.h>
++#include <stdbool.h>
+ 
+ #define SUPPLICANT_SERVICE	"fi.w1.wpa_supplicant1"
+ #define SUPPLICANT_INTERFACE	"fi.w1.wpa_supplicant1"
+@@ -136,3 +137,12 @@ supplicant_dbus_dict_append_array(DBusMessageIter *dict,
+ 						function, user_data);
+ 	dbus_message_iter_close_container(dict, &entry);
+ }
++
++/**
++ * Usage: dbus_message_get_args_from_array_of_sv(iter,
++ *           DBUS_TYPE_STRING, "property_name", &property_value, bool_is_manadatory
++ *           ... ,
++ *           DBUS_TYPE_INVALID);
++ * Only basic types are supported - no strings, containers, dict entries.
++ */
++bool dbus_message_get_args_from_array_of_sv(DBusMessageIter *iter, int first_arg_type, ...);
+diff --git a/gsupplicant/gsupplicant.h b/gsupplicant/gsupplicant.h
+index eab6293f..ba934c18 100644
+--- a/gsupplicant/gsupplicant.h
++++ b/gsupplicant/gsupplicant.h
+@@ -162,8 +162,7 @@ struct _GSupplicantSSID {
+ 	dbus_bool_t use_wps;
+ 	const char *pin_wps;
+ 	const char *bgscan;
+-	unsigned int keymgmt;
+-	GSupplicantMfpOptions ieee80211w;
++	const char *bssid;
+ };
+ 
+ typedef struct _GSupplicantSSID GSupplicantSSID;
+@@ -186,8 +185,15 @@ typedef struct _GSupplicantScanParams GSupplicantScanParams;
+ 
+ struct _GSupplicantPeerParams {
+ 	bool master;
++	char *wps_method;
+ 	char *wps_pin;
+ 	char *path;
++
++	dbus_bool_t persistent;
++	dbus_bool_t join;
++	dbus_bool_t authorize_only;
++	dbus_int32_t frequency;
++	dbus_int32_t go_intent;
+ };
+ 
+ typedef struct _GSupplicantPeerParams GSupplicantPeerParams;
+@@ -201,10 +207,91 @@ struct _GSupplicantP2PServiceParams {
+ 	int response_length;
+ 	unsigned char *wfd_ies;
+ 	int wfd_ies_length;
++
++	const char *service_info;
++	dbus_uint32_t auto_accept;
++	dbus_uint32_t adv_id;
++	uint8_t service_state;
++	dbus_uint16_t config_method;
+ };
+ 
+ typedef struct _GSupplicantP2PServiceParams GSupplicantP2PServiceParams;
+ 
++typedef enum
++{
++	G_SUPPLICANT_P2P_FIND_START_WITH_FULL,
++	G_SUPPLICANT_P2P_FIND_ONLY_SOCIAL,
++	G_SUPPLICANT_P2P_FIND_PROGRESSIVE
++} GSupplicantP2PFindType;
++
++
++struct _GSupplicantP2PSDParams {
++	const char *peer;
++	const char *service_type;
++	dbus_int32_t version;
++	const char *desc;
++	const char *service_info;
++	unsigned char service_transaction_id;
++	unsigned char *query;
++	int query_len;
++	unsigned char *response;
++	dbus_uint32_t auto_accept;
++	dbus_uint32_t adv_id;
++	uint8_t service_state;
++	dbus_uint16_t config_method;
++	int response_len;
++};
++typedef struct _GSupplicantP2PSDParams GSupplicantP2PSDParams;
++
++
++typedef struct _GSupplicantP2PASPProvisionRequestParams {
++	const char *peer;
++	uint16_t config_method;
++	uint32_t advertisement_id;
++	const char *service_mac;
++	uint8_t role;
++	uint32_t session_id;
++	const char *session_mac;
++	const char *service_info;
++} GSupplicantP2PASPProvisionRequestParams;
++
++typedef struct _GSupplicantP2PASPProvisionResponseParams {
++	const char *peer;
++	uint32_t advertisement_id;
++	const char *service_mac;
++	int32_t status;
++	uint8_t role;
++	uint32_t session_id;
++	const char *session_mac;
++} GSupplicantP2PASPProvisionResponseParams;
++
++typedef struct _GSupplicantP2PSProvisionSignalParams {
++	//Common
++	uint32_t advertisement_id;
++	char service_mac[18];
++	uint32_t session_id;
++	char session_mac[18];
++	uint32_t connection_capability;
++	uint32_t password_id;
++	uint16_t feature_capability;
++
++	//Start only
++	char session_info[150]; // up to 144 bytes
++
++	//Done only
++	uint32_t status;
++	uint32_t persist;
++	char group_mac[18];
++} GSupplicantP2PSProvisionSignalParams;
++
++struct _GSupplicantP2PGroupAddParams {
++	dbus_bool_t persistent;
++	const char *persistent_group_object;
++	dbus_int32_t frequency;
++};
++
++typedef struct _GSupplicantP2PGroupAddParams GSupplicantP2PGroupAddParams;
++
+ /* global API */
+ typedef void (*GSupplicantCountryCallback) (int result,
+ 						const char *alpha2,
+@@ -217,9 +304,101 @@ int g_supplicant_set_country(const char *alpha2,
+ /* Interface API */
+ struct _GSupplicantInterface;
+ struct _GSupplicantPeer;
++struct _GSupplicantP2PInterface;
+ 
+ typedef struct _GSupplicantInterface GSupplicantInterface;
+ typedef struct _GSupplicantPeer GSupplicantPeer;
++typedef struct _GSupplicantP2PInterface GSupplicantP2PInterface;
++typedef struct _GSupplicantRequestedPeer GSupplicantRequestedPeer;
++
++struct _GSupplicantP2PDeviceConfigParams {
++	GSupplicantInterface *interface;
++	char *device_name;
++	unsigned char pri_dev_type[8];
++	dbus_uint32_t go_intent;
++	int persistent_reconnect;
++	dbus_uint32_t listen_reg_class;
++	dbus_uint32_t listen_channel;
++	dbus_uint32_t oper_reg_class;
++	dbus_uint32_t oper_channel;
++	char *ssid_postfix;
++	int intra_bss;
++	dbus_uint32_t group_idle;
++	dbus_uint32_t disassoc_low_ack;
++	const void *user_data;
++};
++
++typedef int		connman_bool_t;
++
++struct _GSupplicantP2PPersistentGroup {
++	GSupplicantInterface *interface;
++	char *path;
++	char *group_path;
++	char *bssid;
++	char *bssid_no_colon;
++	char *ssid;
++	char *psk;
++	connman_bool_t go;
++	unsigned long long connected_time;
++};
++typedef struct _GSupplicantP2PPersistentGroup GSupplicantP2PPersistentGroup;
++
++struct _GSupplicantP2PGroup {
++	GSupplicantInterface *interface;
++	GSupplicantInterface *group_interface;
++	char *path;
++	char *ssid;
++	char *bssid_no_colon;
++	char *passphrase;
++	char *psk;
++	char *role;
++	char *ip_addr;
++	char *ip_mask;
++	char *go_ip_addr;
++	int persistent;
++	int freq;
++	GSupplicantP2PPersistentGroup *persistent_group;
++};
++
++typedef struct _GSupplicantP2PGroup GSupplicantP2PGroup;
++
++/* ASP service advertised by the peer.*/
++struct _GSupplicantP2PService {
++	dbus_uint32_t advertisement_id;
++	char service_name[256];
++};
++
++typedef struct _GSupplicantP2PService GSupplicantP2PService;
++
++struct _GSupplicantP2PWPSParams {
++	const char *role;
++	const char *type;
++	const char *p2p_dev_addr;
++	const char *pin;
++};
++typedef struct _GSupplicantP2PWPSParams GSupplicantP2PWPSParams;
++
++struct _GSupplicantP2PFindParams {
++	dbus_int32_t timeout;
++	int disc_type;
++	const char** seek_array;
++	int frequency;
++};
++
++typedef struct _GSupplicantP2PFindParams GSupplicantP2PFindParams;
++
++typedef struct _GSupplicantP2PDeviceConfigParams GSupplicantP2PDeviceConfigParams;
++struct p2p_listen_data {
++	int period;
++	int interval;
++};
++
++struct _GSupplicantP2PInviteParams {
++	const char *peer;
++	const char *persistent_group;
++};
++
++typedef struct _GSupplicantP2PInviteParams GSupplicantP2PInviteParams;
+ 
+ typedef void (*GSupplicantInterfaceCallback) (int result,
+ 					GSupplicantInterface *interface,
+@@ -228,7 +407,7 @@ typedef void (*GSupplicantInterfaceCallback) (int result,
+ void g_supplicant_interface_cancel(GSupplicantInterface *interface);
+ 
+ int g_supplicant_interface_create(const char *ifname, const char *driver,
+-					const char *bridge,
++					const char *bridge, const char *config_file,
+ 					GSupplicantInterfaceCallback callback,
+ 							void *user_data);
+ int g_supplicant_interface_remove(GSupplicantInterface *interface,
+@@ -240,7 +419,8 @@ int g_supplicant_interface_scan(GSupplicantInterface *interface,
+ 							void *user_data);
+ 
+ int g_supplicant_interface_p2p_find(GSupplicantInterface *interface,
+-					GSupplicantInterfaceCallback callback,
++				GSupplicantP2PFindParams *find_data,
++				GSupplicantInterfaceCallback callback,
+ 							void *user_data);
+ 
+ int g_supplicant_interface_p2p_stop_find(GSupplicantInterface *interface);
+@@ -253,16 +433,43 @@ int g_supplicant_interface_p2p_connect(GSupplicantInterface *interface,
+ int g_supplicant_interface_p2p_disconnect(GSupplicantInterface *interface,
+ 					GSupplicantPeerParams *peer_params);
+ 
++int g_supplicant_interface_p2p_group_disconnect(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++					void *user_data);
++
++int g_supplicant_interface_p2p_persistent_group_add(GSupplicantInterface *interface,
++					GSupplicantSSID *ssid, GSupplicantInterfaceCallback callback,
++					void *user_data);
++
++int g_supplicant_interface_p2p_group_add(GSupplicantInterface *interface,
++				GSupplicantP2PGroupAddParams *group_data,
++				GSupplicantInterfaceCallback callback,
++				void *user_data);
++
+ int g_supplicant_interface_p2p_listen(GSupplicantInterface *interface,
+-						int period, int interval);
++						int period, int interval,
++						GSupplicantInterfaceCallback callback,
++						void *user_data);
+ 
+ int g_supplicant_interface_p2p_add_service(GSupplicantInterface *interface,
+ 				GSupplicantInterfaceCallback callback,
+ 				GSupplicantP2PServiceParams *p2p_service_params,
+ 				void *user_data);
+ 
++typedef void (*GSupplicantInterfaceCallbackWithData) (int result,
++					GSupplicantInterface *interface,
++							void *user_data, void* data);
++int g_supplicant_interface_p2p_wps_start(GSupplicantInterface *interface,
++													GSupplicantP2PWPSParams *wps_data,
++													GSupplicantInterfaceCallback callback,
++													void *user_data);
+ int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
+ 				GSupplicantP2PServiceParams *p2p_service_params);
++int g_supplicant_interface_p2p_flush(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback, void *user_data);
++int g_supplicant_interface_p2p_invite(GSupplicantInterface *interface,
++				GSupplicantP2PInviteParams *invite_data,
++				GSupplicantInterfaceCallback callback, void *user_data);
+ 
+ int g_supplicant_set_widi_ies(GSupplicantP2PServiceParams *p2p_service_params,
+ 					GSupplicantInterfaceCallback callback,
+@@ -308,14 +515,32 @@ bool g_supplicant_interface_has_p2p(GSupplicantInterface *interface);
+ int g_supplicant_interface_set_p2p_device_config(GSupplicantInterface *interface,
+ 						const char *device_name,
+ 						const char *primary_dev_type);
++int g_supplicant_interface_set_p2p_device_configs(GSupplicantInterface *interface,
++						GSupplicantP2PDeviceConfigParams *p2p_device_config_data,
++						void *user_data);
++int g_supplicant_interface_get_p2p_device_config(GSupplicantInterface *interface,
++						GSupplicantP2PDeviceConfigParams *p2p_device_config);
++int g_supplicant_interface_set_p2p_disabled(GSupplicantInterface *interface,
++						dbus_bool_t disabled);
+ GSupplicantPeer *g_supplicant_interface_peer_lookup(GSupplicantInterface *interface,
+ 						const char *identifier);
+ bool g_supplicant_interface_is_p2p_finding(GSupplicantInterface *interface);
+ 
++int g_supplicant_interface_update_signal_info(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback, void *user_data);
++
++unsigned int g_supplicant_interface_get_rssi(GSupplicantInterface *interface);
++unsigned int g_supplicant_interface_get_link_speed(GSupplicantInterface *interface);
++unsigned int g_supplicant_interface_get_frequency(GSupplicantInterface *interface);
++unsigned int g_supplicant_interface_get_noise(GSupplicantInterface *interface);
++
+ /* Network and Peer API */
+ struct _GSupplicantNetwork;
+ struct _GSupplicantGroup;
+ 
++struct _GSupplicantP2PNetwork;
++typedef struct _GSupplicantP2PNetwork GSupplicantP2PNetwork;
++
+ typedef struct _GSupplicantNetwork GSupplicantNetwork;
+ typedef struct _GSupplicantGroup GSupplicantGroup;
+ 
+@@ -334,6 +559,17 @@ dbus_bool_t g_supplicant_network_is_wps_active(GSupplicantNetwork *network);
+ dbus_bool_t g_supplicant_network_is_wps_pbc(GSupplicantNetwork *network);
+ dbus_bool_t g_supplicant_network_is_wps_advertizing(GSupplicantNetwork *network);
+ 
++const unsigned char *g_supplicant_network_get_bssid(GSupplicantNetwork *network);
++GHashTable *g_supplicant_network_get_bss_table(GSupplicantNetwork *network);
++
++struct g_supplicant_bss;
++
++typedef struct g_supplicant_bss GSupplicantBss;
++
++const unsigned char *g_supplicant_bss_get_bssid(GSupplicantBss *bss);
++dbus_int16_t g_supplicant_bss_get_signal(GSupplicantBss *bss);
++dbus_uint16_t g_supplicant_bss_get_frequency(GSupplicantBss *bss);
++
+ GSupplicantInterface *g_supplicant_peer_get_interface(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_path(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_identifier(GSupplicantPeer *peer);
+@@ -348,6 +584,13 @@ bool g_supplicant_peer_is_in_a_group(GSupplicantPeer *peer);
+ GSupplicantInterface *g_supplicant_peer_get_group_interface(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_client(GSupplicantPeer *peer);
+ bool g_supplicant_peer_has_requested_connection(GSupplicantPeer *peer);
++
++GSupplicantP2PNetwork* g_supplicant_find_network_from_intf_address(const char* pintf_addr, const char* p2p_dev_addr);
++const char *g_supplicant_peer_identifier_from_intf_address(const char* pintf_addr);
++const char *g_supplicant_peer_wfds_get_identifier(GSupplicantPeer *peer);
++int g_supplicant_peer_wfds_get_asp_services(GSupplicantPeer *peer, GSupplicantP2PService** services);
++const char *g_supplicant_peer_wfds_get_peer_name(GSupplicantPeer *peer);
++char *g_supplicant_group_get_ssid(GSupplicantGroup *group);
+ unsigned int g_supplicant_network_get_keymgmt(GSupplicantNetwork *network);
+ 
+ struct _GSupplicantCallbacks {
+@@ -357,6 +600,7 @@ struct _GSupplicantCallbacks {
+ 	void (*interface_state) (GSupplicantInterface *interface);
+ 	void (*interface_removed) (GSupplicantInterface *interface);
+ 	void (*p2p_support) (GSupplicantInterface *interface);
++	void (*p2p_device_config_loaded) (GSupplicantInterface *interface);
+ 	void (*scan_started) (GSupplicantInterface *interface);
+ 	void (*scan_finished) (GSupplicantInterface *interface);
+ 	void (*ap_create_fail) (GSupplicantInterface *interface);
+@@ -365,6 +609,8 @@ struct _GSupplicantCallbacks {
+ 	void (*network_changed) (GSupplicantNetwork *network,
+ 					const char *property);
+ 	void (*network_associated) (GSupplicantNetwork *network);
++	void (*station_added) (const char *mac);
++	void (*station_removed) (const char *mac);
+ 	void (*sta_authorized) (GSupplicantInterface *interface,
+ 					const char *addr);
+ 	void (*sta_deauthorized) (GSupplicantInterface *interface,
+@@ -373,12 +619,31 @@ struct _GSupplicantCallbacks {
+ 	void (*peer_lost) (GSupplicantPeer *peer);
+ 	void (*peer_changed) (GSupplicantPeer *peer,
+ 					GSupplicantPeerState state);
+-	void (*peer_request) (GSupplicantPeer *peer);
++	void (*peer_request) (GSupplicantPeer *peer, int dev_passwd_id);
++	void (*p2p_sd_response) (GSupplicantInterface *interface, GSupplicantPeer *peer, int indicator, unsigned char *tlv, int tlv_len);
++	void (*p2p_sd_asp_response) (GSupplicantInterface *interface,  GSupplicantPeer *peer, unsigned char transaction_id, unsigned int advertisment_id, unsigned char service_status, dbus_uint16_t config_method, const char* service_name, const char* service_info);
++	void (*wps_state)(GSupplicantInterface *interface);
+ 	void (*debug) (const char *str);
+ 	void (*disconnect_reasoncode)(GSupplicantInterface *interface,
+ 				int reasoncode);
+ 	void (*assoc_status_code)(GSupplicantInterface *interface,
+ 				int reasoncode);
++	void (*p2p_group_started)(GSupplicantGroup *group);
++	void (*p2p_group_finished)(GSupplicantInterface *interface);
++	void (*p2ps_prov_start) (GSupplicantInterface *interface,  GSupplicantPeer *peer, GSupplicantP2PSProvisionSignalParams* params);
++	void (*p2ps_prov_done) (GSupplicantInterface *interface,  GSupplicantPeer *peer, GSupplicantP2PSProvisionSignalParams* params);
++
++	void (*p2p_persistent_group_added) (GSupplicantInterface *interface, GSupplicantP2PPersistentGroup *persistent_group);
++	void (*p2p_persistent_group_removed) (GSupplicantInterface *interface, const char *persistent_group_path);
++	void (*p2p_prov_disc_requested_pbc) (GSupplicantInterface *interface, GSupplicantPeer *peer);
++	void (*p2p_prov_disc_requested_enter_pin) (GSupplicantInterface *interface, GSupplicantPeer *peer);
++	void (*p2p_prov_disc_requested_display_pin) (GSupplicantInterface *interface, GSupplicantPeer *peer, const char *pin);
++	void (*p2p_prov_disc_response_enter_pin) (GSupplicantInterface *interface, GSupplicantPeer *peer);
++	void (*p2p_prov_disc_response_display_pin) (GSupplicantInterface *interface, GSupplicantPeer *peer, const char *pin);
++	void (*p2p_prov_disc_fail) (GSupplicantInterface *interface, GSupplicantPeer *peer, int status);
++
++	void (*p2p_invitation_result)(GSupplicantInterface *interface, int status);
++	void (*p2p_invitation_received) (GSupplicantInterface *interface, GSupplicantP2PNetwork *p2p_network, const char *go_dev_addr, connman_bool_t persistent);
+ };
+ 
+ typedef struct _GSupplicantCallbacks GSupplicantCallbacks;
+diff --git a/gsupplicant/supplicant.c b/gsupplicant/supplicant.c
+index 470d99eb..5e37e33b 100644
+--- a/gsupplicant/supplicant.c
++++ b/gsupplicant/supplicant.c
+@@ -46,6 +46,9 @@
+ 
+ #define BSS_UNKNOWN_STRENGTH    -90
+ 
++#define WPAS_P2P_WPS_PIN_LENGTH		8
++#define MAX_P2P_SSID_LEN			32
++
+ static DBusConnection *connection;
+ 
+ static const GSupplicantCallbacks *callbacks_pointer;
+@@ -145,6 +148,13 @@ static GHashTable *peer_mapping;
+ static GHashTable *group_mapping;
+ static GHashTable *pending_peer_connection;
+ static GHashTable *config_file_table;
++static GHashTable *intf_addr_mapping;
++static GHashTable *dev_addr_mapping;
++static GSList *p2p_network_list;
++static GHashTable *p2p_peer_table;
++
++typedef void (*g_supplicant_p2p_prov_dics_signal_func) (GSupplicantInterface *interface,
++				GSupplicantPeer* peer, void* params);
+ 
+ struct _GSupplicantWpsCredentials {
+ 	unsigned char ssid[32];
+@@ -170,6 +180,10 @@ struct _GSupplicantInterface {
+ 	unsigned int scan_capa;
+ 	unsigned int mode_capa;
+ 	unsigned int max_scan_ssids;
++	unsigned int rssi;
++	unsigned int link_speed;
++	unsigned int frequency;
++	unsigned int noise;
+ 	bool p2p_support;
+ 	bool p2p_finding;
+ 	bool ap_create_in_progress;
+@@ -188,10 +202,15 @@ struct _GSupplicantInterface {
+ 	GHashTable *peer_table;
+ 	GHashTable *group_table;
+ 	GHashTable *bss_mapping;
++	GHashTable *p2p_peer_path_to_network;
++	GHashTable *p2p_group_path_to_group;
+ 	void *data;
+ 	const char *pending_peer_path;
+ 	GSupplicantNetwork *current_network;
+ 	struct added_network_information network_info;
++
++	unsigned char p2p_device_address[6];
++
+ };
+ 
+ struct g_supplicant_bss {
+@@ -219,6 +238,29 @@ struct g_supplicant_bss {
+ 	unsigned int wps_capabilities;
+ };
+ 
++struct _GSupplicantP2PNetwork {
++	GSupplicantInterface *interface;
++	int found_ref;
++	char *path;
++	char *identifier; /* Device address in string 112233445566 format */
++	char *group;
++	char *name;
++	unsigned char p2p_device_addr[6]; /* Device address in binary format */
++	uint8_t pri_dev_type[8];
++	uint8_t dev_capab;
++	uint8_t group_capab;
++	dbus_uint16_t config_methods;
++	dbus_int32_t level;
++	int wfd_dev_type;
++	int wfd_session_avail;
++	int wfd_cp_support;
++	unsigned int wfd_rtsp_port;
++	GSupplicantP2PService* asp_services;
++	int asp_services_len;
++	GHashTable *peer_table;
++	connman_bool_t removed;
++};
++
+ struct _GSupplicantNetwork {
+ 	GSupplicantInterface *interface;
+ 	char *path;
+@@ -245,12 +287,32 @@ struct _GSupplicantPeer {
+ 	unsigned char iface_address[ETH_ALEN];
+ 	char *name;
+ 	unsigned char *widi_ies;
++	char *ip_addr;
+ 	int widi_ies_length;
+ 	char *identifier;
++	dbus_uint16_t config_methods;
+ 	unsigned int wps_capabilities;
+ 	GSList *groups;
+ 	const GSupplicantInterface *current_group_iface;
+ 	bool connection_requested;
++	dbus_int32_t level;
++
++	GSupplicantP2PService* asp_services;
++	int asp_services_len;
++	int status;
++	int found_pending_signal_timeout_ref;
++
++	char *pri_dev_type;
++	GSList* pending_signals; // List of ordered signals pending dispatch when peer properties are fetched and network is created
++	GSList* pending_invitation_signals;
++};
++
++struct _GSupplicantRequestedPeer {
++	char *requested_p2p_dev_addr;
++	char *requested_path;
++	char *requested_ip_addr;
++	bool requested_is_ip_present;
++	struct peer_device_data *found_p2p_network;
+ };
+ 
+ struct _GSupplicantGroup {
+@@ -259,6 +321,21 @@ struct _GSupplicantGroup {
+ 	char *path;
+ 	int role;
+ 	GSList *members;
++	char *ssid;
++	char *passphrase;
++	char *bssid_no_colon;
++	bool persistent;
++	int frequency;
++	char *ip_addr;
++	char *ip_mask;
++	char *go_ip_addr;
++	char *psk;
++	GSupplicantP2PPersistentGroup *persistent_group;
++};
++
++struct _GSupplicantP2PInterface {
++	char *path;
++	GSupplicantP2PDeviceConfigParams *p2p_device_config_param;
+ };
+ 
+ struct interface_data {
+@@ -276,9 +353,13 @@ struct interface_create_data {
+ 	char *ifname;
+ 	char *driver;
+ 	char *bridge;
++	const char *config_file;
++	const char *country_code;
+ 	GSupplicantInterface *interface;
++	char *interface_path;
+ 	GSupplicantInterfaceCallback callback;
+ 	void *user_data;
++	unsigned char get_interface_timer_count;
+ };
+ 
+ struct interface_connect_data {
+@@ -292,6 +373,14 @@ struct interface_connect_data {
+ 	};
+ };
+ 
++struct interface_wps_connect_data {
++	GSupplicantInterface *interface;
++	char *path;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantSSID *ssid;
++	void *user_data;
++};
++
+ struct interface_scan_data {
+ 	GSupplicantInterface *interface;
+ 	char *path;
+@@ -300,7 +389,43 @@ struct interface_scan_data {
+ 	void *user_data;
+ };
+ 
++struct interface_reject_data {
++	GSupplicantInterface *interface;
++	char *path;
++	GSupplicantInterfaceCallback callback;
++	void *user_data;
++	GSupplicantPeerParams *peer;
++};
++
++struct interface_p2p_device_config {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantP2PDeviceConfigParams *p2p_device_config_params;
++	void *user_data;
++};
++
++typedef void (*g_supplicant_p2p_network_signal_func) (GSupplicantInterface *interface, GSupplicantPeer *peer, GSupplicantP2PSProvisionSignalParams* params);
++typedef void (*g_supplicant_p2p_network_signal_free_func) (void* params);
++
++struct g_supplicant_p2p_peer_signal {
++	g_supplicant_p2p_network_signal_func dispatch_function;
++	g_supplicant_p2p_network_signal_free_func free_function; // function to use for freeing the params
++	void* callback_params;
++};
++
++struct g_supplicant_p2p_inv_recv_info {
++	GSupplicantInterface *interface;
++	const char *p2p_go_dev_addr;
++	const char *src_addr;
++	connman_bool_t persistent;
++	unsigned char get_invitation_timer_count;
++};
++
++static int inv_recv_ref = -1;
++static int scan_callback_ref;
++
+ static int network_remove(struct interface_data *data);
++static gboolean get_interface_retry(void* user_data);
+ 
+ static inline void debug(const char *format, ...)
+ {
+@@ -538,6 +663,17 @@ static void callback_p2p_support(GSupplicantInterface *interface)
+ 		callbacks_pointer->p2p_support(interface);
+ }
+ 
++static void callback_p2p_device_config_loaded(GSupplicantInterface *interface)
++{
++	SUPPLICANT_DBG("");
++
++	if (!interface->p2p_support)
++		return;
++
++	if (callbacks_pointer && callbacks_pointer->p2p_device_config_loaded)
++		callbacks_pointer->p2p_device_config_loaded(interface);
++}
++
+ static void callback_scan_started(GSupplicantInterface *interface)
+ {
+ 	if (!callbacks_pointer)
+@@ -674,7 +810,221 @@ static void callback_peer_changed(GSupplicantPeer *peer,
+ 	callbacks_pointer->peer_changed(peer, state);
+ }
+ 
+-static void callback_peer_request(GSupplicantPeer *peer)
++static void callback_p2p_group_started(GSupplicantGroup *group)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_group_started)
++		return;
++
++	callbacks_pointer->p2p_group_started(group);
++}
++
++static void callback_p2p_group_finished(GSupplicantInterface *interface)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_group_finished)
++		return;
++
++	callbacks_pointer->p2p_group_finished(interface);
++}
++
++static void callback_p2ps_prov_start(GSupplicantInterface *interface, GSupplicantPeer *peer,
++                                       GSupplicantP2PSProvisionSignalParams* params)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->p2ps_prov_start == NULL)
++		return;
++
++	callbacks_pointer->p2ps_prov_start(interface,peer, params);
++}
++
++static void callback_p2ps_prov_done(GSupplicantInterface *interface, GSupplicantPeer *peer,
++                                    GSupplicantP2PSProvisionSignalParams* params)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->p2ps_prov_done == NULL)
++		return;
++
++	callbacks_pointer->p2ps_prov_done(interface,peer, params);
++}
++
++static void callback_p2p_prov_disc_requested_pbc(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, void * data)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_prov_disc_requested_pbc)
++		return;
++
++	callbacks_pointer->p2p_prov_disc_requested_pbc(interface, peer);
++}
++
++static void callback_p2p_prov_disc_requested_enter_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, void * data)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_prov_disc_requested_enter_pin)
++		return;
++
++	callbacks_pointer->p2p_prov_disc_requested_enter_pin(interface, peer);
++}
++
++static void callback_p2p_prov_disc_requested_display_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, const char *pin)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_prov_disc_requested_display_pin)
++		return;
++
++	callbacks_pointer->p2p_prov_disc_requested_display_pin(interface, peer, pin);
++}
++
++static void callback_p2p_prov_disc_response_enter_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, void * data)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_prov_disc_requested_enter_pin)
++		return;
++
++	callbacks_pointer->p2p_prov_disc_response_enter_pin(interface, peer);
++}
++
++static void callback_p2p_prov_disc_response_display_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, const char *pin)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_prov_disc_requested_display_pin)
++		return;
++
++	callbacks_pointer->p2p_prov_disc_response_display_pin(interface, peer, pin);
++}
++
++static void callback_p2p_prov_disc_fail(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, const char *pin)
++{
++	if (!callbacks_pointer)
++		return;
++
++	if (!callbacks_pointer->p2p_prov_disc_fail)
++		return;
++
++	callbacks_pointer->p2p_prov_disc_fail(interface, peer, pin);
++}
++
++GSupplicantInterface *g_supplicant_group_get_interface(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->interface;
++}
++
++GSupplicantInterface *g_supplicant_group_get_orig_interface(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->orig_interface;
++}
++
++char *g_supplicant_group_get_bssid_no_colon(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->bssid_no_colon;
++}
++
++char *g_supplicant_group_get_object_path(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->path;
++}
++
++char *g_supplicant_group_get_ssid(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->ssid;
++}
++
++char *g_supplicant_group_get_passphrase(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->passphrase;
++}
++
++int g_supplicant_group_get_frequency(GSupplicantGroup *group)
++{
++	if(!group)
++		return 0;
++
++	return group->frequency;
++}
++
++int g_supplicant_group_get_role(GSupplicantGroup *group)
++{
++	if(!group)
++		return 0;
++
++	return group->role;
++}
++
++bool g_supplicant_group_get_persistent(GSupplicantGroup *group)
++{
++	if(!group)
++		return false;
++
++	return group->persistent;
++}
++
++char *g_supplicant_group_get_ip_addr(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->ip_addr;
++}
++
++char *g_supplicant_group_get_ip_mask(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->ip_mask;
++}
++
++char *g_supplicant_group_get_go_ip_addr(GSupplicantGroup *group)
++{
++	if(!group)
++		return NULL;
++
++	return group->go_ip_addr;
++}
++
++static void callback_peer_request(GSupplicantPeer *peer, int dev_passwd_id)
+ {
+ 	if (!callbacks_pointer)
+ 		return;
+@@ -684,7 +1034,7 @@ static void callback_peer_request(GSupplicantPeer *peer)
+ 
+ 	peer->connection_requested = true;
+ 
+-	callbacks_pointer->peer_request(peer);
++	callbacks_pointer->peer_request(peer, dev_passwd_id);
+ }
+ 
+ static void callback_disconnect_reason_code(GSupplicantInterface *interface,
+@@ -701,6 +1051,39 @@ static void callback_disconnect_reason_code(GSupplicantInterface *interface,
+ 							reason_code);
+ }
+ 
++
++static void callback_p2p_persistent_group_added(GSupplicantInterface *interface, GSupplicantP2PPersistentGroup *group)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->p2p_persistent_group_added == NULL)
++		return;
++
++	callbacks_pointer->p2p_persistent_group_added(interface, group);
++}
++static void callback_p2p_persistent_group_removed(GSupplicantInterface *interface, const char *persistent_group_path)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->p2p_persistent_group_removed == NULL)
++		return;
++
++	callbacks_pointer->p2p_persistent_group_removed(interface, persistent_group_path);
++}
++static void callback_p2p_sd_response(GSupplicantInterface *interface, GSupplicantPeer *peer,
++											int indicator, unsigned char *tlv, int tlv_len)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->p2p_sd_response == NULL)
++		return;
++
++	callbacks_pointer->p2p_sd_response(interface, peer, indicator, tlv, tlv_len);
++}
++
+ static void callback_assoc_status_code(GSupplicantInterface *interface,
+ 				int status_code)
+ {
+@@ -722,9 +1105,17 @@ static void remove_group(gpointer data)
+ 		g_slist_free_full(group->members, g_free);
+ 
+ 	g_free(group->path);
++	g_free(group->bssid_no_colon);
++	g_free(group->ip_addr);
++	g_free(group->ip_mask);
++	g_free(group->go_ip_addr);
++	g_free(group->ssid);
++	g_free(group->psk);
++	g_free(group->passphrase);
+ 	g_free(group);
+ }
+ 
++
+ static void remove_interface(gpointer data)
+ {
+ 	GSupplicantInterface *interface = data;
+@@ -733,6 +1124,15 @@ static void remove_interface(gpointer data)
+ 	g_hash_table_destroy(interface->network_table);
+ 	g_hash_table_destroy(interface->peer_table);
+ 	g_hash_table_destroy(interface->group_table);
++	if (interface->p2p_peer_path_to_network) {
++		g_hash_table_destroy(interface->p2p_peer_path_to_network);
++		interface->p2p_peer_path_to_network = NULL;
++	}
++
++	if (interface->p2p_group_path_to_group) {
++		g_hash_table_destroy(interface->p2p_group_path_to_group);
++		interface->p2p_group_path_to_group = NULL;
++	}
+ 
+ 	if (interface->scan_callback) {
+ 		SUPPLICANT_DBG("call interface %p callback %p scanning %d",
+@@ -791,6 +1191,7 @@ static void remove_peer(gpointer data)
+ {
+ 	GSupplicantPeer *peer = data;
+ 
++	SUPPLICANT_DBG("peer %p", peer);
+ 	callback_peer_lost(peer);
+ 
+ 	if (peer->groups)
+@@ -802,10 +1203,20 @@ static void remove_peer(gpointer data)
+ 	if (pending_peer_connection)
+ 		g_hash_table_remove(pending_peer_connection, peer->path);
+ 
++	if (p2p_peer_table)
++		g_hash_table_remove(p2p_peer_table, peer->path);
++
++	if (peer->found_pending_signal_timeout_ref > 0){
++		g_source_remove(peer->found_pending_signal_timeout_ref);
++		peer->found_pending_signal_timeout_ref = 0;
++	}
++
+ 	g_free(peer->path);
+ 	g_free(peer->name);
+ 	g_free(peer->identifier);
+ 	g_free(peer->widi_ies);
++	g_free(peer->pri_dev_type);
++	g_free(peer->ip_addr);
+ 
+ 	g_free(peer);
+ }
+@@ -1150,6 +1561,50 @@ unsigned int g_supplicant_interface_get_max_scan_ssids(
+ 	return interface->max_scan_ssids;
+ }
+ 
++unsigned int g_supplicant_interface_get_rssi(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return 0;
++
++	return interface->rssi;
++}
++unsigned int g_supplicant_interface_get_link_speed(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return 0;
++
++	return interface->link_speed;
++}
++
++unsigned int g_supplicant_interface_get_frequency(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return 0;
++
++	return interface->frequency;
++}
++
++unsigned int g_supplicant_interface_get_noise(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return 0;
++
++	return interface->noise;
++}
++
++void g_supplicant_interface_set_p2p_persistent_group(GSupplicantInterface *interface, GSupplicantGroup *group, GSupplicantP2PPersistentGroup *persistent_group)
++{
++	group->persistent_group = persistent_group;
++	g_hash_table_replace(interface->p2p_group_path_to_group, group->path, group);
++}
++
++GSupplicantP2PPersistentGroup* g_supplicant_interface_get_p2p_persistent_group(GSupplicantInterface *interface, GSupplicantGroup *group)
++{
++	if (!group)
++		return NULL;
++
++	return group->persistent_group;
++}
+ static void set_network_enabled(DBusMessageIter *iter, void *user_data)
+ {
+ 	dbus_bool_t enable = *(dbus_bool_t *)user_data;
+@@ -1217,7 +1672,7 @@ const char *g_supplicant_network_get_path(GSupplicantNetwork *network)
+ const char *g_supplicant_network_get_mode(GSupplicantNetwork *network)
+ {
+ 	if (!network)
+-		return NULL;
++		return G_SUPPLICANT_MODE_UNKNOWN;
+ 
+ 	return mode2string(network->mode);
+ }
+@@ -1299,22 +1754,69 @@ dbus_bool_t g_supplicant_network_is_wps_advertizing(GSupplicantNetwork *network)
+ 	return FALSE;
+ }
+ 
+-GSupplicantInterface *g_supplicant_peer_get_interface(GSupplicantPeer *peer)
++const unsigned char *g_supplicant_network_get_bssid(GSupplicantNetwork *network)
+ {
+-	if (!peer)
++	if (!network || !network->best_bss)
+ 		return NULL;
+ 
+-	return peer->interface;
++	return network->best_bss->bssid;
+ }
+-
+-const char *g_supplicant_peer_get_path(GSupplicantPeer *peer)
++GHashTable *g_supplicant_network_get_bss_table(GSupplicantNetwork *network)
+ {
+-	if (!peer)
++	if (!network)
++		return NULL;
++
++	return network->bss_table;
++}
++
++const unsigned char *g_supplicant_bss_get_bssid(GSupplicantBss *bss)
++{
++	if (!bss)
++		return NULL;
++
++	return bss->bssid;
++}
++
++dbus_int16_t g_supplicant_bss_get_signal(GSupplicantBss *bss)
++{
++	if (!bss)
++		return 0;
++
++	return bss->signal;
++}
++
++dbus_uint16_t g_supplicant_bss_get_frequency(GSupplicantBss *bss)
++{
++	if (!bss)
++		return 0;
++
++	return bss->frequency;
++}
++
++GSupplicantInterface *g_supplicant_peer_get_interface(GSupplicantPeer *peer)
++{
++	if (!peer)
++		return NULL;
++
++	return peer->interface;
++}
++
++const char *g_supplicant_peer_get_path(GSupplicantPeer *peer)
++{
++	if (!peer)
+ 		return NULL;
+ 
+ 	return peer->path;
+ }
+ 
++dbus_uint16_t g_supplicant_peer_get_config_methods(GSupplicantPeer *peer)
++{
++	if (!peer)
++		return 0;
++
++	return peer->config_methods;
++}
++
+ const char *g_supplicant_peer_get_identifier(GSupplicantPeer *peer)
+ {
+ 	if (!peer)
+@@ -1339,6 +1841,13 @@ const void *g_supplicant_peer_get_iface_address(GSupplicantPeer *peer)
+ 	return peer->iface_address;
+ }
+ 
++const char *g_supplicant_peer_get_ip_address(GSupplicantPeer *peer)
++{
++	if (!peer)
++		return NULL;
++
++	return peer->ip_addr;
++}
+ const char *g_supplicant_peer_get_name(GSupplicantPeer *peer)
+ {
+ 	if (!peer)
+@@ -1356,6 +1865,28 @@ const unsigned char *g_supplicant_peer_get_widi_ies(GSupplicantPeer *peer,
+ 	*length = peer->widi_ies_length;
+ 	return peer->widi_ies;
+ }
++dbus_int32_t g_supplicant_peer_get_level(GSupplicantPeer *peer)
++{
++	if (!peer)
++		return 0;
++
++	return peer->level;
++}
++const char *g_supplicant_peer_get_pri_dev_type(GSupplicantPeer *peer)
++{
++	if (!peer)
++		return NULL;
++
++	return peer->pri_dev_type;
++}
++
++int g_supplicant_peer_get_failure_status(GSupplicantPeer *peer)
++{
++	if (!peer)
++		return 0;
++
++	return peer->status;
++}
+ 
+ bool g_supplicant_peer_is_wps_pbc(GSupplicantPeer *peer)
+ {
+@@ -2100,17 +2631,23 @@ static void interface_bss_added_with_keys(DBusMessageIter *iter,
+ 						void *user_data)
+ {
+ 	struct g_supplicant_bss *bss;
++	GSupplicantInterface *interface = user_data;
+ 
+ 	SUPPLICANT_DBG("");
+ 
++	if (!g_strcmp0(interface->ifname, "p2p0"))
++		return;
++
+ 	bss = interface_bss_added(iter, user_data);
+ 	if (!bss)
+ 		return;
+ 
+ 	dbus_message_iter_next(iter);
+ 
+-	if (dbus_message_iter_get_arg_type(iter) == DBUS_TYPE_INVALID)
++	if (dbus_message_iter_get_arg_type(iter) == DBUS_TYPE_INVALID) {
++		g_free(bss);
+ 		return;
++	}
+ 
+ 	supplicant_dbus_property_foreach(iter, bss_property, bss);
+ 
+@@ -2123,9 +2660,13 @@ static void interface_bss_added_without_keys(DBusMessageIter *iter,
+ 						void *user_data)
+ {
+ 	struct g_supplicant_bss *bss;
++	GSupplicantInterface *interface = user_data;
+ 
+ 	SUPPLICANT_DBG("");
+ 
++	if (!g_strcmp0(interface->ifname, "p2p0"))
++		return;
++
+ 	bss = interface_bss_added(iter, user_data);
+ 	if (!bss)
+ 		return;
+@@ -2304,6 +2845,35 @@ static void wps_property(const char *key, DBusMessageIter *iter,
+ 
+ }
+ 
++static void interface_signal_info(const char *key, DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantInterface *interface = user_data;
++
++	if (g_strcmp0(key, "RSSI") == 0) {
++		dbus_int32_t rssi = 0;
++		dbus_message_iter_get_basic(iter, &rssi);
++
++		interface->rssi = rssi;
++
++	} else if (g_strcmp0(key, "LinkSpeed") == 0) {
++		dbus_int32_t link_speed = 0;
++		dbus_message_iter_get_basic(iter, &link_speed);
++
++		interface->link_speed = link_speed;
++
++	} else if (g_strcmp0(key, "Frequency") == 0) {
++		dbus_int32_t frequency = 0;
++		dbus_message_iter_get_basic(iter, &frequency);
++
++		interface->frequency = frequency;
++
++	} else if (g_strcmp0(key, "Noise") == 0) {
++		dbus_int32_t noise = 0;
++		dbus_message_iter_get_basic(iter, &noise);
++
++		interface->noise = noise;
++	}
++}
+ static void interface_property(const char *key, DBusMessageIter *iter,
+ 							void *user_data)
+ {
+@@ -2419,7 +2989,7 @@ static void interface_property(const char *key, DBusMessageIter *iter,
+ 				g_strdup(interface->ifname), g_strdup(str));
+ 		}
+ 	} else if (g_strcmp0(key, "CurrentBSS") == 0) {
+-		interface_current_bss(interface, iter);
++		interface_bss_added_without_keys(iter, interface);
+ 	} else if (g_strcmp0(key, "CurrentNetwork") == 0) {
+ 		interface_network_added(iter, interface);
+ 	} else if (g_strcmp0(key, "BSSs") == 0) {
+@@ -2431,6 +3001,9 @@ static void interface_property(const char *key, DBusMessageIter *iter,
+ 	} else if (g_strcmp0(key, "Networks") == 0) {
+ 		supplicant_dbus_array_foreach(iter, interface_network_added,
+ 								interface);
++	} else if (g_strcmp0(key, "SignalInfo") == 0) {
++		supplicant_dbus_property_foreach(iter, interface_signal_info,
++                                                               interface);
+ 	} else if (g_strcmp0(key, "DisconnectReason") == 0) {
+ 		int reason_code;
+ 		if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_INVALID) {
+@@ -2653,6 +3226,7 @@ static void signal_name_owner_changed(const char *path, DBusMessageIter *iter)
+ 		g_hash_table_remove_all(group_mapping);
+ 		g_hash_table_remove_all(config_file_table);
+ 		g_hash_table_remove_all(interface_table);
++		g_hash_table_remove_all(p2p_peer_table);
+ 		callback_system_killed();
+ 	}
+ 
+@@ -3071,6 +3645,12 @@ struct peer_property_data {
+ 	bool groups_changed;
+ 	bool services_changed;
+ };
++struct peer_device_data {
++	char *path;
++	char *identifier; /* Device address in string 112233445566 format */
++	unsigned char p2p_device_addr[6]; /* Device address in binary format */
++};
++
+ 
+ static void peer_groups_relation(DBusMessageIter *iter, void *user_data)
+ {
+@@ -3098,12 +3678,70 @@ static void peer_groups_relation(DBusMessageIter *iter, void *user_data)
+ 	}
+ }
+ 
++static void string_to_byte(const char *src, unsigned char *dest)
++{
++	int len = strlen(src);
++	int i=0;
++	unsigned char t = 0;
++
++	for(i=0; i<len; i++) {
++		if (src[i] >= '0' && src[i] <= '9')
++			t = src[i] - '0';
++		if (src[i] >= 'a' && src[i] <= 'f')
++			t = src[i] - 'a' + 10;
++		if (src[i] >= 'A' && src[i] <= 'F')
++			t = src[i] - 'A' + 10;
++
++		if(i%2 == 0)
++			dest[i/2] = (t << 4);
++		else
++			dest[i/2] |= t;
++	}
++}
++static gboolean p2p_network_fire_signals(GSupplicantPeer * peer)
++{
++	if (!peer)
++		return FALSE;
++
++	peer->found_pending_signal_timeout_ref = 0;
++
++	while (peer->pending_signals != NULL)
++	{
++		struct g_supplicant_p2p_peer_signal* signal = peer->pending_signals->data;
++
++		SUPPLICANT_DBG("Firing delayed signal for peer %s", peer->path);
++
++		signal->dispatch_function(peer->interface, peer, signal->callback_params);
++		signal->free_function(signal->callback_params);
++
++		peer->pending_signals = g_slist_remove(peer->pending_signals, signal);
++		g_free(signal);
++	}
++	return FALSE;
++}
++static void p2p_pending_invitation_fire_signals(GSupplicantPeer * peer)
++{
++	while (peer->pending_invitation_signals != NULL)
++	{
++		struct g_supplicant_p2p_peer_signal* signal = peer->pending_invitation_signals->data;
++
++		SUPPLICANT_DBG("Firing delayed signal for peer %s", peer->path);
++
++		signal->dispatch_function(peer->interface, peer, signal->callback_params);
++		signal->free_function(signal->callback_params);
++
++		peer->pending_invitation_signals = g_slist_remove(peer->pending_invitation_signals, signal);
++		g_free(signal);
++	}
++}
+ static void peer_property(const char *key, DBusMessageIter *iter,
+ 							void *user_data)
+ {
+ 	GSupplicantPeer *pending_peer;
+ 	struct peer_property_data *data = user_data;
+ 	GSupplicantPeer *peer = data->peer;
++	int dev_passwd_id = 0;
++	GSupplicantInterface *interface = peer->interface;
+ 
+ 	SUPPLICANT_DBG("key: %s", key);
+ 
+@@ -3111,18 +3749,40 @@ static void peer_property(const char *key, DBusMessageIter *iter,
+ 		return;
+ 
+ 	if (!key) {
++		if (g_hash_table_lookup(p2p_peer_table, peer->path) == NULL)
++			return;
++
+ 		if (peer->name) {
++			struct peer_device_data *p2p_data;
++
++			p2p_data = g_try_new0(struct peer_device_data, 1);
++			if (p2p_data == NULL) {
++				return;
++			}
++
++			if (p2p_data->path == NULL) {
++				char *id = strrchr(peer->path, '/') + 1;
++				p2p_data->identifier = g_strdup(id);
++				p2p_data->path = g_strdup(peer->path);
++				string_to_byte(p2p_data->identifier, p2p_data->p2p_device_addr);
++			}
++			p2p_network_list = g_slist_prepend(p2p_network_list, p2p_data);
++			g_hash_table_replace(interface->p2p_peer_path_to_network, peer->path, p2p_data);
++
+ 			create_peer_identifier(peer);
+ 			callback_peer_found(peer);
+ 			pending_peer = g_hash_table_lookup(
+ 					pending_peer_connection, peer->path);
+ 
+ 			if (pending_peer && pending_peer == peer) {
+-				callback_peer_request(peer);
++				callback_peer_request(peer, dev_passwd_id);
+ 				g_hash_table_remove(pending_peer_connection,
+ 						peer->path);
+ 			}
+ 
++			p2p_pending_invitation_fire_signals(peer);
++			peer->found_pending_signal_timeout_ref = g_timeout_add(500, p2p_network_fire_signals, peer);
++
+ 			dbus_free(data);
+ 		}
+ 
+@@ -3149,6 +3809,7 @@ static void peer_property(const char *key, DBusMessageIter *iter,
+ 		uint16_t wps_config;
+ 
+ 		dbus_message_iter_get_basic(iter, &wps_config);
++		peer->config_methods = wps_config;
+ 
+ 		if (wps_config & G_SUPPLICANT_WPS_CONFIG_PBC)
+ 			peer->wps_capabilities |= G_SUPPLICANT_WPS_PBC;
+@@ -3164,6 +3825,47 @@ static void peer_property(const char *key, DBusMessageIter *iter,
+ 			g_slist_free_full(data->old_groups, g_free);
+ 			data->groups_changed = true;
+ 		}
++
++	} else if (g_strcmp0(key, "p2ps_instance") == 0) {
++		DBusMessageIter array;
++		int len = 0;
++
++		if (peer->asp_services != NULL)
++		{
++			g_free(peer->asp_services);
++			peer->asp_services = NULL;
++			peer->asp_services_len = 0;
++		}
++
++		//get the array size
++		dbus_message_iter_recurse(iter, &array);
++		while (dbus_message_iter_get_arg_type(&array) != DBUS_TYPE_INVALID) {
++			len ++;
++			dbus_message_iter_next(&array);
++		}
++
++		if (len > 0)
++		{
++			int pos = 0;
++			peer->asp_services_len = len;
++			peer->asp_services = g_new0(GSupplicantP2PService, len);
++
++			dbus_message_iter_recurse(iter, &array);
++
++			while (dbus_message_iter_get_arg_type(&array) != DBUS_TYPE_INVALID) {
++				DBusMessageIter item;
++				const char* service_name = NULL;
++				dbus_message_iter_recurse(&array, &item);
++				dbus_message_iter_get_basic(&item, &(peer->asp_services[pos].advertisement_id));
++				dbus_message_iter_next(&item);
++				dbus_message_iter_get_basic(&item, &service_name);
++				(void)g_strlcpy(peer->asp_services[pos].service_name, service_name, 256);
++
++				pos ++;
++				dbus_message_iter_next(&array);
++			}
++		}
++
+ 	} else if (g_strcmp0(key, "IEs") == 0) {
+ 		DBusMessageIter array;
+ 		unsigned char *ie;
+@@ -3188,6 +3890,25 @@ static void peer_property(const char *key, DBusMessageIter *iter,
+ 		memcpy(peer->widi_ies, ie, ie_len);
+ 		peer->widi_ies_length = ie_len;
+ 		data->services_changed = true;
++	} else if (g_strcmp0(key, "level") == 0) {
++		dbus_int32_t level = 0;
++
++		dbus_message_iter_get_basic(iter, &level);
++		peer->level = level;
++	} else if (g_strcmp0(key, "PrimaryDeviceType") == 0) {
++		DBusMessageIter array;
++		unsigned char *device_type;
++		int type_len;
++
++		dbus_message_iter_recurse(iter, &array);
++		dbus_message_iter_get_fixed_array(&array, &device_type, &type_len);
++
++		if (type_len == 8) {
++			peer->pri_dev_type = g_malloc0(type_len*2+1);
++			__connman_util_byte_to_string(device_type, peer->pri_dev_type, type_len);
++		} else {
++			SUPPLICANT_DBG("strange device type\n");
++		}
+ 	}
+ }
+ 
+@@ -3197,6 +3918,7 @@ static void signal_peer_found(const char *path, DBusMessageIter *iter)
+ 	GSupplicantInterface *interface;
+ 	const char *obj_path = NULL;
+ 	GSupplicantPeer *peer;
++	int ret;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+@@ -3220,8 +3942,13 @@ static void signal_peer_found(const char *path, DBusMessageIter *iter)
+ 	peer->path = g_strdup(obj_path);
+ 	g_hash_table_insert(interface->peer_table, peer->path, peer);
+ 	g_hash_table_replace(peer_mapping, peer->path, interface);
++	g_hash_table_replace(p2p_peer_table, g_strdup(peer->path), peer);
+ 
+ 	property_data = dbus_malloc0(sizeof(struct peer_property_data));
++
++	if(!property_data)
++		return;
++
+ 	property_data->peer = peer;
+ 
+ 	dbus_message_iter_next(iter);
+@@ -3232,9 +3959,12 @@ static void signal_peer_found(const char *path, DBusMessageIter *iter)
+ 		return;
+ 	}
+ 
+-	supplicant_dbus_property_get_all(obj_path,
++	ret=supplicant_dbus_property_get_all(obj_path,
+ 					SUPPLICANT_INTERFACE ".Peer",
+ 					peer_property, property_data, NULL);
++
++	if(ret<0)
++		dbus_free(property_data);
+ }
+ 
+ static void signal_peer_lost(const char *path, DBusMessageIter *iter)
+@@ -3242,6 +3972,7 @@ static void signal_peer_lost(const char *path, DBusMessageIter *iter)
+ 	GSupplicantInterface *interface;
+ 	const char *obj_path = NULL;
+ 	GSupplicantPeer *peer;
++	struct peer_device_data *p2p_data;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+@@ -3257,6 +3988,21 @@ static void signal_peer_lost(const char *path, DBusMessageIter *iter)
+ 	if (!peer)
+ 		return;
+ 
++	if (interface->p2p_peer_path_to_network) {
++	p2p_data = g_hash_table_lookup(interface->p2p_peer_path_to_network, obj_path);
++		if (p2p_data == NULL) {
++			g_hash_table_remove(interface->peer_table, obj_path);
++			return;
++		}
++
++	g_hash_table_remove(interface->p2p_peer_path_to_network, obj_path);
++	p2p_network_list = g_slist_remove(p2p_network_list, p2p_data);
++
++	g_free(p2p_data->identifier);
++	g_free(p2p_data->path);
++	g_free(p2p_data);
++	}
++
+ 	g_hash_table_remove(interface->peer_table, obj_path);
+ }
+ 
+@@ -3279,12 +4025,14 @@ static void signal_peer_changed(const char *path, DBusMessageIter *iter)
+ 	}
+ 
+ 	property_data = dbus_malloc0(sizeof(struct peer_property_data));
++	if(!property_data)
++		return;
++
+ 	property_data->peer = peer;
+ 
+ 	supplicant_dbus_property_foreach(iter, peer_property, property_data);
+ 	if (property_data->services_changed)
+-		callback_peer_changed(peer,
+-					G_SUPPLICANT_PEER_SERVICES_CHANGED);
++		callback_peer_changed(peer, G_SUPPLICANT_PEER_SERVICES_CHANGED);
+ 
+ 	if (property_data->groups_changed)
+ 		callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_CHANGED);
+@@ -3295,18 +4043,45 @@ static void signal_peer_changed(const char *path, DBusMessageIter *iter)
+ 		peer->connection_requested = false;
+ }
+ 
++static void remove_colon(char *str)
++{
++	int len = strlen(str);
++	int i=0;
++	int j=0;
++
++	for(i=0; i<len; i++) {
++		if(str[i] == ':') {
++			for(j=i; j<len-1; j++) {
++				str[j] = str[j+1];
++			}
++			len--;
++			i--;
++		}
++	}
++	str[len] = '\0';
++}
++
+ struct group_sig_data {
+ 	const char *peer_obj_path;
+ 	unsigned char iface_address[ETH_ALEN];
++	char dev_addr_buf[13];
+ 	const char *interface_obj_path;
+ 	const char *group_obj_path;
+ 	int role;
++	bool persistent;
++	int status;
++	char *ip_addr;
++	char *ip_mask;
++	char *go_ip_addr;
++	int freq;
+ };
+ 
+ static void group_sig_property(const char *key, DBusMessageIter *iter,
+ 							void *user_data)
+ {
+ 	struct group_sig_data *data = user_data;
++	char *group_bssid_no_colon = NULL;
++	int addr_len;
+ 
+ 	if (!key)
+ 		return;
+@@ -3321,7 +4096,7 @@ static void group_sig_property(const char *key, DBusMessageIter *iter,
+ 
+ 		if (len == ETH_ALEN)
+ 			memcpy(data->iface_address, dev_addr, len);
+-	} else if (g_strcmp0(key, "role") == 0) {
++	} else if (g_strcmp0(key, "role") == 0 || g_strcmp0(key, "role_go") == 0) {
+ 		const char *str = NULL;
+ 
+ 		dbus_message_iter_get_basic(iter, &str);
+@@ -3335,7 +4110,49 @@ static void group_sig_property(const char *key, DBusMessageIter *iter,
+ 		dbus_message_iter_get_basic(iter, &data->interface_obj_path);
+ 	else if (g_strcmp0(key, "group_object") == 0)
+ 		dbus_message_iter_get_basic(iter, &data->group_obj_path);
+-
++	else if (g_strcmp0(key, "persistent") == 0)
++		dbus_message_iter_get_basic(iter, &data->persistent);
++	else if(g_str_equal(key, "go_dev_addr")) {
++			DBusMessageIter array;
++			dbus_message_iter_recurse(iter, &array);
++			dbus_message_iter_get_fixed_array(&array, &group_bssid_no_colon, &addr_len);
++
++			if (addr_len != 6) {
++				//Do not set the bbsid_no_colon unless we have the correct length
++				SUPPLICANT_DBG("group->bssid_no_colon: Error: array length expected to be 6, was %i", addr_len);
++			} else {
++				__connman_util_byte_to_string(group_bssid_no_colon, data->dev_addr_buf, addr_len);
++			}
++	} else if (g_strcmp0(key, "status") == 0)
++		dbus_message_iter_get_basic(iter, &data->status);
++	else if(g_str_equal(key, "IpAddr")) {
++			DBusMessageIter array;
++			char *ip_addr;
++			dbus_message_iter_recurse(iter, &array);
++			dbus_message_iter_get_fixed_array(&array, &ip_addr, &addr_len);
++
++			data->ip_addr = __connman_util_ipaddr_binary_to_string(ip_addr);
++			SUPPLICANT_DBG("ip_addr : %s\n", data->ip_addr);
++	} else if(g_str_equal(key, "IpAddrMask")) {
++			DBusMessageIter array;
++			char *ip_mask;
++			dbus_message_iter_recurse(iter, &array);
++			dbus_message_iter_get_fixed_array(&array, &ip_mask, &addr_len);
++
++			data->ip_mask = __connman_util_ipaddr_binary_to_string(ip_mask);
++			SUPPLICANT_DBG("ip_mask : %s\n", data->ip_mask);
++	} else if(g_str_equal(key, "IpAddrGo")) {
++			DBusMessageIter array;
++			char *go_ip_addr;
++			dbus_message_iter_recurse(iter, &array);
++			dbus_message_iter_get_fixed_array(&array, &go_ip_addr, &addr_len);
++
++			data->go_ip_addr = __connman_util_ipaddr_binary_to_string(go_ip_addr);
++			SUPPLICANT_DBG("go_ip_addr : %s\n", data->go_ip_addr);
++	} else if(g_str_equal(key, "freq")) {
++			dbus_message_iter_get_basic(iter, &data->freq);
++			SUPPLICANT_DBG("freq : %d\n", data->freq);
++	}
+ }
+ 
+ static void signal_group_success(const char *path, DBusMessageIter *iter)
+@@ -3382,16 +4199,137 @@ static void signal_group_failure(const char *path, DBusMessageIter *iter)
+ 	if (!peer)
+ 		return;
+ 
++	peer->status = data.status;
++
+ 	callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_FAILED);
+ 	peer->connection_requested = false;
+ }
+ 
++static void p2p_group_property(const char *key, DBusMessageIter *iter,
++												void *user_data)
++{
++	GSupplicantGroup *group = user_data;
++
++	SUPPLICANT_DBG("key %s", key);
++
++	if (!key) {
++		callback_p2p_group_started(group);
++		return;
++	}
++
++	if (!iter)
++		return;
++
++	if (g_strcmp0(key, "SSID") == 0) {
++		DBusMessageIter array;
++		char *ssid;
++		int ssid_len;
++
++		dbus_message_iter_recurse(iter, &array);
++		dbus_message_iter_get_fixed_array(&array, &ssid, &ssid_len);
++
++		if (ssid_len > 0 && ssid_len < 33) {
++			group->ssid = g_strndup(ssid, ssid_len);
++		}
++	} else if (g_strcmp0(key, "Passphrase") == 0) {
++		char *passphrase;
++
++		dbus_message_iter_get_basic(iter, &passphrase);
++		group->passphrase = g_strdup(passphrase);
++	} else if (g_strcmp0(key, "Frequency") == 0) {
++		dbus_uint16_t frequency = 0;
++
++		dbus_message_iter_get_basic(iter, &frequency);
++		group->frequency = frequency;
++	}
++}
++
++static void p2p_group_ssid_property(const char *key, DBusMessageIter *iter,
++										void *user_data)
++{
++	GSupplicantGroup *group = user_data;
++	char *ssid;
++	int len = 0;
++	DBusMessageIter iter_array;
++	GSupplicantPeer *peer = NULL;
++
++	if(iter == NULL)
++		return;
++
++	dbus_message_iter_recurse(iter, &iter_array);
++
++	dbus_message_iter_get_fixed_array(&iter_array, &ssid, &len);
++
++	if(len >= MAX_P2P_SSID_LEN)
++		len = MAX_P2P_SSID_LEN - 1;
++
++	group->ssid = g_strndup(ssid, len);
++	callback_p2p_group_started(group);
++}
++
++static void p2p_group_psk_property(const char *key, DBusMessageIter *iter,
++										void *user_data)
++{
++	GSupplicantGroup *group = user_data;
++	int len = 0;
++	unsigned char *psk;
++	char psk_s[65];
++	DBusMessageIter iter_array;
++
++	if(iter == NULL)
++		return;
++
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_ARRAY)
++	{
++		SUPPLICANT_DBG("not array %d\n", dbus_message_iter_get_arg_type(iter));
++		return;
++	}
++
++	dbus_message_iter_recurse(iter, &iter_array);
++
++	dbus_message_iter_get_fixed_array(&iter_array, &psk, &len);
++	__connman_util_byte_to_string(psk, psk_s, len);
++	group->psk = g_strdup(psk_s);
++	SUPPLICANT_DBG("psk : %s\n", group->psk);
++}
++
++static void p2p_group_passphrase_property(const char *key, DBusMessageIter *iter,
++												void *user_data)
++{
++	GSupplicantGroup *group = user_data;
++	char *passphrase;
++
++	if(iter == NULL)
++		return;
++
++	dbus_message_iter_get_basic(iter, &passphrase);
++	group->passphrase = g_strdup(passphrase);
++
++	SUPPLICANT_DBG("passphrase : %s\n", group->passphrase);
++
++}
++
++static void interface_p2p_group_started(GSupplicantGroup *group) {
++
++	if (!group->path)
++		return;
++
++	supplicant_dbus_property_get(group->path, SUPPLICANT_INTERFACE ".Group",
++							"PSK", p2p_group_psk_property, group, NULL);
++
++	supplicant_dbus_property_get(group->path, SUPPLICANT_INTERFACE ".Group",
++							"Passphrase", p2p_group_passphrase_property, group, NULL);
++
++	supplicant_dbus_property_get(group->path, SUPPLICANT_INTERFACE ".Group",
++							"SSID", p2p_group_ssid_property, group, NULL);
++}
++
+ static void signal_group_started(const char *path, DBusMessageIter *iter)
+ {
+ 	GSupplicantInterface *interface, *g_interface;
+-	struct group_sig_data data = {};
++	struct group_sig_data data = {0,};
+ 	GSupplicantGroup *group;
+-	GSupplicantPeer *peer;
++	GSupplicantPeer *peer = NULL;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+@@ -3403,11 +4341,13 @@ static void signal_group_started(const char *path, DBusMessageIter *iter)
+ 	if (!data.interface_obj_path || !data.group_obj_path)
+ 		return;
+ 
+-	peer = g_hash_table_lookup(interface->peer_table,
+-						interface->pending_peer_path);
+-	interface->pending_peer_path = NULL;
+-	if (!peer)
+-		return;
++	if (interface->pending_peer_path) {
++		peer = g_hash_table_lookup(interface->peer_table,
++							interface->pending_peer_path);
++		interface->pending_peer_path = NULL;
++		if (!peer)
++			return;
++	}
+ 
+ 	g_interface = g_hash_table_lookup(interface_table,
+ 						data.interface_obj_path);
+@@ -3427,12 +4367,26 @@ static void signal_group_started(const char *path, DBusMessageIter *iter)
+ 	group->orig_interface = interface;
+ 	group->path = g_strdup(data.group_obj_path);
+ 	group->role = data.role;
++	group->persistent = data.persistent;
++	group->bssid_no_colon = g_strdup(data.dev_addr_buf);
++	group->ip_addr = g_strdup(data.ip_addr);
++	group->ip_mask= g_strdup(data.ip_mask);
++	group->go_ip_addr = g_strdup(data.go_ip_addr);
++	group->frequency = data.freq;
+ 
+ 	g_hash_table_insert(interface->group_table, group->path, group);
+ 	g_hash_table_replace(group_mapping, group->path, group);
+ 
+-	peer->current_group_iface = g_interface;
+-	callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_STARTED);
++	if (!peer) {
++		peer = g_supplicant_interface_peer_lookup(group->orig_interface, group->bssid_no_colon);
++	}
++
++	if (peer) {
++		peer->current_group_iface = g_interface;
++		callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_STARTED);
++	}
++
++	interface_p2p_group_started(group);
+ }
+ 
+ static void remove_peer_group_interface(GHashTable *group_table,
+@@ -3460,6 +4414,40 @@ static void remove_peer_group_interface(GHashTable *group_table,
+ 	}
+ }
+ 
++static void remove_peer_peertable(GSupplicantInterface *interface)
++{
++	GHashTableIter iter;
++	gpointer value, key;
++
++	g_hash_table_iter_init(&iter, interface->peer_table);
++
++	while (g_hash_table_iter_next(&iter, &key, &value)) {
++		GSupplicantPeer *peer = value;
++		char *peer_path = key;
++		struct peer_device_data *p2p_data = NULL;
++
++		if (g_hash_table_lookup(p2p_peer_table, peer_path))
++		{
++			if (interface->p2p_peer_path_to_network) {
++				p2p_data = g_hash_table_lookup(interface->p2p_peer_path_to_network, peer_path);
++				if (p2p_data == NULL) {
++					g_hash_table_iter_remove(&iter);
++					continue;
++				}
++
++				g_hash_table_remove(interface->p2p_peer_path_to_network, peer_path);
++				p2p_network_list = g_slist_remove(p2p_network_list, p2p_data);
++
++				g_free(p2p_data->identifier);
++				g_free(p2p_data->path);
++				g_free(p2p_data);
++			}
++
++			g_hash_table_iter_remove(&iter);
++		}
++	}
++}
++
+ static void signal_group_finished(const char *path, DBusMessageIter *iter)
+ {
+ 	GSupplicantInterface *interface;
+@@ -3480,6 +4468,9 @@ static void signal_group_finished(const char *path, DBusMessageIter *iter)
+ 	g_hash_table_remove(group_mapping, data.group_obj_path);
+ 
+ 	g_hash_table_remove(interface->group_table, data.group_obj_path);
++
++	callback_p2p_group_finished(interface);
++	remove_peer_peertable(interface);
+ }
+ 
+ static void signal_group_request(const char *path, DBusMessageIter *iter)
+@@ -3487,6 +4478,7 @@ static void signal_group_request(const char *path, DBusMessageIter *iter)
+ 	GSupplicantInterface *interface;
+ 	GSupplicantPeer *peer;
+ 	const char *obj_path;
++	dbus_uint16_t dev_passwd_id = 0;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+@@ -3502,2002 +4494,4814 @@ static void signal_group_request(const char *path, DBusMessageIter *iter)
+ 	if (!peer)
+ 		return;
+ 
++	dbus_message_iter_next(iter);
++
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_UINT16) {
++		SUPPLICANT_DBG("not uint 16\n");
++		return;
++	}
++
++	dbus_message_iter_get_basic(iter, &dev_passwd_id);
++
+ 	/*
+ 	 * Peer has been previously found and property set,
+ 	 * otherwise, defer connection to when peer property
+ 	 * is set.
+ 	 */
+ 	if (peer->identifier)
+-		callback_peer_request(peer);
++		callback_peer_request(peer, dev_passwd_id);
+ 	else
+ 		g_hash_table_replace(pending_peer_connection, peer->path, peer);
+ }
+ 
+-static void signal_group_peer_joined(const char *path, DBusMessageIter *iter)
++static void callback_p2p_invitation_result(GSupplicantInterface *interface, int status)
+ {
+-	const char *peer_path = NULL;
+-	GSupplicantInterface *interface;
+-	GSupplicantGroup *group;
+-	GSupplicantPeer *peer;
++	if (!callbacks_pointer)
++		return;
+ 
+-	SUPPLICANT_DBG("");
++	if (!callbacks_pointer->p2p_invitation_result)
++		return;
+ 
+-	group = g_hash_table_lookup(group_mapping, path);
+-	if (!group)
++	callbacks_pointer->p2p_invitation_result(interface, status);
++}
++static void interface_p2p_invitation_result(DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantInterface *interface = user_data;
++	DBusMessageIter dict, entry, value;
++	char *key;
++	int status = 0;
++
++	SUPPLICANT_DBG("interface_p2p_invitation_result");
++
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_ARRAY) {
++		SUPPLICANT_DBG("not array\n");
+ 		return;
++	}
+ 
+-	dbus_message_iter_get_basic(iter, &peer_path);
+-	if (!peer_path)
++	dbus_message_iter_recurse(iter, &dict);
++	if(dbus_message_iter_get_arg_type(&dict) != DBUS_TYPE_DICT_ENTRY) {
++		SUPPLICANT_DBG("not dict\n");
+ 		return;
++	}
+ 
+-	interface = g_hash_table_lookup(peer_mapping, peer_path);
+-	if (!interface)
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
+ 		return;
++	}
+ 
+-	peer = g_hash_table_lookup(interface->peer_table, peer_path);
+-	if (!peer)
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "status")) {
++		SUPPLICANT_DBG("not status\n");
++		return;
++	}
++
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
+ 		return;
++	}
+ 
+-	group->members = g_slist_prepend(group->members, g_strdup(peer_path));
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_get_basic(&value, &status);
++	SUPPLICANT_DBG("status : %d\n", status);
+ 
+-	callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_JOINED);
++	callback_p2p_invitation_result(interface, status);
+ }
+-
+-static void signal_group_peer_disconnected(const char *path, DBusMessageIter *iter)
++static void signal_invitation_result(const char *path, DBusMessageIter *iter)
+ {
+-	const char *peer_path = NULL;
+ 	GSupplicantInterface *interface;
+-	GSupplicantGroup *group;
+-	GSupplicantPeer *peer;
+-	GSList *elem;
+ 
+-	SUPPLICANT_DBG("");
++	SUPPLICANT_DBG("signal invitation result");
+ 
+-	group = g_hash_table_lookup(group_mapping, path);
+-	if (!group)
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
+ 		return;
+ 
+-	dbus_message_iter_get_basic(iter, &peer_path);
+-	if (!peer_path)
++	interface_p2p_invitation_result(iter, interface);
++}
++static void callback_p2p_invitation_received(GSupplicantInterface *interface, GSupplicantPeer *peer, const char *go_dev_addr, bool persistent)
++{
++	if (!callbacks_pointer)
+ 		return;
+ 
+-	for (elem = group->members; elem; elem = elem->next) {
+-		if (!g_strcmp0(elem->data, peer_path))
+-			break;
+-	}
+-
+-	if (!elem)
++	if (!callbacks_pointer->p2p_invitation_received)
+ 		return;
+ 
+-	g_free(elem->data);
+-	group->members = g_slist_delete_link(group->members, elem);
+-
+-	interface = g_hash_table_lookup(peer_mapping, peer_path);
+-	if (!interface)
++	callbacks_pointer->p2p_invitation_received(interface, peer, go_dev_addr, persistent);
++}
++static void callback_p2p_pending_invitation_received(GSupplicantInterface *interface, GSupplicantPeer *peer, void * data)
++{
++	if (!callbacks_pointer)
+ 		return;
+ 
+-	peer = g_hash_table_lookup(interface->peer_table, peer_path);
+-	if (!peer)
++	if (!callbacks_pointer->p2p_invitation_received)
+ 		return;
+ 
+-	callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_DISCONNECTED);
+-	peer->connection_requested = false;
++	struct g_supplicant_p2p_inv_recv_info *inv_recv = data;
++	callbacks_pointer->p2p_invitation_received(interface, peer, inv_recv->p2p_go_dev_addr, inv_recv->persistent);
+ }
+ 
+-static struct {
+-	const char *interface;
+-	const char *member;
+-	void (*function) (const char *path, DBusMessageIter *iter);
+-} signal_map[] = {
+-	{ DBUS_INTERFACE_DBUS,  "NameOwnerChanged",  signal_name_owner_changed },
++static gboolean add_pending_invitation_for_peer(gpointer argv)
++{
++	struct g_supplicant_p2p_inv_recv_info *inv_recv = argv;
++	GSupplicantInterface *interface = inv_recv->interface;
+ 
+-	{ SUPPLICANT_INTERFACE, "PropertiesChanged", signal_properties_changed },
+-	{ SUPPLICANT_INTERFACE, "InterfaceAdded",    signal_interface_added    },
+-	{ SUPPLICANT_INTERFACE, "InterfaceCreated",  signal_interface_added    },
+-	{ SUPPLICANT_INTERFACE, "InterfaceRemoved",  signal_interface_removed  },
++	GSupplicantPeer *peer = g_supplicant_interface_peer_lookup(interface, inv_recv->src_addr);
+ 
+-	{ SUPPLICANT_INTERFACE ".Interface", "PropertiesChanged", signal_interface_changed },
+-	{ SUPPLICANT_INTERFACE ".Interface", "ScanDone",          signal_scan_done         },
+-	{ SUPPLICANT_INTERFACE ".Interface", "BSSAdded",          signal_bss_added         },
+-	{ SUPPLICANT_INTERFACE ".Interface", "BSSRemoved",        signal_bss_removed       },
+-	{ SUPPLICANT_INTERFACE ".Interface", "NetworkAdded",      signal_network_added     },
+-	{ SUPPLICANT_INTERFACE ".Interface", "NetworkRemoved",    signal_network_removed   },
+-	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_sta_authorized    },
+-	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_sta_deauthorized  },
++	if (!peer && inv_recv->get_invitation_timer_count < 10) {
++			inv_recv_ref = g_timeout_add(100, add_pending_invitation_for_peer, inv_recv);
++			inv_recv->get_invitation_timer_count++;
++			return FALSE;
++	}
++	else if (peer)//Send the signal later
++	{
++		if (peer->path) {
++			SUPPLICANT_DBG("Added signal to list print path %s" , peer->path);
++			struct peer_device_data *p2p_data = g_hash_table_lookup(interface->p2p_peer_path_to_network, peer->path);
++
++			if (!p2p_data && inv_recv->get_invitation_timer_count < 10) {
++				inv_recv_ref = g_timeout_add(100, add_pending_invitation_for_peer, inv_recv);
++				inv_recv->get_invitation_timer_count++;
++				return FALSE;
++			}
+ 
+-	{ SUPPLICANT_INTERFACE ".BSS", "PropertiesChanged", signal_bss_changed   },
++			if (p2p_data && p2p_data->path && (strcmp(peer->path, p2p_data->path) == 0)) {
++				SUPPLICANT_DBG("Added signal to list print p2p_data->path  %s" , p2p_data->path);
++				callback_p2p_invitation_received(interface, peer, inv_recv->p2p_go_dev_addr, inv_recv->persistent);
++				goto done;
++			}
++		}
+ 
+-	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Credentials", signal_wps_credentials },
+-	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Event",       signal_wps_event       },
++		struct g_supplicant_p2p_peer_signal* signal = g_try_new0(struct g_supplicant_p2p_peer_signal, 1);
++		if(signal == NULL)
++		{
++			goto done;
++		}
+ 
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "DeviceFound", signal_peer_found },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "DeviceLost",  signal_peer_lost  },
++		signal->callback_params = (void *)inv_recv;
++		signal->free_function = g_free;
++		signal->dispatch_function = callback_p2p_pending_invitation_received;
++		peer->pending_invitation_signals = g_slist_append(peer->pending_invitation_signals, signal);
+ 
+-	{ SUPPLICANT_INTERFACE ".Peer", "PropertiesChanged", signal_peer_changed },
++		SUPPLICANT_DBG("Added signal to list");
++		return FALSE;
++	}
+ 
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationSuccess", signal_group_success },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationFailure", signal_group_failure },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GroupStarted", signal_group_started },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GroupFinished", signal_group_finished },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationRequest", signal_group_request },
++done:
++	g_free(inv_recv);
++	inv_recv_ref = -1;
++	return FALSE;
++}
++static void interface_p2p_invitation_received(DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantInterface *interface = user_data;
++	DBusMessageIter dict, entry, value, array;
++	char *key;
++	int status;
++	int addr_len = 6;
++	unsigned char *bssid, *go_dev_addr, *src_addr;
++	char go_dev_addr_str[13], src_addr_str[13];
++	char *p_go_dev_addr, *p_src_addr;
+ 
+-	{ SUPPLICANT_INTERFACE ".Group", "PeerJoined", signal_group_peer_joined },
+-	{ SUPPLICANT_INTERFACE ".Group", "PeerDisconnected", signal_group_peer_disconnected },
++	SUPPLICANT_DBG("interface_p2p_invitation_received");
+ 
+-	{ }
+-};
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_ARRAY) {
++		SUPPLICANT_DBG("not array\n");
++		return;
++	}
+ 
+-static DBusHandlerResult g_supplicant_filter(DBusConnection *conn,
+-					DBusMessage *message, void *data)
+-{
+-	DBusMessageIter iter;
+-	const char *path;
+-	int i;
++	dbus_message_iter_recurse(iter, &dict);
++	if(dbus_message_iter_get_arg_type(&dict) != DBUS_TYPE_DICT_ENTRY) {
++		SUPPLICANT_DBG("not dict\n");
++		return;
++	}
+ 
+-	path = dbus_message_get_path(message);
+-	if (!path)
+-		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
++	}
+ 
+-	if (!dbus_message_iter_init(message, &iter))
+-		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "status")) {
++		SUPPLICANT_DBG("not status\n");
++		return;
++	}
+ 
+-	for (i = 0; signal_map[i].interface; i++) {
+-		if (!dbus_message_has_interface(message, signal_map[i].interface))
+-			continue;
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
++		return;
++	}
+ 
+-		if (!dbus_message_has_member(message, signal_map[i].member))
+-			continue;
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_get_basic(&value, &status);
++	SUPPLICANT_DBG("status : %d\n", status);
++/*
++	if (status == 0) //Persistent group reinvoke case
++		g_supplicant_interface_p2p_listen(interface, 0, 0);
++	else
++*/
++	if (status != 0 && status != 1)
++		return;
+ 
+-		signal_map[i].function(path, &iter);
+-		break;
++	dbus_message_iter_next(&dict);
++
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
+ 	}
+ 
+-	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+-}
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "sa")) {
++		SUPPLICANT_DBG("not sa\n");
++		return;
++	}
+ 
+-void g_supplicant_interface_cancel(GSupplicantInterface *interface)
+-{
+-	SUPPLICANT_DBG("Cancelling any pending DBus calls");
+-	supplicant_dbus_method_call_cancel_all(interface);
+-	supplicant_dbus_property_call_cancel_all(interface);
+-}
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
++		return;
++	}
+ 
+-struct supplicant_regdom {
+-	GSupplicantCountryCallback callback;
+-	const char *alpha2;
+-	const void *user_data;
+-};
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_recurse(&value, &array);
+ 
+-static void country_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
+-{
+-	struct supplicant_regdom *regdom = user_data;
+-	int result = 0;
++	dbus_message_iter_get_fixed_array(&array, &src_addr, &addr_len);
+ 
+-	SUPPLICANT_DBG("Country setting result");
++	dbus_message_iter_next(&dict);
+ 
+-	if (!user_data)
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
+ 		return;
++	}
+ 
+-	if (error) {
+-		SUPPLICANT_DBG("Country setting failure %s", error);
+-		result = -EINVAL;
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++
++	if(!g_str_equal(key, "go_dev_addr")) {
++		SUPPLICANT_DBG("not go_dev_addr\n");
++		return;
+ 	}
+ 
+-	if (regdom->callback)
+-		regdom->callback(result, regdom->alpha2,
+-					(void *) regdom->user_data);
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
++		return;
++	}
+ 
+-	g_free(regdom);
+-}
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_recurse(&value, &array);
+ 
+-static void country_params(DBusMessageIter *iter, void *user_data)
+-{
+-	struct supplicant_regdom *regdom = user_data;
++	dbus_message_iter_get_fixed_array(&array, &go_dev_addr, &addr_len);
+ 
+-	dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING,
+-							&regdom->alpha2);
+-}
++	dbus_message_iter_next(&dict);
+ 
+-int g_supplicant_set_country(const char *alpha2,
+-				GSupplicantCountryCallback callback,
+-					const void *user_data)
+-{
+-	struct supplicant_regdom *regdom;
+-	int ret;
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
++	}
+ 
+-	SUPPLICANT_DBG("Country setting %s", alpha2);
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "bssid")) {
++		if(status == 0)
++			goto go_next; //BSSID is not exist at persistent go case
++		SUPPLICANT_DBG("not bssid\n");
++		return;
++	}
+ 
+-	if (!system_available)
+-		return -EFAULT;
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
++		return;
++	}
+ 
+-	regdom = dbus_malloc0(sizeof(*regdom));
+-	if (!regdom)
+-		return -ENOMEM;
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_recurse(&value, &array);
+ 
+-	regdom->callback = callback;
+-	regdom->alpha2 = alpha2;
+-	regdom->user_data = user_data;
++	dbus_message_iter_get_fixed_array(&array, &bssid, &addr_len);
+ 
+-	ret =  supplicant_dbus_property_set(SUPPLICANT_PATH, SUPPLICANT_INTERFACE,
+-					"Country", DBUS_TYPE_STRING_AS_STRING,
+-					country_params, country_result,
+-					regdom, NULL);
+-	if (ret < 0) {
+-		dbus_free(regdom);
+-		SUPPLICANT_DBG("Unable to set Country configuration");
+-	}
+-	return ret;
+-}
++go_next:
+ 
+-int g_supplicant_interface_set_country(GSupplicantInterface *interface,
+-					GSupplicantCountryCallback callback,
+-							const char *alpha2,
+-							void *user_data)
+-{
+-	struct supplicant_regdom *regdom;
+-	int ret;
++	__connman_util_byte_to_string(go_dev_addr, go_dev_addr_str, 6);
++	p_go_dev_addr = g_strdup(go_dev_addr_str);
+ 
+-	regdom = dbus_malloc0(sizeof(*regdom));
+-	if (!regdom)
+-		return -ENOMEM;
++	__connman_util_byte_to_string(src_addr, src_addr_str, 6);
++	p_src_addr = g_strdup(src_addr_str);
+ 
+-	regdom->callback = callback;
+-	regdom->alpha2 = alpha2;
+-	regdom->user_data = user_data;
++	if (inv_recv_ref != -1) {
++		g_free(p_src_addr);
++		g_free(p_go_dev_addr);
++		return;
++	}
+ 
+-	ret =  supplicant_dbus_property_set(interface->path,
+-				SUPPLICANT_INTERFACE ".Interface",
+-				"Country", DBUS_TYPE_STRING_AS_STRING,
+-				country_params, country_result,
+-					regdom, NULL);
+-	if (ret < 0) {
+-		dbus_free(regdom);
+-		SUPPLICANT_DBG("Unable to set Country configuration");
++	struct g_supplicant_p2p_inv_recv_info *inv_recv = g_try_new0(struct g_supplicant_p2p_inv_recv_info, 1);
++	if (!inv_recv) {
++		g_free(p_src_addr);
++		g_free(p_go_dev_addr);
++		return;
+ 	}
+ 
+-	return ret;
+-}
++	inv_recv->interface = interface;
++	inv_recv->p2p_go_dev_addr = p_go_dev_addr;
++	inv_recv->src_addr = p_src_addr;
++	inv_recv->persistent = !status;
+ 
+-bool g_supplicant_interface_has_p2p(GSupplicantInterface *interface)
+-{
+-	if (!interface)
+-		return false;
++	inv_recv_ref = g_timeout_add(100, add_pending_invitation_for_peer, inv_recv);
+ 
+-	return interface->p2p_support;
++	return;
++}
++static void empty_free_function(void* ptr)
++{
++	// Does nothing
+ }
++static void fire_p2p_signal_when_network_present(GSupplicantInterface *interface,
++                                                 const char* path,
++                                                 g_supplicant_p2p_network_signal_func signal_func,
++                                                 g_supplicant_p2p_network_signal_free_func free_func,
++                                                 void* signal_params)
++{
++	struct peer_device_data *p2p_data;
+ 
+-struct supplicant_p2p_dev_config {
+-	char *device_name;
+-	char *dev_type;
+-};
+ 
+-static void p2p_device_config_result(const char *error,
+-					DBusMessageIter *iter, void *user_data)
+-{
+-	struct supplicant_p2p_dev_config *config = user_data;
++	p2p_data = g_hash_table_lookup(interface->p2p_peer_path_to_network, path);
+ 
+-	if (error)
+-		SUPPLICANT_DBG("Unable to set P2P Device configuration: %s",
+-									error);
++	if (free_func == NULL)
++	{
++		free_func = empty_free_function;
++	}
+ 
+-	g_free(config->device_name);
+-	g_free(config->dev_type);
+-	dbus_free(config);
+-}
++	if(p2p_data != NULL)
++	{
++		//Send signal right away
++		GSupplicantPeer *peer;
++		peer = g_hash_table_lookup(interface->peer_table, p2p_data->path);
+ 
+-static int dev_type_str2bin(const char *type, unsigned char dev_type[8])
+-{
+-	int length, pos, end;
+-	char b[3] = {};
+-	char *e = NULL;
++		signal_func(interface, peer, signal_params);
++		free_func(signal_params);
++	}
++	else //Send the signal later
++	{
++		GSupplicantPeer *peer;
++		SUPPLICANT_DBG("network not present, delaying signal dispatch");
+ 
+-	end = strlen(type);
+-	for (length = pos = 0; type[pos] != '\0' && length < 8; length++) {
+-		if (pos+2 > end)
+-			return 0;
++		peer = g_hash_table_lookup(interface->peer_table, path);
+ 
+-		b[0] = type[pos];
+-		b[1] = type[pos+1];
++		if (peer == NULL)
++		{
++			free_func(signal_params);
++			SUPPLICANT_DBG("failed - no peer for path %s", path);
++			return;
++		}
+ 
+-		dev_type[length] = strtol(b, &e, 16);
+-		if (e && *e != '\0')
+-			return 0;
++		struct g_supplicant_p2p_peer_signal* signal = g_try_new0(struct g_supplicant_p2p_peer_signal, 1);
++		if(signal == NULL)
++		{
++			free_func(signal_params);
++			return;
++		}
+ 
+-		pos += 2;
+-	}
++		signal->callback_params = signal_params;
++		signal->free_function = free_func;
++		signal->dispatch_function = signal_func;
++		peer->pending_signals = g_slist_append(peer->pending_signals, signal);
+ 
+-	return 8;
+-}
++		SUPPLICANT_DBG("Added signal to list");
+ 
+-static void p2p_device_config_params(DBusMessageIter *iter, void *user_data)
++	}
++}
++static void interface_p2p_prov_disc_request_or_response(DBusMessageIter *iter,
++					void *user_data, bool is_request, char *wps_method)
+ {
+-	struct supplicant_p2p_dev_config *config = user_data;
+-	DBusMessageIter dict;
++	GSupplicantInterface *interface = user_data;
++	char *path, *pin = NULL;
+ 
+-	supplicant_dbus_dict_open(iter, &dict);
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_OBJECT_PATH) {
++		SUPPLICANT_DBG("not object path\n");
++		return;
++	}
+ 
+-	supplicant_dbus_dict_append_basic(&dict, "DeviceName",
+-				DBUS_TYPE_STRING, &config->device_name);
++	dbus_message_iter_get_basic(iter, &path);
+ 
+-	if (config->dev_type) {
+-		unsigned char dev_type[8] = {}, *type;
+-		int len;
++	if (g_str_equal(wps_method, "disp_pin")) {
++		dbus_message_iter_next(iter);
+ 
+-		len = dev_type_str2bin(config->dev_type, dev_type);
+-		if (len) {
+-			type = dev_type;
+-			supplicant_dbus_dict_append_fixed_array(&dict,
+-					"PrimaryDeviceType",
+-					DBUS_TYPE_BYTE, &type, len);
++		if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_STRING) {
++			SUPPLICANT_DBG("not string\n");
++			return;
++		}
++
++		dbus_message_iter_get_basic(iter, &pin);
++
++		if (!pin || strlen(pin) != WPAS_P2P_WPS_PIN_LENGTH) {
++			SUPPLICANT_DBG("strange\n");
++			return;
+ 		}
+ 	}
+ 
+-	supplicant_dbus_dict_close(iter, &dict);
+-}
++	g_supplicant_p2p_prov_dics_signal_func callback_method = NULL;
+ 
+-int g_supplicant_interface_set_p2p_device_config(GSupplicantInterface *interface,
+-					const char *device_name,
+-					const char *primary_dev_type)
++	if (is_request) {
++		if (g_str_equal(wps_method, "pbc"))
++			callback_method = callback_p2p_prov_disc_requested_pbc;
++		else if (g_str_equal(wps_method, "enter_pin"))
++			callback_method = callback_p2p_prov_disc_requested_enter_pin;
++		else if (g_str_equal(wps_method, "disp_pin"))
++			callback_method = callback_p2p_prov_disc_requested_display_pin;
++	}
++	else {
++		if (g_str_equal(wps_method, "enter_pin"))
++			callback_method = callback_p2p_prov_disc_response_enter_pin;
++		else if (g_str_equal(wps_method, "disp_pin"))
++			callback_method = callback_p2p_prov_disc_response_display_pin;
++	}
++
++	if (callback_method)
++	{
++		pin = g_strdup(pin);
++		fire_p2p_signal_when_network_present(interface,
++		                                     path,
++		                                     callback_method,
++		                                     g_free,
++		                                     (void *)pin);
++	}
++}
++static void interface_p2p_prov_disc_fail(DBusMessageIter *iter, void *user_data)
+ {
+-	struct supplicant_p2p_dev_config *config;
+-	int ret;
++	GSupplicantInterface *interface = user_data;
++	GSupplicantPeer *peer;
++	const char *path;
++	int status;
+ 
+-	SUPPLICANT_DBG("P2P Device settings %s/%s",
+-					device_name, primary_dev_type);
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_OBJECT_PATH) {
++		SUPPLICANT_DBG("not object path\n");
++		return;
++	}
+ 
+-	config = dbus_malloc0(sizeof(*config));
+-	if (!config)
+-		return -ENOMEM;
++	dbus_message_iter_get_basic(iter, &path);
+ 
+-	config->device_name = g_strdup(device_name);
+-	config->dev_type = g_strdup(primary_dev_type);
++	dbus_message_iter_next(iter);
+ 
+-	ret = supplicant_dbus_property_set(interface->path,
+-				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
+-				"P2PDeviceConfig",
+-				DBUS_TYPE_ARRAY_AS_STRING
+-				DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+-				DBUS_TYPE_STRING_AS_STRING
+-				DBUS_TYPE_VARIANT_AS_STRING
+-				DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
+-				p2p_device_config_params,
+-				p2p_device_config_result, config, NULL);
+-	if (ret < 0) {
+-		g_free(config->device_name);
+-		g_free(config->dev_type);
+-		dbus_free(config);
+-		SUPPLICANT_DBG("Unable to set P2P Device configuration");
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_INT32) {
++		SUPPLICANT_DBG("not int32\n");
++		return;
+ 	}
+ 
+-	return ret;
+-}
++	dbus_message_iter_get_basic(iter, &status);
+ 
+-static gboolean peer_lookup_by_identifier(gpointer key, gpointer value,
+-							gpointer user_data)
+-{
+-	const GSupplicantPeer *peer = value;
+-	const char *identifier = user_data;
++	peer = g_hash_table_lookup(interface->peer_table, path);
+ 
+-	if (!g_strcmp0(identifier, peer->identifier))
+-		return TRUE;
++	if (!peer)
++		return;
+ 
+-	return FALSE;
++	callback_p2p_prov_disc_fail(interface, peer, status);
+ }
+-
+-GSupplicantPeer *g_supplicant_interface_peer_lookup(GSupplicantInterface *interface,
+-							const char *identifier)
++static void signal_prov_disc_fail(const char *path, DBusMessageIter *iter)
+ {
+-	GSupplicantPeer *peer;
++	GSupplicantInterface *interface;
+ 
+-	peer = g_hash_table_find(interface->peer_table,
+-					peer_lookup_by_identifier,
+-					(void *) identifier);
+-	return peer;
+-}
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
+ 
+-static void interface_create_data_free(struct interface_create_data *data)
+-{
+-	g_free(data->ifname);
+-	g_free(data->driver);
+-	g_free(data->bridge);
+-	dbus_free(data);
++	interface_p2p_prov_disc_fail(iter, interface);
+ }
+-
+-static bool interface_exists(GSupplicantInterface *interface,
+-				const char *path)
++static void p2p_persistent_group_property_by_added(const char *key, DBusMessageIter *iter, void *user_data)
+ {
+-	GSupplicantInterface *tmp;
++	GSupplicantP2PPersistentGroup *persistent_group = user_data;
+ 
+-	tmp = g_hash_table_lookup(interface_table, path);
+-	if (tmp && tmp == interface)
+-		return true;
++	if(persistent_group == NULL){
++		return;
++	}
+ 
+-	return false;
+-}
++	if (key == NULL) {
++		callback_p2p_persistent_group_added(persistent_group->interface, persistent_group);
++		return;
++	}
+ 
+-static void interface_create_property(const char *key, DBusMessageIter *iter,
+-							void *user_data)
++	if(g_strcmp0(key, "bssid") == 0) {
++		char *bssid;
++		dbus_message_iter_get_basic(iter, &bssid);
++		persistent_group->bssid = g_strdup(bssid);
++		remove_colon(bssid);
++		persistent_group->bssid_no_colon = g_strdup(bssid);
++		SUPPLICANT_DBG("bssid : %s\n", persistent_group->bssid);
++	} else if(g_strcmp0(key, "binary-ssid") == 0) {
++		/*
++		 * In persistent case, when p2p-SSID is in Korean,
++		 * connman cannot save the persistent information in connman config file.
++		 * It changes string to byte array in Korean SSID which is encoded EUC-KR.
++		 */
++		const char *ssid;
++		int len = 0;
++		DBusMessageIter iter_array;
++		dbus_message_iter_recurse(iter, &iter_array);
++
++		dbus_message_iter_get_fixed_array(&iter_array, &ssid, &len);
++
++		if(len >= MAX_P2P_SSID_LEN)
++			len = MAX_P2P_SSID_LEN - 1;
++
++		persistent_group->ssid = g_strndup(ssid, len);
++		SUPPLICANT_DBG("ssid : %s\n", persistent_group->ssid);
++	} else if(g_strcmp0(key, "psk") == 0) {
++		const char *psk;
++		dbus_message_iter_get_basic(iter, &psk);
++		persistent_group->psk = g_strdup(psk);
++		SUPPLICANT_DBG("psk : %s\n", persistent_group->psk);
++	}
++}
++static void interface_persistent_group_added(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_create_data *data = user_data;
+-	GSupplicantInterface *interface = data->interface;
++	GSupplicantInterface *interface = user_data;
++	char *pg_path;
++	int ret;
++	GSupplicantP2PPersistentGroup *persistent_group;
+ 
+-	if (!key) {
+-		if (data->callback) {
+-			data->callback(0, data->interface, data->user_data);
+-			callback_p2p_support(interface);
+-		}
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_OBJECT_PATH) {
++		SUPPLICANT_DBG("not object path\n");
++		return;
++	}
+ 
+-		interface_create_data_free(data);
++	dbus_message_iter_get_basic(iter, &pg_path);
++
++	/* signal data parsed if needed */
++
++	persistent_group = g_try_new0(GSupplicantP2PPersistentGroup, 1);
++	if (persistent_group == NULL){
++		return;
+ 	}
+ 
+-	interface_property(key, iter, interface);
++	persistent_group->interface = interface;
++	persistent_group->path = g_strdup(pg_path);
++
++	ret=supplicant_dbus_property_get_all(persistent_group->path,
++					SUPPLICANT_INTERFACE ".PersistentGroup",
++					p2p_persistent_group_property_by_added, persistent_group, NULL);
++	if(ret<0) {
++		g_free(persistent_group);
++	}
+ }
++static void signal_persistent_group_added(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
+ 
+-static void interface_create_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++	SUPPLICANT_DBG("signal persistent group added");
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
++
++	interface_persistent_group_added(iter, interface);
++}
++static void interface_persistent_group_removed(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_create_data *data = user_data;
+-	const char *path = NULL;
+-	int err;
++	GSupplicantInterface *interface = user_data;
++	char *pg_path;
+ 
+-	SUPPLICANT_DBG("");
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_OBJECT_PATH) {
++		SUPPLICANT_DBG("not object path\n");
++		return;
++	}
+ 
+-	if (error) {
+-		g_warning("error %s", error);
+-		err = -EIO;
+-		goto done;
++	dbus_message_iter_get_basic(iter, &pg_path);
++
++	callback_p2p_persistent_group_removed(interface, pg_path);
++}
++static void signal_persistent_group_removed(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	SUPPLICANT_DBG("signal persistent group removed");
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
++
++	interface_persistent_group_removed(iter, interface);
++}
++static void interface_p2p_sd_response(DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantInterface *interface = user_data;
++	DBusMessageIter dict, entry, value, array;
++	char *key;
++	char *peer_path;
++	dbus_uint16_t indicator;
++	int tlv_len = 0;
++	unsigned char *tlv;
++
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_ARRAY) {
++		SUPPLICANT_DBG("not array\n");
++		return;
+ 	}
+ 
+-	dbus_message_iter_get_basic(iter, &path);
+-	if (!path) {
+-		err = -EINVAL;
+-		goto done;
++	dbus_message_iter_recurse(iter, &dict);
++	if(dbus_message_iter_get_arg_type(&dict) != DBUS_TYPE_DICT_ENTRY) {
++		SUPPLICANT_DBG("not dict\n");
++		return;
+ 	}
+ 
+-	if (!system_available) {
+-		err = -EFAULT;
+-		goto done;
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
+ 	}
+ 
+-	data->interface = g_hash_table_lookup(interface_table, path);
+-	if (!data->interface) {
+-		data->interface = interface_alloc(path);
+-		if (!data->interface) {
+-			err = -ENOMEM;
+-			goto done;
+-		}
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "peer_object")) {
++		SUPPLICANT_DBG("not peer_object\n");
++		return;
+ 	}
+ 
+-	err = supplicant_dbus_property_get_all(path,
+-					SUPPLICANT_INTERFACE ".Interface",
+-					interface_create_property, data,
+-					NULL);
+-	if (err == 0)
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
+ 		return;
++	}
+ 
+-done:
+-	if (data->callback)
+-		data->callback(err, NULL, data->user_data);
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_get_basic(&value, &peer_path);
++	SUPPLICANT_DBG("peer_path : %s\n", peer_path);
+ 
+-	interface_create_data_free(data);
+-}
++	dbus_message_iter_next(&dict);
+ 
+-static void interface_create_params(DBusMessageIter *iter, void *user_data)
+-{
+-	struct interface_create_data *data = user_data;
+-	DBusMessageIter dict;
+-	char *config_file = NULL;
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
++	}
+ 
+-	SUPPLICANT_DBG("");
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "update_indicator")) {
++		SUPPLICANT_DBG("not update_indicator\n");
++		return;
++	}
+ 
+-	supplicant_dbus_dict_open(iter, &dict);
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
++		return;
++	}
+ 
+-	supplicant_dbus_dict_append_basic(&dict, "Ifname",
+-					DBUS_TYPE_STRING, &data->ifname);
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_get_basic(&value, &indicator);
++	SUPPLICANT_DBG("indicator : %d\n", indicator);
+ 
+-	if (data->driver)
+-		supplicant_dbus_dict_append_basic(&dict, "Driver",
+-					DBUS_TYPE_STRING, &data->driver);
++	dbus_message_iter_next(&dict);
+ 
+-	if (data->bridge)
+-		supplicant_dbus_dict_append_basic(&dict, "BridgeIfname",
+-					DBUS_TYPE_STRING, &data->bridge);
++	dbus_message_iter_recurse(&dict, &entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
++	}
+ 
+-	config_file = g_hash_table_lookup(config_file_table, data->ifname);
+-	if (config_file) {
+-		SUPPLICANT_DBG("[%s] ConfigFile %s", data->ifname, config_file);
++	dbus_message_iter_get_basic(&entry, &key);
++	SUPPLICANT_DBG("key : %s\n", key);
++	if(!g_str_equal(key, "tlvs")) {
++		SUPPLICANT_DBG("not tlvs\n");
++		return;
++	}
+ 
+-		supplicant_dbus_dict_append_basic(&dict, "ConfigFile",
+-					DBUS_TYPE_STRING, &config_file);
++	dbus_message_iter_next(&entry);
++	if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_VARIANT) {
++		SUPPLICANT_DBG("not variant\n");
++		return;
+ 	}
+ 
+-	supplicant_dbus_dict_close(iter, &dict);
+-}
++	dbus_message_iter_recurse(&entry, &value);
++	dbus_message_iter_recurse(&value, &array);
+ 
+-static void interface_get_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++	dbus_message_iter_get_fixed_array(&array, &tlv, &tlv_len);
++
++	GSupplicantPeer *peer;
++	peer = g_hash_table_lookup(interface->peer_table, peer_path);
++	if (!peer)
++	   return;
++
++	callback_p2p_sd_response(interface, peer, indicator, tlv, tlv_len);
++}
++static void signal_sd_response(const char *path, DBusMessageIter *iter)
+ {
+-	struct interface_create_data *data = user_data;
+ 	GSupplicantInterface *interface;
+-	const char *path = NULL;
+-	int err;
+ 
+-	SUPPLICANT_DBG("");
++	SUPPLICANT_DBG("signal service discovery response");
+ 
+-	if (error) {
+-		SUPPLICANT_DBG("Interface not created yet");
+-		goto create;
+-	}
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
+ 
+-	dbus_message_iter_get_basic(iter, &path);
+-	if (!path) {
+-		err = -EINVAL;
+-		goto done;
+-	}
++	interface_p2p_sd_response(iter, interface);
++}
++static void callback_p2p_sd_asp_response(GSupplicantInterface *interface, GSupplicantPeer *peer,
++										 unsigned char transaction_id,
++										 unsigned int advertisement_id,
++										 unsigned char service_status,
++										 dbus_uint16_t config_method,
++										 const char* service_name,
++										 const char* service_info)
++{
++	if (callbacks_pointer == NULL)
++		return;
+ 
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (!interface) {
+-		err = -ENOENT;
+-		goto done;
+-	}
++	if (callbacks_pointer->p2p_sd_asp_response == NULL)
++		return;
+ 
+-	if (data->callback) {
+-		data->callback(0, interface, data->user_data);
+-		callback_p2p_support(interface);
++	callbacks_pointer->p2p_sd_asp_response(interface, peer,
++									   transaction_id,
++									   advertisement_id,
++									   service_status,
++									   config_method,
++									   service_name,
++									   service_info);
++}
++static void interface_p2p_sd_asp_response(DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantInterface *interface = user_data;
++	const char *peer_path;
++	unsigned char transaction_id;
++	unsigned int advertisement_id;
++	unsigned char service_status;
++	dbus_uint16_t config_method;
++	const char* service_name = NULL;
++	const char* service_info = NULL;
++
++	if (!dbus_message_get_args_from_array_of_sv(iter,
++												DBUS_TYPE_OBJECT_PATH, "peer_object", &peer_path, true,
++												DBUS_TYPE_BYTE, "service_transaction_id", &transaction_id, true,
++												DBUS_TYPE_UINT32, "adv_id", &advertisement_id, true,
++												DBUS_TYPE_BYTE, "service_status", &service_status, true,
++												DBUS_TYPE_UINT16, "config_method", &config_method, true,
++												DBUS_TYPE_STRING, "service_name", &service_name, true,
++												DBUS_TYPE_STRING, "service_info", &service_info, false,
++												DBUS_TYPE_INVALID)) {
++		SUPPLICANT_DBG("could not parse DBUS message\n");
++		return;
+ 	}
+ 
+-	interface_create_data_free(data);
+ 
+-	return;
++	GSupplicantPeer *peer;
++	peer = g_hash_table_lookup(interface->peer_table, peer_path);
++	if (!peer)
++	   return;
+ 
+-create:
+-	if (!system_available) {
+-		err = -EFAULT;
+-		goto done;
+-	}
++	callback_p2p_sd_asp_response(interface, peer,
++								 transaction_id,
++								 advertisement_id,
++								 service_status,
++								 config_method,
++								 service_name,
++								 service_info);
++}
+ 
+-	SUPPLICANT_DBG("Creating interface");
++static void signal_sd_asp_response(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
+ 
+-	err = supplicant_dbus_method_call(SUPPLICANT_PATH,
+-						SUPPLICANT_INTERFACE,
+-						"CreateInterface",
+-						interface_create_params,
+-						interface_create_result, data,
+-						NULL);
+-	if (err == 0)
+-		return;
++	SUPPLICANT_DBG("signal service discovery ASP response");
+ 
+-done:
+-	if (data->callback)
+-		data->callback(err, NULL, data->user_data);
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
+ 
+-	interface_create_data_free(data);
++	interface_p2p_sd_asp_response(iter, interface);
+ }
+-
+-static void interface_get_params(DBusMessageIter *iter, void *user_data)
++static void interface_p2ps_prov_done(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_create_data *data = user_data;
++	GSupplicantInterface *interface = user_data;
++	const char *path;
++	GSupplicantP2PSProvisionSignalParams* params;
++	const char* service_mac = "";
++	const char* session_mac = "";
++	const char* group_mac = "";
++
++	params = g_try_new0(GSupplicantP2PSProvisionSignalParams, 1);
++	if(params == NULL)
++		return;
++
++	if (!dbus_message_get_args_from_array_of_sv(iter,
++												DBUS_TYPE_OBJECT_PATH, "peer_object", &path, true,
++												DBUS_TYPE_UINT32, "adv_id", &params->advertisement_id, true,
++												DBUS_TYPE_STRING, "adv_mac", &service_mac, true,
++												DBUS_TYPE_UINT32, "session_id", &params->session_id, true,
++												DBUS_TYPE_STRING, "session_mac", &session_mac, true,
++												DBUS_TYPE_UINT32, "status", &params->status, true,
++												DBUS_TYPE_UINT32, "connection_capability", &params->connection_capability, true,
++												DBUS_TYPE_UINT32, "passwd_id", &params->password_id, true,
++												DBUS_TYPE_UINT32, "persist", &params->persist, false,
++												DBUS_TYPE_STRING, "group_mac", &group_mac, false,
++												//DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, "feature_capability", &feature_capability_array, &feature_capability_len,
++												DBUS_TYPE_INVALID)) {
++		SUPPLICANT_DBG("could not parse DBUS message\n");
++		g_free(params);
++		return;
++	}
+ 
+-	SUPPLICANT_DBG("");
++	(void)g_strlcpy(params->session_mac, session_mac, 18);
++	(void)g_strlcpy(params->service_mac, service_mac, 18);
++	(void)g_strlcpy(params->group_mac, group_mac, 18);
+ 
+-	dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, &data->ifname);
+-}
++	GSupplicantPeer *peer;
++	peer = g_hash_table_lookup(interface->peer_table, path);
++	if (!peer) {
++	   g_free(params);
++	   return;
++	}
+ 
+-int g_supplicant_interface_create(const char *ifname, const char *driver,
+-					const char *bridge,
+-					GSupplicantInterfaceCallback callback,
+-							void *user_data)
++	fire_p2p_signal_when_network_present(interface,
++	                                     path,
++	                                     (g_supplicant_p2p_network_signal_func)callback_p2ps_prov_done,
++	                                     g_free,
++	                                     params);
++	//callback_p2ps_prov_done(interface, peer, params);
++}
++static void interface_p2ps_prov_start(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_create_data *data;
+-	int ret;
+-
+-	SUPPLICANT_DBG("ifname %s", ifname);
++	GSupplicantInterface *interface = user_data;
++	const char *path;
++	GSupplicantP2PSProvisionSignalParams* params;
++	const char* service_mac = "";
++	const char* session_mac = "";
++	const char* session_info = "";
+ 
+-	if (!ifname)
+-		return -EINVAL;
++	params = g_try_new0(GSupplicantP2PSProvisionSignalParams, 1);
++	if(params == NULL)
++		return;
+ 
+-	if (!system_available)
+-		return -EFAULT;
++	SUPPLICANT_DBG("");
+ 
+-	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
+-		return -ENOMEM;
++	if (!dbus_message_get_args_from_array_of_sv(iter,
++												DBUS_TYPE_OBJECT_PATH, "peer_object", &path, true,
++												DBUS_TYPE_UINT32, "adv_id", &params->advertisement_id, true,
++												DBUS_TYPE_STRING, "adv_mac", &service_mac, true,
++												DBUS_TYPE_UINT32, "session_id", &params->session_id, true,
++												DBUS_TYPE_STRING, "session_mac", &session_mac, true,
++												DBUS_TYPE_UINT32, "connection_capability", &params->connection_capability, true,
++												DBUS_TYPE_UINT32, "passwd_id", &params->password_id, false,
++												DBUS_TYPE_STRING, "session_info", &session_info, false,
++												//TODO: get feature_cap
++												//DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, "feature_capability", &feature_capability_array, &feature_capability_len,
++												DBUS_TYPE_INVALID)) {
++		SUPPLICANT_DBG("could not parse DBUS message\n");
++		g_free(params);
++		return;
++	}
+ 
+-	data->ifname = g_strdup(ifname);
+-	data->driver = g_strdup(driver);
+-	data->bridge = g_strdup(bridge);
+-	data->callback = callback;
+-	data->user_data = user_data;
++	(void)g_strlcpy(params->session_mac, session_mac, 18);
++	(void)g_strlcpy(params->service_mac, service_mac, 18);
++	(void)g_strlcpy(params->session_info, session_info, 150);
+ 
+-	ret = supplicant_dbus_method_call(SUPPLICANT_PATH,
+-						SUPPLICANT_INTERFACE,
+-						"GetInterface",
+-						interface_get_params,
+-						interface_get_result, data,
+-						NULL);
+-	if (ret < 0)
+-		interface_create_data_free(data);
++	SUPPLICANT_DBG("");
++	GSupplicantPeer *peer;
++	peer = g_hash_table_lookup(interface->peer_table, path);
++	if (!peer) {
++	   g_free(params);
++	   return;
++	}
+ 
+-	return ret;
++	fire_p2p_signal_when_network_present(interface,
++	                                     path,
++	                                     (g_supplicant_p2p_network_signal_func)callback_p2ps_prov_start,
++	                                     g_free,
++	                                     params);
+ }
+-
+-static void interface_remove_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++static void signal_p2ps_prov_start(const char *path, DBusMessageIter *iter)
+ {
+-	struct interface_data *data = user_data;
+-	int err;
+-
+-	if (error) {
+-		err = -EIO;
+-		SUPPLICANT_DBG("error: %s", error);
+-		goto done;
+-	}
++	GSupplicantInterface *interface;
++	SUPPLICANT_DBG("");
+ 
+-	if (!system_available) {
+-		err = -EFAULT;
+-		goto done;
+-	}
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
+ 
+-	/*
+-	 * The gsupplicant interface is already freed by the InterfaceRemoved
+-	 * signal callback. Simply invoke the interface_data callback.
+-	 */
+-	err = 0;
++	interface_p2ps_prov_start(iter, interface);
++}
+ 
+-done:
+-	g_free(data->path);
++static void signal_p2ps_prov_done(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
+ 
+-	if (data->callback)
+-		data->callback(err, NULL, data->user_data);
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
+ 
+-	dbus_free(data);
++	interface_p2ps_prov_done(iter, interface);
+ }
++static void extract_peer_with_ip(const char *path, DBusMessageIter *iter, connman_bool_t joined, bool is_ip_present);
+ 
+-
+-static void interface_remove_params(DBusMessageIter *iter, void *user_data)
++static void signal_group_peer_joined(const char *path, DBusMessageIter *iter)
+ {
+-	struct interface_data *data = user_data;
+-
+-	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
+-							&data->interface->path);
++	const char *peer_path = NULL;
++	extract_peer_with_ip(path, iter, TRUE, false);
+ }
++static gboolean peer_joined_with_ip(gpointer data)
++{
++	GSupplicantPeer *peer = data;
+ 
++	callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_JOINED);
+ 
+-int g_supplicant_interface_remove(GSupplicantInterface *interface,
+-			GSupplicantInterfaceCallback callback,
+-							void *user_data)
++	return FALSE;
++}
++static bool find_p2p_network(GSupplicantRequestedPeer *requested_peer)
+ {
+-	struct interface_data *data;
+-	int ret;
++	GSList *item;
++	struct peer_device_data *p2p_network=NULL;
++	unsigned char p2p_dev_addr_byte[6] = {0,};
++	int i;
++	bool same = false;
+ 
+-	if (!interface)
+-		return -EINVAL;
++	if (requested_peer == NULL)
++		return false;
+ 
+-	if (!system_available)
+-		return -EFAULT;
++	string_to_byte(requested_peer->requested_p2p_dev_addr, p2p_dev_addr_byte);
+ 
+-	g_supplicant_interface_cancel(interface);
++	item = p2p_network_list;
+ 
+-	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
+-		return -ENOMEM;
++	while(item) {
++		p2p_network = item->data;
++		same = true;
++		for(i = 0; i < 6; i++) {
++			if(p2p_network->p2p_device_addr[i] != p2p_dev_addr_byte[i]) {
++				same = false;
++				break;
++			}
++		}
+ 
+-	data->interface = interface;
+-	data->path = g_strdup(interface->path);
+-	data->callback = callback;
+-	data->user_data = user_data;
++		if(same)
++			break;
+ 
+-	ret = supplicant_dbus_method_call(SUPPLICANT_PATH,
+-						SUPPLICANT_INTERFACE,
+-						"RemoveInterface",
+-						interface_remove_params,
+-						interface_remove_result, data,
+-						NULL);
+-	if (ret < 0) {
+-		g_free(data->path);
+-		dbus_free(data);
++		item = g_slist_next(item);
++		p2p_network = NULL;
+ 	}
+-	return ret;
+-}
+ 
+-static void interface_scan_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++	requested_peer->found_p2p_network = p2p_network;
++
++	return same;
++}
++static gboolean requested_peer_joined_with_ip(gpointer data)
+ {
+-	struct interface_scan_data *data = user_data;
+-	int err = 0;
++	GSupplicantRequestedPeer *requested_peer = data;
+ 
+-	if (error) {
+-		SUPPLICANT_DBG("error %s", error);
+-		err = -EIO;
+-	}
++	GSupplicantGroup *group;
++	GSupplicantInterface *interface;
++	GSupplicantPeer *peer;
++	struct peer_device_data *p2p_network=NULL;
+ 
+-	/* A non ready interface cannot send/receive anything */
+-	if (interface_exists(data->interface, data->path)) {
+-		if (!data->interface->ready)
+-			err = -ENOLINK;
+-	}
++	if (requested_peer == NULL)
++			return FALSE;
+ 
+-	g_free(data->path);
++	group = g_hash_table_lookup(group_mapping, requested_peer->requested_path);
++	if (!group)
++		goto error;
+ 
+-	if (err != 0) {
+-		if (data->callback)
+-			data->callback(err, data->interface, data->user_data);
+-	} else {
+-		data->interface->scan_callback = data->callback;
+-		data->interface->scan_data = data->user_data;
++	if (requested_peer->found_p2p_network == NULL){
++		if(!find_p2p_network(requested_peer))
++			goto error;
+ 	}
+ 
+-	if (data->scan_params)
+-		g_supplicant_free_scan_params(data->scan_params);
++	p2p_network = requested_peer->found_p2p_network;
+ 
+-	dbus_free(data);
+-}
++	interface = g_hash_table_lookup(peer_mapping, p2p_network->path);
++	if (!interface)
++		goto error;
+ 
+-static void add_scan_frequency(DBusMessageIter *iter, unsigned int freq)
+-{
+-	DBusMessageIter data;
+-	unsigned int width = 0; /* Not used by wpa_supplicant atm */
++	peer = g_hash_table_lookup(interface->peer_table, p2p_network->path);
++	if (!peer) {
++		g_hash_table_remove(peer_mapping, requested_peer->requested_path);
++		goto error;
++	}
+ 
+-	dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &data);
++	peer->current_group_iface = group->interface;
++	if (requested_peer->requested_is_ip_present) {
++		peer->ip_addr = g_strdup(requested_peer->requested_ip_addr);
++	}
++	group->members = g_slist_prepend(group->members, g_strdup(p2p_network->path));
+ 
+-	dbus_message_iter_append_basic(&data, DBUS_TYPE_UINT32, &freq);
+-	dbus_message_iter_append_basic(&data, DBUS_TYPE_UINT32, &width);
+-
+-	dbus_message_iter_close_container(iter, &data);
+-}
++	g_timeout_add(300, peer_joined_with_ip, peer);
+ 
+-static void add_scan_frequencies(DBusMessageIter *iter,
+-						void *user_data)
+-{
+-	GSupplicantScanParams *scan_data = user_data;
+-	unsigned int freq;
+-	int i;
++error:
++	g_free(requested_peer->requested_p2p_dev_addr);
++	g_free(requested_peer->requested_path);
++	g_free(requested_peer->requested_ip_addr);
++	requested_peer->found_p2p_network = NULL;
+ 
+-	for (i = 0; i < scan_data->num_freqs; i++) {
+-		freq = scan_data->freqs[i];
+-		if (!freq)
+-			break;
++	g_free(requested_peer);
++	requested_peer = NULL;
+ 
+-		add_scan_frequency(iter, freq);
+-	}
++	return FALSE;
+ }
+-
+-static void append_ssid(DBusMessageIter *iter,
+-			const void *ssid, unsigned int len)
++GSupplicantGroup *g_supplicant_get_group(const char *path)
+ {
+-	DBusMessageIter array;
++	GSupplicantGroup *group;
+ 
+-	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
+-	DBUS_TYPE_BYTE_AS_STRING, &array);
++	if (!path)
++		return NULL;
+ 
+-	dbus_message_iter_append_fixed_array(&array, DBUS_TYPE_BYTE,
+-								&ssid, len);
+-	dbus_message_iter_close_container(iter, &array);
+-}
++	group = g_hash_table_lookup(group_mapping, path);
++	if (!group)
++		return NULL;
+ 
+-static void append_ssids(DBusMessageIter *iter, void *user_data)
++	return group;
++}
++static void extract_peer_with_ip(const char *path, DBusMessageIter *iter, connman_bool_t joined, bool is_ip_present)
+ {
+-	GSupplicantScanParams *scan_data = user_data;
+-	GSList *list;
++	GSupplicantGroup *group;
++	GSupplicantPeer *peer;
++	GSupplicantRequestedPeer *requested_peer;
++	const char *peer_path;
++	const char *ip_addr;
++	char *intf_addr, *pintf_addr;
++	char *p2p_dev_addr = NULL;
++	char *dev_addr = NULL;
++	unsigned char intf_addr_byte[6];
+ 
+-	for (list = scan_data->ssids; list; list = list->next) {
+-		struct scan_ssid *scan_ssid = list->data;
++	group = g_hash_table_lookup(group_mapping, path);
++	if (!group)
++		return;
+ 
+-		append_ssid(iter, scan_ssid->ssid, scan_ssid->ssid_len);
++	dbus_message_iter_get_basic(iter, &peer_path);
++	if (!peer_path)
++		return;
++
++	if (is_ip_present) {
++		dbus_message_iter_next(iter);
++		if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_STRING) {
++			SUPPLICANT_DBG("not string\n");
++			return;
++		}
++		dbus_message_iter_get_basic(iter, &ip_addr);
+ 	}
+-}
+ 
+-static void supplicant_add_scan_frequency(DBusMessageIter *dict,
+-		supplicant_dbus_array_function function,
+-					void *user_data)
+-{
+-	GSupplicantScanParams *scan_params = user_data;
+-	DBusMessageIter entry, value, array;
+-	const char *key = "Channels";
++	dbus_message_iter_next(iter);
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
++	}
+ 
+-	if (scan_params->freqs && scan_params->freqs[0] != 0) {
+-		dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY,
+-						NULL, &entry);
++	dbus_message_iter_get_basic(iter, &p2p_dev_addr);
++	if (!p2p_dev_addr)
++		return;
+ 
+-		dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
++	requested_peer = g_try_new0(GSupplicantRequestedPeer, 1);
++	if (requested_peer == NULL)
++		return;
+ 
+-		dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT,
+-					DBUS_TYPE_ARRAY_AS_STRING
+-					DBUS_STRUCT_BEGIN_CHAR_AS_STRING
+-					DBUS_TYPE_UINT32_AS_STRING
+-					DBUS_TYPE_UINT32_AS_STRING
+-					DBUS_STRUCT_END_CHAR_AS_STRING,
+-					&value);
++	if (is_ip_present)
++		requested_peer->requested_ip_addr = g_strdup(ip_addr);
+ 
+-		dbus_message_iter_open_container(&value, DBUS_TYPE_ARRAY,
+-					DBUS_STRUCT_BEGIN_CHAR_AS_STRING
+-					DBUS_TYPE_UINT32_AS_STRING
+-					DBUS_TYPE_UINT32_AS_STRING
+-					DBUS_STRUCT_END_CHAR_AS_STRING,
+-					&array);
++	requested_peer->requested_path = g_strdup(path);
++	requested_peer->requested_p2p_dev_addr = g_strdup(p2p_dev_addr);
++	requested_peer->requested_is_ip_present = is_ip_present;
+ 
+-		if (function)
+-			function(&array, user_data);
++	intf_addr = strrchr(peer_path, '/') + 1;
+ 
+-		dbus_message_iter_close_container(&value, &array);
+-		dbus_message_iter_close_container(&entry, &value);
+-		dbus_message_iter_close_container(dict, &entry);
+-	}
+-}
++	if(joined == TRUE) {
++		pintf_addr = g_strdup(intf_addr);
++		g_hash_table_replace(intf_addr_mapping, g_strdup(peer_path), pintf_addr);
++	} else {
++		pintf_addr = g_hash_table_lookup(intf_addr_mapping, peer_path);
+ 
+-static void interface_scan_params(DBusMessageIter *iter, void *user_data)
+-{
+-	DBusMessageIter dict;
+-	const char *type = "passive";
+-	struct interface_scan_data *data = user_data;
++		if(pintf_addr == NULL)
++			goto error;
++	}
+ 
+-	supplicant_dbus_dict_open(iter, &dict);
++	dev_addr = g_hash_table_lookup(dev_addr_mapping, pintf_addr);
++	if(!dev_addr) {
++		g_hash_table_replace(dev_addr_mapping, g_strdup(pintf_addr), g_strdup(p2p_dev_addr));
++	}
+ 
+-	if (data && data->scan_params) {
+-		type = "active";
++	if (find_p2p_network(requested_peer))
++		(void)requested_peer_joined_with_ip(requested_peer);
++	else
++		g_timeout_add(200, requested_peer_joined_with_ip, requested_peer);
+ 
+-		supplicant_dbus_dict_append_basic(&dict, "Type",
+-					DBUS_TYPE_STRING, &type);
++	return;
+ 
++error:
++	g_free(requested_peer->requested_path);
++	g_free(requested_peer->requested_p2p_dev_addr);
++	g_free(requested_peer->requested_ip_addr);
++	requested_peer->found_p2p_network = NULL;
+ 
+-		if (data->scan_params->ssids) {
+-			supplicant_dbus_dict_append_array(&dict, "SSIDs",
+-							DBUS_TYPE_STRING,
+-							append_ssids,
+-							data->scan_params);
+-		}
+-		supplicant_add_scan_frequency(&dict, add_scan_frequencies,
+-						data->scan_params);
+-	} else
+-		supplicant_dbus_dict_append_basic(&dict, "Type",
+-					DBUS_TYPE_STRING, &type);
++	g_free(requested_peer);
++	requested_peer = NULL;
++}
++static void signal_peer_joined_with_ip(const char *path, DBusMessageIter *iter)
++{
++	SUPPLICANT_DBG("signal peer joined with ip");
+ 
+-	supplicant_dbus_dict_close(iter, &dict);
++	extract_peer_with_ip(path, iter, TRUE, true);
+ }
+ 
+-static int interface_ready_to_scan(GSupplicantInterface *interface)
++GSupplicantP2PNetwork* g_supplicant_find_network_from_intf_address(const char* pintf_addr, const char* p2p_dev_addr)
+ {
+-	if (!interface)
+-		return -EINVAL;
++	struct peer_device_data *p2p_network = NULL;
++	unsigned char intf_addr_byte[6];
++	unsigned char p2p_dev_addr_byte[6] = {0};
++	GSList *item;
++	int i;
++	bool same;
+ 
+-	if (!system_available)
+-		return -EFAULT;
++	string_to_byte(pintf_addr, intf_addr_byte);
++	string_to_byte(p2p_dev_addr, p2p_dev_addr_byte);
+ 
+-	if (interface->scanning)
+-		return -EALREADY;
++	item = p2p_network_list;
+ 
+-	switch (interface->state) {
+-	case G_SUPPLICANT_STATE_AUTHENTICATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATED:
+-	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
+-		return -EBUSY;
+-	case G_SUPPLICANT_STATE_UNKNOWN:
+-	case G_SUPPLICANT_STATE_DISABLED:
+-	case G_SUPPLICANT_STATE_DISCONNECTED:
+-	case G_SUPPLICANT_STATE_INACTIVE:
+-	case G_SUPPLICANT_STATE_SCANNING:
+-	case G_SUPPLICANT_STATE_COMPLETED:
+-		break;
++	while(item) {
++		p2p_network = item->data;
++		same = true;
++
++		for(i = 0; i < 6; i++) {
++			if(p2p_network->p2p_device_addr[i] != p2p_dev_addr_byte[i]) {
++				same = false;
++				break;
++			}
++		}
++		if(same)
++			break;
++
++		item = g_slist_next(item);
++		p2p_network = NULL;
+ 	}
+ 
+-	return 0;
++	return p2p_network;
+ }
+ 
+-int g_supplicant_interface_scan(GSupplicantInterface *interface,
+-				GSupplicantScanParams *scan_data,
+-				GSupplicantInterfaceCallback callback,
+-							void *user_data)
++/* @pintf_addr: interface mac address in the form of 0012233445a */
++const char * g_supplicant_peer_identifier_from_intf_address(const char* pintf_addr)
+ {
+-	struct interface_scan_data *data;
+-	int ret;
++	struct peer_device_data *p2p_network = NULL;
++	unsigned char intf_addr_byte[6];
++	unsigned char p2p_dev_addr_byte[6] = {0};
++	GSList *item;
++	int i;
++	bool same;
++	GSupplicantPeer *peer = NULL;
++	GSupplicantInterface *interface;
++	char *p2p_dev_addr = NULL;
+ 
+-	ret = interface_ready_to_scan(interface);
+-	if (ret)
+-		return ret;
++	p2p_dev_addr = g_hash_table_lookup(dev_addr_mapping, pintf_addr);
++	if(!p2p_dev_addr)
++		return peer;
+ 
+-	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
+-		return -ENOMEM;
++	string_to_byte(p2p_dev_addr, p2p_dev_addr_byte);
++	string_to_byte(pintf_addr, intf_addr_byte);
+ 
+-	data->interface = interface;
+-	data->path = g_strdup(interface->path);
+-	data->callback = callback;
+-	data->user_data = user_data;
+-	data->scan_params = scan_data;
++	item = p2p_network_list;
+ 
+-        interface->scan_callback = callback;
+-        interface->scan_data = user_data;
++	while(item) {
++		p2p_network = item->data;
++		same = true;
+ 
+-	ret = supplicant_dbus_method_call(interface->path,
+-			SUPPLICANT_INTERFACE ".Interface", "Scan",
+-			interface_scan_params, interface_scan_result, data,
+-			interface);
++		for(i = 0; i < 6; i++) {
++			if(p2p_network->p2p_device_addr[i] != p2p_dev_addr_byte[i]) {
++				same = false;
++				break;
++			}
++		}
+ 
+-	if (ret < 0) {
+-		g_free(data->path);
+-		dbus_free(data);
+-	}
++		if(same)
++			break;
+ 
+-	return ret;
+-}
++		item = g_slist_next(item);
++		p2p_network = NULL;
++	}
+ 
+-static int parse_supplicant_error(DBusMessageIter *iter)
+-{
+-	int err = -ECONNABORTED;
+-	char *key;
++	if(p2p_network == NULL)
++		return peer;
+ 
+-	if (!iter)
+-		return err;
++	interface = g_hash_table_lookup(peer_mapping, p2p_network->path);
++	if (!interface)
++		return peer;
+ 
+-	/* If the given passphrase is malformed wpa_s returns
+-	 * "invalid message format" but this error should be interpreted as
+-	 * invalid-key.
+-	 */
+-	while (dbus_message_iter_get_arg_type(iter) == DBUS_TYPE_STRING) {
+-		dbus_message_iter_get_basic(iter, &key);
+-		if (strncmp(key, "psk", 3) == 0 ||
+-				strncmp(key, "wep_key", 7) == 0 ||
+-				strcmp(key, "invalid message format") == 0) {
+-			err = -ENOKEY;
+-			break;
+-		}
+-		dbus_message_iter_next(iter);
+-	}
++	peer = g_hash_table_lookup(interface->peer_table, p2p_network->path);
+ 
+-	return err;
++	return g_supplicant_peer_get_identifier(peer);
+ }
+ 
+-static void interface_select_network_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++static void signal_group_peer_disconnected(const char *path, DBusMessageIter *iter)
+ {
+-	struct interface_connect_data *data = user_data;
+-	int err;
++	const char *peer_path = NULL;
++	GSupplicantInterface *interface;
++	GSupplicantGroup *group;
++	GSupplicantPeer *peer;
++	struct peer_device_data *p2p_network = NULL;
++	char  *pintf_addr;
++	char *p2p_dev_addr = NULL;
++
++	GSList *elem;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+-	err = 0;
+-	if (error) {
+-		SUPPLICANT_DBG("SelectNetwork error %s", error);
+-		err = parse_supplicant_error(iter);
+-	}
++	group = g_hash_table_lookup(group_mapping, path);
++	if (!group)
++		return;
+ 
+-	g_free(data->path);
++	dbus_message_iter_get_basic(iter, &peer_path);
++	if (!peer_path)
++		return;
+ 
+-	if (data->callback)
+-		data->callback(err, data->interface, data->user_data);
++	dbus_message_iter_next(iter);
++	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_STRING) {
++		SUPPLICANT_DBG("not string\n");
++		return;
++	}
+ 
+-	g_free(data->ssid);
+-	dbus_free(data);
+-}
++	dbus_message_iter_get_basic(iter, &p2p_dev_addr);
++	if (!p2p_dev_addr)
++		return;
+ 
+-static void interface_select_network_params(DBusMessageIter *iter,
+-							void *user_data)
+-{
+-	struct interface_connect_data *data = user_data;
+-	GSupplicantInterface *interface = data->interface;
++	pintf_addr = g_hash_table_lookup(intf_addr_mapping, peer_path);
++	if (pintf_addr == NULL)
++		return;
+ 
+-	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
+-					&interface->network_path);
+-}
++	p2p_network = g_supplicant_find_network_from_intf_address(pintf_addr, p2p_dev_addr);
+ 
+-static void interface_add_network_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
+-{
+-	struct interface_connect_data *data = user_data;
+-	GSupplicantInterface *interface = data->interface;
+-	const char *path;
+-	int err;
++	if (p2p_network == NULL)
++		return;
+ 
+-	if (error)
+-		goto error;
++	g_hash_table_remove(dev_addr_mapping, pintf_addr);
+ 
+-	dbus_message_iter_get_basic(iter, &path);
+-	if (!path)
+-		goto error;
++	for (elem = group->members; elem; elem = elem->next) {
++		if (!g_strcmp0(elem->data, p2p_network->path))
++			break;
++	}
+ 
+-	SUPPLICANT_DBG("PATH: %s", path);
++	if (!elem)
++		return;
+ 
+-	interface->network_path = g_strdup(path);
++	g_free(elem->data);
++	group->members = g_slist_delete_link(group->members, elem);
+ 
+-	store_network_information(interface, data->ssid);
++	interface = g_hash_table_lookup(peer_mapping, p2p_network->path);
++	if (!interface)
++		return;
+ 
+-	supplicant_dbus_method_call(data->interface->path,
+-			SUPPLICANT_INTERFACE ".Interface", "SelectNetwork",
+-			interface_select_network_params,
+-			interface_select_network_result, data,
+-			interface);
++	peer = g_hash_table_lookup(interface->peer_table, p2p_network->path);
++	if (!peer)
++		return;
+ 
+-	return;
++	callback_peer_changed(peer, G_SUPPLICANT_PEER_GROUP_DISCONNECTED);
++	peer->connection_requested = false;
++}
+ 
+-error:
+-	SUPPLICANT_DBG("AddNetwork error %s", error);
++static struct {
++	const char *interface;
++	const char *member;
++	void (*function) (const char *path, DBusMessageIter *iter);
++} signal_map[] = {
++	{ DBUS_INTERFACE_DBUS,  "NameOwnerChanged",  signal_name_owner_changed },
+ 
+-	if (interface_exists(data->interface, data->interface->path)) {
+-		err = parse_supplicant_error(iter);
+-		if (data->callback)
+-			data->callback(err, data->interface, data->user_data);
++	{ SUPPLICANT_INTERFACE, "PropertiesChanged", signal_properties_changed },
++	{ SUPPLICANT_INTERFACE, "InterfaceAdded",    signal_interface_added    },
++	{ SUPPLICANT_INTERFACE, "InterfaceCreated",  signal_interface_added    },
++	{ SUPPLICANT_INTERFACE, "InterfaceRemoved",  signal_interface_removed  },
+ 
+-		g_free(interface->network_path);
+-		interface->network_path = NULL;
+-	}
++	{ SUPPLICANT_INTERFACE ".Interface", "PropertiesChanged", signal_interface_changed },
++	{ SUPPLICANT_INTERFACE ".Interface", "ScanDone",          signal_scan_done         },
++	{ SUPPLICANT_INTERFACE ".Interface", "BSSAdded",          signal_bss_added         },
++	{ SUPPLICANT_INTERFACE ".Interface", "BSSRemoved",        signal_bss_removed       },
++	{ SUPPLICANT_INTERFACE ".Interface", "NetworkAdded",      signal_network_added     },
++	{ SUPPLICANT_INTERFACE ".Interface", "NetworkRemoved",    signal_network_removed   },
++	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_sta_authorized    },
++	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_sta_deauthorized  },
+ 
+-	g_free(data->path);
+-	g_free(data->ssid);
+-	g_free(data);
+-}
++	{ SUPPLICANT_INTERFACE ".BSS", "PropertiesChanged", signal_bss_changed   },
+ 
+-static void add_network_security_none(DBusMessageIter *dict)
+-{
+-	const char *auth_alg = "OPEN";
++	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Credentials", signal_wps_credentials },
++	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Event",       signal_wps_event       },
+ 
+-	supplicant_dbus_dict_append_basic(dict, "auth_alg",
+-					DBUS_TYPE_STRING, &auth_alg);
+-}
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "DeviceFound", signal_peer_found },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "DeviceLost",  signal_peer_lost  },
+ 
+-static void add_network_security_wep(DBusMessageIter *dict,
+-					GSupplicantSSID *ssid)
+-{
+-	const char *auth_alg = "OPEN SHARED";
+-	dbus_uint32_t key_index = 0;
++	{ SUPPLICANT_INTERFACE ".Peer", "PropertiesChanged", signal_peer_changed },
+ 
+-	supplicant_dbus_dict_append_basic(dict, "auth_alg",
+-					DBUS_TYPE_STRING, &auth_alg);
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationSuccess", signal_group_success },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationFailure", signal_group_failure },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GroupStarted", signal_group_started },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GroupFinished", signal_group_finished },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationRequest", signal_group_request },
+ 
+-	if (ssid->passphrase) {
+-		int size = strlen(ssid->passphrase);
+-		if (size == 10 || size == 26) {
+-			unsigned char *key = g_try_malloc(13);
+-			char tmp[3];
+-			int i;
++	{ SUPPLICANT_INTERFACE ".Group", "PeerJoined", signal_group_peer_joined },
++	{ SUPPLICANT_INTERFACE ".Group", "PeerDisconnected", signal_group_peer_disconnected },
+ 
+-			memset(tmp, 0, sizeof(tmp));
+-			if (!key)
+-				size = 0;
++	{ }
++};
+ 
+-			for (i = 0; i < size / 2; i++) {
+-				memcpy(tmp, ssid->passphrase + (i * 2), 2);
+-				key[i] = (unsigned char) strtol(tmp, NULL, 16);
+-			}
++static DBusHandlerResult g_supplicant_filter(DBusConnection *conn,
++					DBusMessage *message, void *data)
++{
++	DBusMessageIter iter;
++	const char *path;
++	int i;
+ 
+-			supplicant_dbus_dict_append_fixed_array(dict,
+-							"wep_key0",
+-							DBUS_TYPE_BYTE,
+-							&key, size / 2);
+-			g_free(key);
+-		} else if (size == 5 || size == 13) {
+-			unsigned char *key = g_try_malloc(13);
+-			int i;
++	path = dbus_message_get_path(message);
++	if (!path)
++		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+ 
+-			if (!key)
+-				size = 0;
++	if (!dbus_message_iter_init(message, &iter))
++		return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+ 
+-			for (i = 0; i < size; i++)
+-				key[i] = (unsigned char) ssid->passphrase[i];
++	for (i = 0; signal_map[i].interface; i++) {
++		if (!dbus_message_has_interface(message, signal_map[i].interface))
++			continue;
+ 
+-			supplicant_dbus_dict_append_fixed_array(dict,
+-								"wep_key0",
+-								DBUS_TYPE_BYTE,
+-								&key, size);
+-			g_free(key);
+-		} else
+-			supplicant_dbus_dict_append_basic(dict,
+-							"wep_key0",
+-							DBUS_TYPE_STRING,
+-							&ssid->passphrase);
++		if (!dbus_message_has_member(message, signal_map[i].member))
++			continue;
+ 
+-		supplicant_dbus_dict_append_basic(dict, "wep_tx_keyidx",
+-					DBUS_TYPE_UINT32, &key_index);
++		signal_map[i].function(path, &iter);
++		break;
+ 	}
++
++	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+ }
+ 
+-static dbus_bool_t is_psk_raw_key(const char *psk)
++struct interface_p2p_invite_data {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantP2PInviteParams *p2p_invite_params;
++	void *user_data;
++};
++
++static void interface_p2p_invite_params(DBusMessageIter *iter, void *user_data)
+ {
+-	int i;
++	DBusMessageIter dict;
++	struct interface_p2p_invite_data *data = user_data;
+ 
+-	/* A raw key is always 64 bytes length... */
+-	if (strlen(psk) != 64)
+-		return FALSE;
++	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	/* ... and its content is in hex representation */
+-	for (i = 0; i < 64; i++)
+-		if (!isxdigit((unsigned char) psk[i]))
+-			return FALSE;
++	if (data && data->p2p_invite_params) {
++		GSupplicantP2PInviteParams* params = data->p2p_invite_params;
+ 
+-	return TRUE;
+-}
++		supplicant_dbus_dict_append_basic(&dict, "peer",
++					DBUS_TYPE_OBJECT_PATH, &params->peer);
+ 
+-static unsigned char hexchar2bin(char c)
+-{
+-	if ((c >= '0') && (c <= '9'))
+-		return c - '0';
+-	else if ((c >= 'A') && (c <= 'F'))
+-		return c - 'A' + 10;
+-	else if ((c >= 'a') && (c <= 'f'))
+-		return c - 'a' + 10;
+-	else
+-		return c;
++		if(params->persistent_group)
++			supplicant_dbus_dict_append_basic(&dict, "persistent_group_object",
++					DBUS_TYPE_OBJECT_PATH, &params->persistent_group);
++	}
++
++	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-static void hexstring2bin(const char *string, unsigned char *data,
+-				size_t data_len)
++static void interface_p2p_invite_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
+ {
+-	size_t i;
++	struct interface_p2p_invite_data *data = user_data;
++	int err = 0;
+ 
+-	for (i = 0; i < data_len; i++)
+-		data[i] = (hexchar2bin(string[i * 2 + 0]) << 4 |
+-			   hexchar2bin(string[i * 2 + 1]) << 0);
+-}
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
+ 
+-static void add_network_security_psk(DBusMessageIter *dict,
+-					GSupplicantSSID *ssid)
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	dbus_free(data);
++}
++int g_supplicant_interface_p2p_invite(GSupplicantInterface *interface,
++				GSupplicantP2PInviteParams *invite_data,
++				GSupplicantInterfaceCallback callback, void *user_data)
+ {
+-	if (ssid->passphrase && strlen(ssid->passphrase) > 0) {
+-		const char *key = "psk";
++	struct interface_p2p_invite_data *data;
++	int ret;
+ 
+-		if (is_psk_raw_key(ssid->passphrase)) {
+-			unsigned char data[32];
+-			unsigned char *datap = data;
++	if (!interface)
++		return -EINVAL;
+ 
+-			/* The above pointer alias is required by D-Bus because
+-			 * with D-Bus and GCC, non-heap-allocated arrays cannot
+-			 * be passed directly by their base pointer. */
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
+ 
+-			hexstring2bin(ssid->passphrase, datap, sizeof(data));
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++	data->p2p_invite_params = invite_data;
+ 
+-			supplicant_dbus_dict_append_fixed_array(dict,
+-							key, DBUS_TYPE_BYTE,
+-							&datap, sizeof(data));
+-		} else
+-			supplicant_dbus_dict_append_basic(dict,
+-							key, DBUS_TYPE_STRING,
+-							&ssid->passphrase);
++	SUPPLICANT_DBG("interface->path : %s\n", interface->path);
++
++	ret = supplicant_dbus_method_call(interface->path,
++					SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++					"Invite",
++					interface_p2p_invite_params,
++					interface_p2p_invite_result, data, NULL);
++
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
+ 	}
++
++	return -EINPROGRESS;
+ }
+ 
+-static void add_network_security_tls(DBusMessageIter *dict,
+-					GSupplicantSSID *ssid)
++void g_supplicant_interface_cancel(GSupplicantInterface *interface)
+ {
+-	/*
+-	 * For TLS, we at least need:
+-	 *              The client certificate
+-	 *              The client private key file
+-	 *              The client private key file password
+-	 *
+-	 * The Authority certificate is optional.
+-	 */
+-	if (!ssid->client_cert_path)
++	if (!interface)
+ 		return;
+ 
+-	if (!ssid->private_key_path)
+-		return;
++	SUPPLICANT_DBG("Cancelling any pending DBus calls");
++	supplicant_dbus_method_call_cancel_all(interface);
++	supplicant_dbus_property_call_cancel_all(interface);
++}
+ 
+-	if (!ssid->private_key_passphrase)
+-		return;
++struct supplicant_regdom {
++	GSupplicantCountryCallback callback;
++	const char *alpha2;
++	const void *user_data;
++};
+ 
+-	if (ssid->ca_cert_path)
+-		supplicant_dbus_dict_append_basic(dict, "ca_cert",
++static void country_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct supplicant_regdom *regdom = user_data;
++	int result = 0;
++
++	SUPPLICANT_DBG("Country setting result");
++
++	if (!user_data)
++		return;
++
++	if (error) {
++		SUPPLICANT_DBG("Country setting failure %s", error);
++		result = -EINVAL;
++	}
++
++	if (regdom->callback)
++		regdom->callback(result, regdom->alpha2,
++					(void *) regdom->user_data);
++
++	g_free(regdom);
++}
++
++static void country_params(DBusMessageIter *iter, void *user_data)
++{
++	struct supplicant_regdom *regdom = user_data;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING,
++							&regdom->alpha2);
++}
++
++int g_supplicant_set_country(const char *alpha2,
++				GSupplicantCountryCallback callback,
++					const void *user_data)
++{
++	struct supplicant_regdom *regdom;
++	int ret;
++
++	SUPPLICANT_DBG("Country setting %s", alpha2);
++
++	if (!system_available)
++		return -EFAULT;
++
++	regdom = dbus_malloc0(sizeof(*regdom));
++	if (!regdom)
++		return -ENOMEM;
++
++	regdom->callback = callback;
++	regdom->alpha2 = alpha2;
++	regdom->user_data = user_data;
++
++	ret =  supplicant_dbus_property_set(SUPPLICANT_PATH, SUPPLICANT_INTERFACE,
++					"Country", DBUS_TYPE_STRING_AS_STRING,
++					country_params, country_result,
++					regdom, NULL);
++	if (ret < 0) {
++		dbus_free(regdom);
++		SUPPLICANT_DBG("Unable to set Country configuration");
++	}
++	return ret;
++}
++
++int g_supplicant_interface_set_country(GSupplicantInterface *interface,
++					GSupplicantCountryCallback callback,
++							const char *alpha2,
++							void *user_data)
++{
++	struct supplicant_regdom *regdom;
++	int ret;
++
++	if (!interface)
++		return -EINVAL;
++	regdom = dbus_malloc0(sizeof(*regdom));
++	if (!regdom)
++		return -ENOMEM;
++
++	regdom->callback = callback;
++	regdom->alpha2 = alpha2;
++	regdom->user_data = user_data;
++
++	ret =  supplicant_dbus_property_set(interface->path,
++				SUPPLICANT_INTERFACE ".Interface",
++				"Country", DBUS_TYPE_STRING_AS_STRING,
++				country_params, country_result,
++					regdom, NULL);
++	if (ret < 0) {
++		dbus_free(regdom);
++		SUPPLICANT_DBG("Unable to set Country configuration");
++	}
++
++	return ret;
++}
++
++bool g_supplicant_interface_has_p2p(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return false;
++
++	return interface->p2p_support;
++}
++
++struct supplicant_p2p_dev_config {
++	char *device_name;
++	char *dev_type;
++};
++
++static void p2p_device_config_result(const char *error,
++					DBusMessageIter *iter, void *user_data)
++{
++	struct supplicant_p2p_dev_config *config = user_data;
++
++	if (error)
++		SUPPLICANT_DBG("Unable to set P2P Device configuration: %s",
++									error);
++
++	g_free(config->device_name);
++	g_free(config->dev_type);
++	dbus_free(config);
++}
++
++static int dev_type_str2bin(const char *type, unsigned char dev_type[8])
++{
++	int length, pos, end;
++	char b[3] = {};
++	char *e = NULL;
++
++	end = strlen(type);
++	for (length = pos = 0; type[pos] != '\0' && length < 8; length++) {
++		if (pos+2 > end)
++			return 0;
++
++		b[0] = type[pos];
++		b[1] = type[pos+1];
++
++		dev_type[length] = strtol(b, &e, 16);
++		if (e && *e != '\0')
++			return 0;
++
++		pos += 2;
++	}
++
++	return 8;
++}
++
++static void p2p_device_config_params(DBusMessageIter *iter, void *user_data)
++{
++	struct supplicant_p2p_dev_config *config = user_data;
++	DBusMessageIter dict;
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	supplicant_dbus_dict_append_basic(&dict, "DeviceName",
++				DBUS_TYPE_STRING, &config->device_name);
++
++	if (config->dev_type) {
++		unsigned char dev_type[8] = {}, *type;
++		int len;
++
++		len = dev_type_str2bin(config->dev_type, dev_type);
++		if (len) {
++			type = dev_type;
++			supplicant_dbus_dict_append_fixed_array(&dict,
++					"PrimaryDeviceType",
++					DBUS_TYPE_BYTE, &type, len);
++		}
++	}
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++int g_supplicant_interface_set_p2p_device_config(GSupplicantInterface *interface,
++					const char *device_name,
++					const char *primary_dev_type)
++{
++	struct supplicant_p2p_dev_config *config;
++	int ret;
++
++	SUPPLICANT_DBG("P2P Device settings %s/%s",
++					device_name, primary_dev_type);
++
++	config = dbus_malloc0(sizeof(*config));
++	if (!config)
++		return -ENOMEM;
++
++	config->device_name = g_strdup(device_name);
++	config->dev_type = g_strdup(primary_dev_type);
++
++	ret = supplicant_dbus_property_set(interface->path,
++				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++				"P2PDeviceConfig",
++				DBUS_TYPE_ARRAY_AS_STRING
++				DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
++				DBUS_TYPE_STRING_AS_STRING
++				DBUS_TYPE_VARIANT_AS_STRING
++				DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
++				p2p_device_config_params,
++				p2p_device_config_result, config, NULL);
++	if (ret < 0) {
++		g_free(config->device_name);
++		g_free(config->dev_type);
++		dbus_free(config);
++		SUPPLICANT_DBG("Unable to set P2P Device configuration");
++	}
++
++	return ret;
++}
++
++static void p2p_device_config_property_update(DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantP2PDeviceConfigParams *p2p_device_config = user_data;
++	DBusMessageIter iter_dict, iter_dict_entry;
++	char *key = NULL;
++
++	dbus_message_iter_recurse(iter, &iter_dict);
++	dbus_message_iter_get_basic(&iter_dict, &key);
++
++	dbus_message_iter_next(&iter_dict);
++	dbus_message_iter_recurse(&iter_dict, &iter_dict_entry);
++
++	if (!key)
++		return;
++
++	if (g_strcmp0(key, "DeviceName") == 0) {
++		char *name = NULL;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &name);
++
++		if(p2p_device_config->device_name != NULL){
++			g_free(p2p_device_config->device_name);
++			p2p_device_config->device_name = NULL;
++		}
++
++		p2p_device_config->device_name = g_strdup(name);
++
++		SUPPLICANT_DBG("device_name : %s\n", p2p_device_config->device_name);
++	} else if (g_strcmp0(key, "PrimaryDeviceType") == 0) {
++		DBusMessageIter array;
++		unsigned char *device_type = NULL;
++		int type_len = 0;
++		int i=0;
++
++		dbus_message_iter_recurse(&iter_dict_entry, &array);
++		dbus_message_iter_get_fixed_array(&array, &device_type, &type_len);
++
++		if(type_len == 8) {
++			for(i=0; i<type_len; i++)
++				p2p_device_config->pri_dev_type[i] = device_type[i];
++		} else {
++			SUPPLICANT_DBG("strange device type\n");
++		}
++	} else if (g_strcmp0(key, "GOIntent") == 0) {
++		dbus_uint32_t go_intent;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &go_intent);
++		p2p_device_config->go_intent = go_intent;
++		SUPPLICANT_DBG("go_intent : %d\n", p2p_device_config->go_intent);
++	} else if (g_strcmp0(key, "PersistentReconnect") == 0) {
++		dbus_bool_t persistent_reconnect;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &persistent_reconnect);
++		p2p_device_config->persistent_reconnect = persistent_reconnect;
++		SUPPLICANT_DBG("persistent_reconnect : %d\n", p2p_device_config->persistent_reconnect);
++	} else if (g_strcmp0(key, "ListenRegClass") == 0) {
++		dbus_uint32_t listen_reg_class;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &listen_reg_class);
++		p2p_device_config->listen_reg_class = listen_reg_class;
++		SUPPLICANT_DBG("listen_reg_class : %d\n", p2p_device_config->listen_reg_class);
++	} else if (g_strcmp0(key, "ListenChannel") == 0) {
++		dbus_uint32_t listen_channel;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &listen_channel);
++		p2p_device_config->listen_channel = listen_channel;
++	} else if (g_strcmp0(key, "OperRegClass") == 0) {
++		dbus_uint32_t oper_reg_class;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &oper_reg_class);
++		p2p_device_config->oper_reg_class = oper_reg_class;
++	} else if (g_strcmp0(key, "OperChannel") == 0) {
++		dbus_uint32_t oper_channel;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &oper_channel);
++		p2p_device_config->oper_channel = oper_channel;
++	} else if (g_strcmp0(key, "SsidPostfix") == 0) {
++		char *ssid_postfix = NULL;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &ssid_postfix);
++
++		if(p2p_device_config->ssid_postfix != NULL){
++			g_free(p2p_device_config->ssid_postfix);
++			p2p_device_config->ssid_postfix = NULL;
++		}
++
++		p2p_device_config->ssid_postfix = g_strdup(ssid_postfix);
++	} else if (g_strcmp0(key, "IntraBss") == 0) {
++		dbus_bool_t intra_bss;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &intra_bss);
++		p2p_device_config->intra_bss = intra_bss;
++	} else if (g_strcmp0(key, "GroupIdle") == 0) {
++		dbus_uint32_t group_idle;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &group_idle);
++		p2p_device_config->group_idle = group_idle;
++	} else if (g_strcmp0(key, "disassoc_low_ack") == 0) {
++		dbus_uint32_t disassoc_low_ack;
++
++		dbus_message_iter_get_basic(&iter_dict_entry, &disassoc_low_ack);
++		p2p_device_config->disassoc_low_ack = disassoc_low_ack;
++	} else
++		SUPPLICANT_DBG("key %s type %c",
++					key, dbus_message_iter_get_arg_type(&iter_dict_entry));
++}
++
++static void p2p_device_config_property(const char *key, DBusMessageIter *iter,
++					void *user_data)
++{
++	GSupplicantInterface *interface;
++	GSupplicantP2PInterface *p2p_device_interface = user_data;
++	GSupplicantP2PDeviceConfigParams *p2p_device_config = p2p_device_interface->p2p_device_config_param;;
++
++	GSupplicantInterface *check_interface = NULL;
++
++	if (key){
++		check_interface = g_hash_table_lookup(interface_table, key);
++		if (check_interface == NULL)
++			return;
++
++		struct wifi_data *check_wifi = g_supplicant_interface_get_data(check_interface);
++		if (check_wifi == NULL)
++			return;
++	}
++
++	if (p2p_device_config->interface->path == NULL)
++		return;
++
++	interface = g_hash_table_lookup(interface_table, p2p_device_config->interface->path);
++	if (interface == NULL || interface != p2p_device_config->interface) {
++		g_free(p2p_device_interface->path);
++		g_free(p2p_device_interface);
++		return;
++	}
++
++	if (iter)
++		supplicant_dbus_array_foreach(iter, p2p_device_config_property_update, p2p_device_config);
++
++	callback_p2p_device_config_loaded(p2p_device_config->interface);
++
++	g_free(p2p_device_interface->path);
++	g_free(p2p_device_interface);
++}
++int g_supplicant_interface_get_p2p_device_config(GSupplicantInterface *interface,
++					GSupplicantP2PDeviceConfigParams *p2p_device_config_data)
++{
++	GSupplicantP2PInterface *p2p_device_interface = NULL;
++	int ret;
++
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	p2p_device_interface = g_try_malloc0(sizeof(GSupplicantP2PInterface));
++	if(!p2p_device_interface)
++		return -ENOMEM;
++
++	p2p_device_interface->path = g_strdup(interface->path);
++	p2p_device_interface->p2p_device_config_param = p2p_device_config_data;
++	p2p_device_interface->p2p_device_config_param->interface = interface;
++
++	ret = supplicant_dbus_property_get(interface->path,
++				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++				"P2PDeviceConfig",
++				p2p_device_config_property,
++				p2p_device_interface,
++				NULL);
++
++	if (ret < 0) {
++		g_free(p2p_device_interface->path);
++		g_free(p2p_device_interface);
++		SUPPLICANT_DBG("Unable to get P2P Device configuration");
++	}
++
++	return ret;
++}
++static void interface_set_p2p_device_config_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_device_config *config = user_data;
++	GSupplicantP2PDeviceConfigParams *config_params = config->p2p_device_config_params;
++	DBusMessageIter dict;
++	uint8_t *pri_dev_type = config_params->pri_dev_type;
++	uint8_t pri_dev_type_check[8] = {0,};
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	if(config_params->device_name)
++		supplicant_dbus_dict_append_basic(&dict, "DeviceName", DBUS_TYPE_STRING, &config_params->device_name);
++
++	if(memcmp(&pri_dev_type_check[0], pri_dev_type, 8) != 0)
++		supplicant_dbus_dict_append_fixed_array(&dict, "PrimaryDeviceType", DBUS_TYPE_BYTE, &pri_dev_type, 8);
++
++	if(config_params->go_intent != 0)
++		supplicant_dbus_dict_append_basic(&dict, "GOIntent", DBUS_TYPE_UINT32, &config_params->go_intent);
++
++	supplicant_dbus_dict_append_basic(&dict, "PersistentReconnect", DBUS_TYPE_BOOLEAN, &config_params->persistent_reconnect);
++
++	if(config_params->listen_reg_class != 0)
++		supplicant_dbus_dict_append_basic(&dict, "ListenRegClass", DBUS_TYPE_UINT32, &config_params->listen_reg_class);
++
++	if(config_params->listen_channel != 0)
++		supplicant_dbus_dict_append_basic(&dict, "ListenChannel", DBUS_TYPE_UINT32, &config_params->listen_channel);
++
++	if(config_params->oper_reg_class != 0)
++		supplicant_dbus_dict_append_basic(&dict, "OperRegClass", DBUS_TYPE_UINT32, &config_params->oper_reg_class);
++
++	if(config_params->oper_channel != 0)
++		supplicant_dbus_dict_append_basic(&dict, "OperChannel", DBUS_TYPE_UINT32, &config_params->oper_channel);
++
++	if(config_params->ssid_postfix)
++		supplicant_dbus_dict_append_basic(&dict, "SsidPostfix", DBUS_TYPE_STRING, &config_params->ssid_postfix);
++
++	supplicant_dbus_dict_append_basic(&dict, "IntraBss", DBUS_TYPE_BOOLEAN, &config_params->intra_bss);
++
++	if(config_params->group_idle != 0)
++		supplicant_dbus_dict_append_basic(&dict, "GroupIdle", DBUS_TYPE_UINT32, &config_params->group_idle);
++
++	if(config_params->disassoc_low_ack != 0)
++		supplicant_dbus_dict_append_basic(&dict, "disassoc_low_ack", DBUS_TYPE_UINT32, &config_params->disassoc_low_ack);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++static void interface_set_p2p_device_config_result(const char *error,
++												DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_device_config *config = user_data;
++
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++	}
++
++	dbus_free(config);
++}
++int g_supplicant_interface_set_p2p_device_configs(GSupplicantInterface *interface,
++												GSupplicantP2PDeviceConfigParams *p2p_device_config_data,
++												void *user_data)
++{
++	struct interface_p2p_device_config *config = NULL;
++	int ret;
++
++	if (!interface)
++		return -EINVAL;
++
++	config = dbus_malloc0(sizeof(*config));
++	if (!config)
++		return -ENOMEM;
++
++	config->interface = interface;
++	config->user_data = user_data;
++	config->p2p_device_config_params = p2p_device_config_data;
++
++	ret = supplicant_dbus_property_set(interface->path,
++				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++				"P2PDeviceConfig", DBUS_TYPE_ARRAY_AS_STRING
++				DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
++				DBUS_TYPE_STRING_AS_STRING
++				DBUS_TYPE_VARIANT_AS_STRING
++				DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
++				interface_set_p2p_device_config_params,
++				interface_set_p2p_device_config_result, config, NULL);
++
++	if (ret < 0) {
++		dbus_free(config);
++		SUPPLICANT_DBG("Unable to set P2P Device configuration");
++	}
++
++	return ret;
++}
++
++static void set_p2p_disabled(DBusMessageIter *iter, void *user_data)
++{
++	dbus_bool_t enable = *(dbus_bool_t *)user_data;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &enable);
++}
++
++int g_supplicant_interface_set_p2p_disabled(GSupplicantInterface *interface,
++							dbus_bool_t disabled)
++{
++	GSupplicantInterface *check_interface = NULL;
++	if (interface == NULL || interface->path == NULL)
++		return -EINVAL;
++
++	check_interface = g_hash_table_lookup(interface_table, interface->path);
++	if (check_interface == NULL)
++		return -EINVAL;
++
++	if (system_available == FALSE)
++		return -EFAULT;
++
++	SUPPLICANT_DBG("disabled %d", disabled);
++
++	return supplicant_dbus_property_set(interface->path,
++				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++				"P2PDisabled", DBUS_TYPE_BOOLEAN_AS_STRING,
++				set_p2p_disabled, NULL, &disabled, NULL);
++}
++static gboolean peer_lookup_by_identifier(gpointer key, gpointer value,
++							gpointer user_data)
++{
++	const GSupplicantPeer *peer = value;
++	const char *identifier = user_data;
++
++	if (!g_strcmp0(identifier, peer->identifier))
++		return TRUE;
++
++	return FALSE;
++}
++
++GSupplicantPeer *g_supplicant_interface_peer_lookup(GSupplicantInterface *interface,
++							const char *identifier)
++{
++	GSupplicantPeer *peer;
++
++	peer = g_hash_table_find(interface->peer_table,
++					peer_lookup_by_identifier,
++					(void *) identifier);
++	return peer;
++}
++
++static void interface_create_data_free(struct interface_create_data *data)
++{
++	g_free(data->ifname);
++	g_free(data->driver);
++	g_free(data->bridge);
++	if (data->config_file)
++		g_free(data->config_file);
++	if (data->interface_path)
++		g_free(data->interface_path);
++	dbus_free(data);
++}
++
++static bool interface_exists(GSupplicantInterface *interface,
++				const char *path)
++{
++	GSupplicantInterface *tmp;
++
++	tmp = g_hash_table_lookup(interface_table, path);
++	if (tmp && tmp == interface)
++		return true;
++
++	return false;
++}
++
++static void interface_create_property(const char *key, DBusMessageIter *iter,
++							void *user_data)
++{
++	struct interface_create_data *data = user_data;
++	GSupplicantInterface *interface = data->interface;
++
++	if (!key) {
++		if (data->callback && interface_exists(data->interface, data->interface_path)) {
++			data->callback(0, data->interface, data->user_data);
++			callback_p2p_support(interface);
++		}
++
++		interface_create_data_free(data);
++	}
++
++	interface_property(key, iter, interface);
++}
++
++static void interface_create_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_create_data *data = user_data;
++	const char *path = NULL;
++	int err;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		g_warning("error %s", error);
++		err = -EIO;
++		goto done;
++	}
++
++	dbus_message_iter_get_basic(iter, &path);
++	if (!path) {
++		err = -EINVAL;
++		goto done;
++	}
++	data->interface_path = g_strdup(path);
++
++	if (!system_available) {
++		err = -EFAULT;
++		goto done;
++	}
++
++	data->interface = g_hash_table_lookup(interface_table, path);
++	if (!data->interface) {
++		data->interface = interface_alloc(path);
++		if (!data->interface) {
++			err = -ENOMEM;
++			goto done;
++		}
++	}
++
++	err = supplicant_dbus_property_get_all(path,
++					SUPPLICANT_INTERFACE ".Interface",
++					interface_create_property, data,
++					NULL);
++	if (err == 0)
++		return;
++
++done:
++	if (data->callback)
++		data->callback(err, NULL, data->user_data);
++
++	interface_create_data_free(data);
++}
++
++static void interface_create_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_create_data *data = user_data;
++	DBusMessageIter dict;
++	char *config_file = NULL;
++
++	SUPPLICANT_DBG("");
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	supplicant_dbus_dict_append_basic(&dict, "Ifname",
++					DBUS_TYPE_STRING, &data->ifname);
++
++	if (data->driver)
++		supplicant_dbus_dict_append_basic(&dict, "Driver",
++					DBUS_TYPE_STRING, &data->driver);
++
++	if (data->bridge)
++		supplicant_dbus_dict_append_basic(&dict, "BridgeIfname",
++					DBUS_TYPE_STRING, &data->bridge);
++
++	config_file = g_hash_table_lookup(config_file_table, data->ifname);
++	if (!config_file && data->config_file)
++		config_file = data->config_file;
++
++	if (config_file) {
++		SUPPLICANT_DBG("[%s] ConfigFile %s", data->ifname, config_file);
++
++		supplicant_dbus_dict_append_basic(&dict, "ConfigFile",
++					DBUS_TYPE_STRING, &config_file);
++	}
++
++    if (data->config_file != NULL)
++            supplicant_dbus_dict_append_basic(&dict, "ConfigFile",
++                                    DBUS_TYPE_STRING, &data->config_file);
++
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++static void interface_get_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_create_data *data = user_data;
++	GSupplicantInterface *interface;
++	const char *path = NULL;
++	int err;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		SUPPLICANT_DBG("Interface not created yet");
++
++		if ( (g_str_has_prefix(data->ifname, "p2p-wlan0-") == TRUE) && data->get_interface_timer_count < 10)
++		{
++			g_timeout_add(50, get_interface_retry, data);
++			data->get_interface_timer_count++;
++			return;
++		}
++		goto create;
++	}
++
++	dbus_message_iter_get_basic(iter, &path);
++	if (!path || (strlen(path) == 0)) {
++		err = -EINVAL;
++		goto done;
++	}
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface) {
++		err = -ENOENT;
++		goto done;
++	}
++
++	if (data->callback) {
++		data->callback(0, interface, data->user_data);
++		callback_p2p_support(interface);
++	}
++
++	interface_create_data_free(data);
++
++	return;
++
++create:
++	if (!system_available) {
++		err = -EFAULT;
++		goto done;
++	}
++
++	SUPPLICANT_DBG("Creating interface");
++
++	err = supplicant_dbus_method_call(SUPPLICANT_PATH,
++						SUPPLICANT_INTERFACE,
++						"CreateInterface",
++						interface_create_params,
++						interface_create_result, data,
++						NULL);
++	if (err == 0)
++		return;
++
++done:
++	if (data->callback)
++		data->callback(err, NULL, data->user_data);
++
++	interface_create_data_free(data);
++}
++
++static void interface_get_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_create_data *data = user_data;
++
++	SUPPLICANT_DBG("");
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, &data->ifname);
++}
++
++static gboolean get_interface_retry(void* user_data)
++{
++	supplicant_dbus_method_call(SUPPLICANT_PATH,
++					SUPPLICANT_INTERFACE,
++					"GetInterface",
++					interface_get_params,
++					interface_get_result, user_data,
++					NULL);
++	return FALSE;
++}
++
++int g_supplicant_interface_create(const char *ifname, const char *driver,
++					const char *bridge, const char *config_file,
++					GSupplicantInterfaceCallback callback,
++							void *user_data)
++{
++	struct interface_create_data *data;
++	int ret;
++
++	SUPPLICANT_DBG("ifname %s", ifname);
++
++	if (!ifname)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->ifname = g_strdup(ifname);
++	data->driver = g_strdup(driver);
++	data->bridge = g_strdup(bridge);
++	data->config_file = g_strdup(config_file);
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(SUPPLICANT_PATH,
++						SUPPLICANT_INTERFACE,
++						"GetInterface",
++						interface_get_params,
++						interface_get_result, data,
++						NULL);
++	if (ret < 0)
++		interface_create_data_free(data);
++
++	return ret;
++}
++
++static void interface_remove_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int err;
++
++	if (error) {
++		err = -EIO;
++		SUPPLICANT_DBG("error: %s", error);
++		goto done;
++	}
++
++	if (!system_available) {
++		err = -EFAULT;
++		goto done;
++	}
++
++	/*
++	 * The gsupplicant interface is already freed by the InterfaceRemoved
++	 * signal callback. Simply invoke the interface_data callback.
++	 */
++	err = 0;
++
++done:
++	g_free(data->path);
++
++	if (data->callback)
++		data->callback(err, NULL, data->user_data);
++
++	dbus_free(data);
++}
++
++
++static void interface_remove_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
++							&data->interface->path);
++}
++
++
++int g_supplicant_interface_remove(GSupplicantInterface *interface,
++			GSupplicantInterfaceCallback callback,
++							void *user_data)
++{
++	struct interface_data *data;
++	int ret;
++
++	if (!interface || !(interface->path))
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	g_supplicant_interface_cancel(interface);
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(SUPPLICANT_PATH,
++						SUPPLICANT_INTERFACE,
++						"RemoveInterface",
++						interface_remove_params,
++						interface_remove_result, data,
++						NULL);
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++	}
++	return ret;
++}
++
++static void interface_scan_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_scan_data *data = user_data;
++	int err = 0;
++
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++
++	/* A non ready interface cannot send/receive anything */
++	if (interface_exists(data->interface, data->path)) {
++		if (!data->interface->ready)
++			err = -ENOLINK;
++	}
++
++	g_free(data->path);
++
++	if (err != 0) {
++		if (data->callback)
++			data->callback(err, data->interface, data->user_data);
++	} else {
++		data->interface->scan_callback = data->callback;
++		data->interface->scan_data = data->user_data;
++	}
++
++	if (data->scan_params)
++		g_supplicant_free_scan_params(data->scan_params);
++
++	dbus_free(data);
++}
++
++static void add_scan_frequency(DBusMessageIter *iter, unsigned int freq)
++{
++	DBusMessageIter data;
++	unsigned int width = 0; /* Not used by wpa_supplicant atm */
++
++	dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &data);
++
++	dbus_message_iter_append_basic(&data, DBUS_TYPE_UINT32, &freq);
++	dbus_message_iter_append_basic(&data, DBUS_TYPE_UINT32, &width);
++
++	dbus_message_iter_close_container(iter, &data);
++}
++
++static void add_scan_frequencies(DBusMessageIter *iter,
++						void *user_data)
++{
++	GSupplicantScanParams *scan_data = user_data;
++	unsigned int freq;
++	int i;
++
++	for (i = 0; i < scan_data->num_freqs; i++) {
++		freq = scan_data->freqs[i];
++		if (!freq)
++			break;
++
++		add_scan_frequency(iter, freq);
++	}
++}
++
++static void append_ssid(DBusMessageIter *iter,
++			const void *ssid, unsigned int len)
++{
++	DBusMessageIter array;
++
++	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
++	DBUS_TYPE_BYTE_AS_STRING, &array);
++
++	dbus_message_iter_append_fixed_array(&array, DBUS_TYPE_BYTE,
++								&ssid, len);
++	dbus_message_iter_close_container(iter, &array);
++}
++
++static void append_ssids(DBusMessageIter *iter, void *user_data)
++{
++	GSupplicantScanParams *scan_data = user_data;
++	GSList *list;
++
++	for (list = scan_data->ssids; list; list = list->next) {
++		struct scan_ssid *scan_ssid = list->data;
++
++		append_ssid(iter, scan_ssid->ssid, scan_ssid->ssid_len);
++	}
++}
++
++static void supplicant_add_scan_frequency(DBusMessageIter *dict,
++		supplicant_dbus_array_function function,
++					void *user_data)
++{
++	GSupplicantScanParams *scan_params = user_data;
++	DBusMessageIter entry, value, array;
++	const char *key = "Channels";
++
++	if (scan_params->freqs && scan_params->freqs[0] != 0) {
++		dbus_message_iter_open_container(dict, DBUS_TYPE_DICT_ENTRY,
++						NULL, &entry);
++
++		dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
++
++		dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT,
++					DBUS_TYPE_ARRAY_AS_STRING
++					DBUS_STRUCT_BEGIN_CHAR_AS_STRING
++					DBUS_TYPE_UINT32_AS_STRING
++					DBUS_TYPE_UINT32_AS_STRING
++					DBUS_STRUCT_END_CHAR_AS_STRING,
++					&value);
++
++		dbus_message_iter_open_container(&value, DBUS_TYPE_ARRAY,
++					DBUS_STRUCT_BEGIN_CHAR_AS_STRING
++					DBUS_TYPE_UINT32_AS_STRING
++					DBUS_TYPE_UINT32_AS_STRING
++					DBUS_STRUCT_END_CHAR_AS_STRING,
++					&array);
++
++		if (function)
++			function(&array, user_data);
++
++		dbus_message_iter_close_container(&value, &array);
++		dbus_message_iter_close_container(&entry, &value);
++		dbus_message_iter_close_container(dict, &entry);
++	}
++}
++
++static void interface_scan_params(DBusMessageIter *iter, void *user_data)
++{
++	DBusMessageIter dict;
++	const char *type = "passive";
++	struct interface_scan_data *data = user_data;
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	if (data && data->scan_params) {
++		type = "active";
++
++		supplicant_dbus_dict_append_basic(&dict, "Type",
++					DBUS_TYPE_STRING, &type);
++
++
++		if (data->scan_params->ssids) {
++			supplicant_dbus_dict_append_array(&dict, "SSIDs",
++							DBUS_TYPE_STRING,
++							append_ssids,
++							data->scan_params);
++		}
++		supplicant_add_scan_frequency(&dict, add_scan_frequencies,
++						data->scan_params);
++	} else
++		supplicant_dbus_dict_append_basic(&dict, "Type",
++					DBUS_TYPE_STRING, &type);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++static int interface_ready_to_scan(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	if (interface->scanning)
++		return -EALREADY;
++
++	switch (interface->state) {
++	case G_SUPPLICANT_STATE_AUTHENTICATING:
++	case G_SUPPLICANT_STATE_ASSOCIATING:
++	case G_SUPPLICANT_STATE_ASSOCIATED:
++	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
++	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
++		return -EBUSY;
++	case G_SUPPLICANT_STATE_UNKNOWN:
++	case G_SUPPLICANT_STATE_DISABLED:
++	case G_SUPPLICANT_STATE_DISCONNECTED:
++	case G_SUPPLICANT_STATE_INACTIVE:
++	case G_SUPPLICANT_STATE_SCANNING:
++	case G_SUPPLICANT_STATE_COMPLETED:
++		break;
++	}
++
++	return 0;
++}
++
++int g_supplicant_interface_scan(GSupplicantInterface *interface,
++				GSupplicantScanParams *scan_data,
++				GSupplicantInterfaceCallback callback,
++							void *user_data)
++{
++	struct interface_scan_data *data;
++	int ret;
++
++	ret = interface_ready_to_scan(interface);
++	if (ret)
++		return ret;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->callback = callback;
++	data->user_data = user_data;
++	data->scan_params = scan_data;
++
++        interface->scan_callback = callback;
++        interface->scan_data = user_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++			SUPPLICANT_INTERFACE ".Interface", "Scan",
++			interface_scan_params, interface_scan_result, data,
++			interface);
++
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++	}
++
++	return ret;
++}
++
++static int parse_supplicant_error(DBusMessageIter *iter)
++{
++	int err = -ECONNABORTED;
++	char *key;
++
++	if (!iter)
++		return err;
++
++	/* If the given passphrase is malformed wpa_s returns
++	 * "invalid message format" but this error should be interpreted as
++	 * invalid-key.
++	 */
++	while (dbus_message_iter_get_arg_type(iter) == DBUS_TYPE_STRING) {
++		dbus_message_iter_get_basic(iter, &key);
++		if (strncmp(key, "psk", 3) == 0 ||
++				strncmp(key, "wep_key", 7) == 0 ||
++				strcmp(key, "invalid message format") == 0) {
++			err = -ENOKEY;
++			break;
++		}
++		dbus_message_iter_next(iter);
++	}
++
++	return err;
++}
++
++static void interface_select_network_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	int err;
++
++	SUPPLICANT_DBG("");
++
++	err = 0;
++	if (error) {
++		SUPPLICANT_DBG("SelectNetwork error %s", error);
++		err = parse_supplicant_error(iter);
++	}
++
++	g_free(data->path);
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	g_free(data->ssid);
++	dbus_free(data);
++}
++
++static void interface_select_network_params(DBusMessageIter *iter,
++							void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	GSupplicantInterface *interface = data->interface;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
++					&interface->network_path);
++}
++
++static void interface_add_network_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	GSupplicantInterface *interface = data->interface;
++	const char *path;
++	int err;
++
++	if (error)
++		goto error;
++
++	dbus_message_iter_get_basic(iter, &path);
++	if (!path)
++		goto error;
++
++	SUPPLICANT_DBG("PATH: %s", path);
++
++	if (interface->network_path)
++		g_free(interface->network_path);
++	interface->network_path = g_strdup(path);
++
++	store_network_information(interface, data->ssid);
++
++	supplicant_dbus_method_call(data->interface->path,
++			SUPPLICANT_INTERFACE ".Interface", "SelectNetwork",
++			interface_select_network_params,
++			interface_select_network_result, data,
++			interface);
++
++	return;
++
++error:
++	SUPPLICANT_DBG("AddNetwork error %s", error);
++
++	if (interface_exists(data->interface, data->interface->path)) {
++		err = parse_supplicant_error(iter);
++		if (data->callback)
++			data->callback(err, data->interface, data->user_data);
++
++		g_free(interface->network_path);
++		interface->network_path = NULL;
++	}
++
++	g_free(data->path);
++	g_free(data->ssid);
++	g_free(data);
++}
++
++static void add_network_security_none(DBusMessageIter *dict)
++{
++	const char *auth_alg = "OPEN";
++
++	supplicant_dbus_dict_append_basic(dict, "auth_alg",
++					DBUS_TYPE_STRING, &auth_alg);
++}
++
++static void add_network_security_wep(DBusMessageIter *dict,
++					GSupplicantSSID *ssid)
++{
++	const char *auth_alg = "OPEN SHARED";
++	dbus_uint32_t key_index = 0;
++
++	supplicant_dbus_dict_append_basic(dict, "auth_alg",
++					DBUS_TYPE_STRING, &auth_alg);
++
++	if (ssid->passphrase) {
++		int size = strlen(ssid->passphrase);
++		if (size == 10 || size == 26) {
++			unsigned char *key = g_try_malloc(13);
++			char tmp[3];
++			int i;
++
++			memset(tmp, 0, sizeof(tmp));
++			if (!key)
++				size = 0;
++
++			for (i = 0; i < size / 2; i++) {
++				memcpy(tmp, ssid->passphrase + (i * 2), 2);
++				key[i] = (unsigned char) strtol(tmp, NULL, 16);
++			}
++
++			supplicant_dbus_dict_append_fixed_array(dict,
++							"wep_key0",
++							DBUS_TYPE_BYTE,
++							&key, size / 2);
++			g_free(key);
++		} else if (size == 5 || size == 13) {
++			unsigned char *key = g_try_malloc(13);
++			int i;
++
++			if (!key)
++				size = 0;
++
++			for (i = 0; i < size; i++)
++				key[i] = (unsigned char) ssid->passphrase[i];
++
++			supplicant_dbus_dict_append_fixed_array(dict,
++								"wep_key0",
++								DBUS_TYPE_BYTE,
++								&key, size);
++			g_free(key);
++		} else
++			supplicant_dbus_dict_append_basic(dict,
++							"wep_key0",
++							DBUS_TYPE_STRING,
++							&ssid->passphrase);
++
++		supplicant_dbus_dict_append_basic(dict, "wep_tx_keyidx",
++					DBUS_TYPE_UINT32, &key_index);
++	}
++}
++
++static dbus_bool_t is_psk_raw_key(const char *psk)
++{
++	int i;
++
++	/* A raw key is always 64 bytes length... */
++	if (strlen(psk) != 64)
++		return FALSE;
++
++	/* ... and its content is in hex representation */
++	for (i = 0; i < 64; i++)
++		if (!isxdigit((unsigned char) psk[i]))
++			return FALSE;
++
++	return TRUE;
++}
++
++static unsigned char hexchar2bin(char c)
++{
++	if ((c >= '0') && (c <= '9'))
++		return c - '0';
++	else if ((c >= 'A') && (c <= 'F'))
++		return c - 'A' + 10;
++	else if ((c >= 'a') && (c <= 'f'))
++		return c - 'a' + 10;
++	else
++		return c;
++}
++
++static void hexstring2bin(const char *string, unsigned char *data,
++				size_t data_len)
++{
++	size_t i;
++
++	for (i = 0; i < data_len; i++)
++		data[i] = (hexchar2bin(string[i * 2 + 0]) << 4 |
++			   hexchar2bin(string[i * 2 + 1]) << 0);
++}
++
++static void add_network_security_psk(DBusMessageIter *dict,
++					GSupplicantSSID *ssid)
++{
++	if (ssid->passphrase && strlen(ssid->passphrase) > 0) {
++		const char *key = "psk";
++
++		if (is_psk_raw_key(ssid->passphrase)) {
++			unsigned char data[32];
++			unsigned char *datap = data;
++
++			/* The above pointer alias is required by D-Bus because
++			 * with D-Bus and GCC, non-heap-allocated arrays cannot
++			 * be passed directly by their base pointer. */
++
++			hexstring2bin(ssid->passphrase, datap, sizeof(data));
++
++			supplicant_dbus_dict_append_fixed_array(dict,
++							key, DBUS_TYPE_BYTE,
++							&datap, sizeof(data));
++		} else
++			supplicant_dbus_dict_append_basic(dict,
++							key, DBUS_TYPE_STRING,
++							&ssid->passphrase);
++	}
++}
++
++static void add_network_security_tls(DBusMessageIter *dict,
++					GSupplicantSSID *ssid)
++{
++	/*
++	 * For TLS, we at least need:
++	 *              The client certificate
++	 *              The client private key file
++	 *              The client private key file password
++	 *
++	 * The Authority certificate is optional.
++	 */
++	if (!ssid->client_cert_path)
++		return;
++
++	if (!ssid->private_key_path)
++		return;
++
++	if (!ssid->private_key_passphrase)
++		return;
++
++	if (ssid->ca_cert_path)
++		supplicant_dbus_dict_append_basic(dict, "ca_cert",
+ 					DBUS_TYPE_STRING, &ssid->ca_cert_path);
+ 
+-	supplicant_dbus_dict_append_basic(dict, "private_key",
+-						DBUS_TYPE_STRING,
+-						&ssid->private_key_path);
+-	supplicant_dbus_dict_append_basic(dict, "private_key_passwd",
+-						DBUS_TYPE_STRING,
+-						&ssid->private_key_passphrase);
+-	supplicant_dbus_dict_append_basic(dict, "client_cert",
+-						DBUS_TYPE_STRING,
+-						&ssid->client_cert_path);
++	supplicant_dbus_dict_append_basic(dict, "private_key",
++						DBUS_TYPE_STRING,
++						&ssid->private_key_path);
++	supplicant_dbus_dict_append_basic(dict, "private_key_passwd",
++						DBUS_TYPE_STRING,
++						&ssid->private_key_passphrase);
++	supplicant_dbus_dict_append_basic(dict, "client_cert",
++						DBUS_TYPE_STRING,
++						&ssid->client_cert_path);
++}
++
++static void add_network_security_peap(DBusMessageIter *dict,
++					GSupplicantSSID *ssid)
++{
++	char *phase2_auth;
++
++	/*
++	 * For PEAP/TTLS, we at least need
++	 *              The authority certificate
++	 *              The 2nd phase authentication method
++	 *              The 2nd phase passphrase
++	 *
++	 * The Client certificate is optional although strongly recommended
++	 * When setting it, we need in addition
++	 *              The Client private key file
++	 *              The Client private key file password
++	 */
++	if (!ssid->passphrase)
++		return;
++
++	if (!ssid->phase2_auth)
++		return;
++
++	if (ssid->client_cert_path) {
++		if (!ssid->private_key_path)
++			return;
++
++		if (!ssid->private_key_passphrase)
++			return;
++
++		supplicant_dbus_dict_append_basic(dict, "client_cert",
++						DBUS_TYPE_STRING,
++						&ssid->client_cert_path);
++
++		supplicant_dbus_dict_append_basic(dict, "private_key",
++						DBUS_TYPE_STRING,
++						&ssid->private_key_path);
++
++		supplicant_dbus_dict_append_basic(dict, "private_key_passwd",
++						DBUS_TYPE_STRING,
++						&ssid->private_key_passphrase);
++
++	}
++
++	if(g_strcmp0(ssid->phase2_auth, "GTC") == 0 && g_strcmp0(ssid->eap, "ttls") == 0)
++		phase2_auth = g_strdup_printf("autheap=%s", ssid->phase2_auth);
++	else if (g_str_has_prefix(ssid->phase2_auth, "EAP-")) {
++		phase2_auth = g_strdup_printf("autheap=%s",
++					ssid->phase2_auth + strlen("EAP-"));
++	} else
++		phase2_auth = g_strdup_printf("auth=%s", ssid->phase2_auth);
++
++	supplicant_dbus_dict_append_basic(dict, "password",
++						DBUS_TYPE_STRING,
++						&ssid->passphrase);
++
++	if (ssid->ca_cert_path)
++		supplicant_dbus_dict_append_basic(dict, "ca_cert",
++						DBUS_TYPE_STRING,
++						&ssid->ca_cert_path);
++
++	supplicant_dbus_dict_append_basic(dict, "phase2",
++						DBUS_TYPE_STRING,
++						&phase2_auth);
++
++	g_free(phase2_auth);
++}
++
++static void add_network_security_eap(DBusMessageIter *dict,
++					GSupplicantSSID *ssid)
++{
++	char *eap_value;
++
++	if (!ssid->eap || !ssid->identity)
++		return;
++
++	if (g_strcmp0(ssid->eap, "tls") == 0) {
++		add_network_security_tls(dict, ssid);
++	} else if (g_strcmp0(ssid->eap, "peap") == 0 ||
++				g_strcmp0(ssid->eap, "ttls") == 0) {
++		add_network_security_peap(dict, ssid);
++	} else
++		return;
++
++	eap_value = g_ascii_strup(ssid->eap, -1);
++
++	supplicant_dbus_dict_append_basic(dict, "eap",
++						DBUS_TYPE_STRING,
++						&eap_value);
++	supplicant_dbus_dict_append_basic(dict, "identity",
++						DBUS_TYPE_STRING,
++						&ssid->identity);
++	if(ssid->anonymous_identity)
++		supplicant_dbus_dict_append_basic(dict, "anonymous_identity",
++						     DBUS_TYPE_STRING,
++						     &ssid->anonymous_identity);
++
++	if(ssid->subject_match)
++		supplicant_dbus_dict_append_basic(dict, "subject_match",
++						     DBUS_TYPE_STRING,
++						     &ssid->subject_match);
++
++	if(ssid->altsubject_match)
++		supplicant_dbus_dict_append_basic(dict, "altsubject_match",
++						     DBUS_TYPE_STRING,
++						     &ssid->altsubject_match);
++
++	if(ssid->domain_suffix_match)
++		supplicant_dbus_dict_append_basic(dict, "domain_suffix_match",
++						     DBUS_TYPE_STRING,
++						     &ssid->domain_suffix_match);
++
++	if(ssid->domain_match)
++		supplicant_dbus_dict_append_basic(dict, "domain_match",
++						     DBUS_TYPE_STRING,
++						     &ssid->domain_match);
++
++	g_free(eap_value);
++}
++
++static void add_network_security_ciphers(DBusMessageIter *dict,
++						GSupplicantSSID *ssid)
++{
++	unsigned int p_cipher, g_cipher, i;
++	char *pairwise, *group;
++	char *pair_ciphers[4];
++	char *group_ciphers[5];
++
++	p_cipher = ssid->pairwise_cipher;
++	g_cipher = ssid->group_cipher;
++
++	if (p_cipher == 0 && g_cipher == 0)
++		return;
++
++	i = 0;
++
++	if (p_cipher & G_SUPPLICANT_PAIRWISE_CCMP)
++		pair_ciphers[i++] = "CCMP";
++
++	if (p_cipher & G_SUPPLICANT_PAIRWISE_TKIP)
++		pair_ciphers[i++] = "TKIP";
++
++	if (p_cipher & G_SUPPLICANT_PAIRWISE_NONE)
++		pair_ciphers[i++] = "NONE";
++
++	pair_ciphers[i] = NULL;
++
++	i = 0;
++
++	if (g_cipher & G_SUPPLICANT_GROUP_CCMP)
++		group_ciphers[i++] = "CCMP";
++
++	if (g_cipher & G_SUPPLICANT_GROUP_TKIP)
++		group_ciphers[i++] = "TKIP";
++
++	if (g_cipher & G_SUPPLICANT_GROUP_WEP104)
++		group_ciphers[i++] = "WEP104";
++
++	if (g_cipher & G_SUPPLICANT_GROUP_WEP40)
++		group_ciphers[i++] = "WEP40";
++
++	group_ciphers[i] = NULL;
++
++	pairwise = g_strjoinv(" ", pair_ciphers);
++	group = g_strjoinv(" ", group_ciphers);
++
++	SUPPLICANT_DBG("cipher %s %s", pairwise, group);
++
++	supplicant_dbus_dict_append_basic(dict, "pairwise",
++						DBUS_TYPE_STRING,
++						&pairwise);
++	supplicant_dbus_dict_append_basic(dict, "group",
++						DBUS_TYPE_STRING,
++						&group);
++
++	g_free(pairwise);
++	g_free(group);
++}
++
++static void add_network_security_proto(DBusMessageIter *dict,
++						GSupplicantSSID *ssid)
++{
++	unsigned int protocol, i;
++	char *proto;
++	char *protos[3];
++
++	protocol = ssid->protocol;
++
++	if (protocol == 0)
++		return;
++
++	i = 0;
++
++	if (protocol & G_SUPPLICANT_PROTO_RSN)
++		protos[i++] = "RSN";
++
++	if (protocol & G_SUPPLICANT_PROTO_WPA)
++		protos[i++] = "WPA";
++
++	protos[i] = NULL;
++
++	proto = g_strjoinv(" ", protos);
++
++	SUPPLICANT_DBG("proto %s", proto);
++
++	supplicant_dbus_dict_append_basic(dict, "proto",
++						DBUS_TYPE_STRING,
++						&proto);
++
++	g_free(proto);
++}
++
++static void add_network_ieee80211w(DBusMessageIter *dict, GSupplicantSSID *ssid,
++				   GSupplicantMfpOptions ieee80211w)
++{
++	supplicant_dbus_dict_append_basic(dict, "ieee80211w", DBUS_TYPE_UINT32,
++					  &ieee80211w);
++}
++
++static void add_network_security(DBusMessageIter *dict, GSupplicantSSID *ssid)
++{
++	GSupplicantMfpOptions ieee80211w;
++	char *key_mgmt;
++
++	switch (ssid->security) {
++	case G_SUPPLICANT_SECURITY_NONE:
++		key_mgmt = "NONE";
++		add_network_security_none(dict);
++		add_network_security_ciphers(dict, ssid);
++		break;
++	case G_SUPPLICANT_SECURITY_UNKNOWN:
++	case G_SUPPLICANT_SECURITY_WEP:
++		key_mgmt = "NONE";
++		add_network_security_wep(dict, ssid);
++		add_network_security_ciphers(dict, ssid);
++		break;
++	case G_SUPPLICANT_SECURITY_PSK:
++			key_mgmt = "WPA-PSK";
++		add_network_security_psk(dict, ssid);
++		add_network_security_ciphers(dict, ssid);
++		add_network_security_proto(dict, ssid);
++		break;
++	case G_SUPPLICANT_SECURITY_IEEE8021X:
++		key_mgmt = "WPA-EAP";
++		add_network_security_eap(dict, ssid);
++		add_network_security_ciphers(dict, ssid);
++		add_network_security_proto(dict, ssid);
++		break;
++	}
++
++	supplicant_dbus_dict_append_basic(dict, "key_mgmt",
++				DBUS_TYPE_STRING, &key_mgmt);
++}
++
++static void add_network_mode(DBusMessageIter *dict, GSupplicantSSID *ssid)
++{
++	dbus_uint32_t mode;
++
++	switch (ssid->mode) {
++	case G_SUPPLICANT_MODE_UNKNOWN:
++	case G_SUPPLICANT_MODE_INFRA:
++		mode = 0;
++		break;
++	case G_SUPPLICANT_MODE_IBSS:
++		mode = 1;
++		break;
++	case G_SUPPLICANT_MODE_MASTER:
++		mode = 2;
++		break;
++	}
++
++	supplicant_dbus_dict_append_basic(dict, "mode",
++				DBUS_TYPE_UINT32, &mode);
++}
++
++static void interface_add_network_params(DBusMessageIter *iter, void *user_data)
++{
++	DBusMessageIter dict;
++	struct interface_connect_data *data = user_data;
++	GSupplicantSSID *ssid = data->ssid;
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	if (ssid->scan_ssid)
++		supplicant_dbus_dict_append_basic(&dict, "scan_ssid",
++					 DBUS_TYPE_UINT32, &ssid->scan_ssid);
++
++	if (ssid->freq)
++		supplicant_dbus_dict_append_basic(&dict, "frequency",
++					 DBUS_TYPE_UINT32, &ssid->freq);
++
++	if (ssid->bgscan)
++		supplicant_dbus_dict_append_basic(&dict, "bgscan",
++					DBUS_TYPE_STRING, &ssid->bgscan);
++
++	add_network_mode(&dict, ssid);
++
++	add_network_security(&dict, ssid);
++
++	supplicant_dbus_dict_append_fixed_array(&dict, "ssid",
++					DBUS_TYPE_BYTE, &ssid->ssid,
++						ssid->ssid_len);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++static void interface_wps_start_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	int err;
++
++	SUPPLICANT_DBG("");
++
++	err = 0;
++	if (error) {
++		SUPPLICANT_DBG("error: %s", error);
++		err = parse_supplicant_error(iter);
++	}
++
++	if(data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	g_free(data->path);
++	g_free(data->ssid);
++	dbus_free(data);
++}
++
++static void interface_add_wps_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	GSupplicantSSID *ssid = data->ssid;
++	const char *role = "enrollee", *type;
++	DBusMessageIter dict;
++
++	SUPPLICANT_DBG("");
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	supplicant_dbus_dict_append_basic(&dict, "Role",
++						DBUS_TYPE_STRING, &role);
++
++	type = "pbc";
++	if (ssid->pin_wps) {
++		type = "pin";
++		supplicant_dbus_dict_append_basic(&dict, "Pin",
++					DBUS_TYPE_STRING, &ssid->pin_wps);
++	}
++
++	supplicant_dbus_dict_append_basic(&dict, "Type",
++					DBUS_TYPE_STRING, &type);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++static void wps_start(const char *error, DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		SUPPLICANT_DBG("error: %s", error);
++		g_free(data->path);
++		g_free(data->ssid);
++		dbus_free(data);
++		return;
++	}
++
++	supplicant_dbus_method_call(data->interface->path,
++			SUPPLICANT_INTERFACE ".Interface.WPS", "Start",
++			interface_add_wps_params,
++			interface_wps_start_result, data, NULL);
++}
++
++static void wps_process_credentials(DBusMessageIter *iter, void *user_data)
++{
++	dbus_bool_t credentials = TRUE;
++
++	SUPPLICANT_DBG("");
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &credentials);
++}
++
++
++int g_supplicant_interface_connect(GSupplicantInterface *interface,
++				GSupplicantSSID *ssid,
++				GSupplicantInterfaceCallback callback,
++							void *user_data)
++{
++	struct interface_connect_data *data;
++	struct interface_data *intf_data;
++	int ret = 0;
++
++	SUPPLICANT_DBG("");
++
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	/* TODO: Check if we're already connected and switch */
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->callback = callback;
++	data->ssid = ssid;
++	data->user_data = user_data;
++
++	if (ssid->use_wps) {
++		g_free(interface->wps_cred.key);
++		memset(&interface->wps_cred, 0,
++				sizeof(struct _GSupplicantWpsCredentials));
++
++		ret = supplicant_dbus_property_set(interface->path,
++			SUPPLICANT_INTERFACE ".Interface.WPS",
++			"ProcessCredentials", DBUS_TYPE_BOOLEAN_AS_STRING,
++			wps_process_credentials, wps_start, data, interface);
++	} else {
++		/* By the time there is a request for connect and the network
++		 * path is not NULL it means that connman has not removed the
++		 * previous network pointer. This can happen in the case AP
++		 * deauthenticated client and connman does not remove the
++		 * previously connected network pointer. This causes supplicant
++		 * to reallocate the memory for struct wpa_ssid again even if it
++		 * is the same SSID. This causes memory usage of wpa_supplicnat
++		 * to go high. The idea here is that if the previously connected
++		 * network is not removed at the time of next connection attempt
++		 * check if the network path is not NULL. In case it is non-NULL
++		 * first remove the network and then once removal is successful, add
++		 * the network.
++		 */
++
++		if (interface->network_path != NULL) {
++			g_free(data->path);
++			dbus_free(data);
++
++			/*
++			 * If this add network is for the same network for
++			 * which wpa_supplicant already has a profile then do
++			 * not need to add another profile. Only if the
++			 * profile that needs to get added is different from
++			 * what is there in wpa_s delete the current one. A
++			 * network is identified by its SSID, security_type
++			 * and passphrase (private passphrase in case security
++			 * type is 802.11x).
++			 */
++			if (compare_network_parameters(interface, ssid)) {
++				return -EALREADY;
++			}
++
++			intf_data = dbus_malloc0(sizeof(*intf_data));
++			if (!intf_data)
++				return -ENOMEM;
++
++			intf_data->interface = interface;
++			intf_data->path = g_strdup(interface->path);
++			intf_data->callback = callback;
++			intf_data->ssid = ssid;
++			intf_data->user_data = user_data;
++			intf_data->network_remove_in_progress = TRUE;
++			network_remove(intf_data);
++		} else {
++			ret = supplicant_dbus_method_call(interface->path,
++					SUPPLICANT_INTERFACE ".Interface", "AddNetwork",
++					interface_add_network_params,
++					interface_add_network_result, data,
++					interface);
++		}
++        }
++
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++
++static void interface_wps_cancel_result(const char *error,
++		DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int err = 0;
++
++	SUPPLICANT_DBG("");
++
++	if (error != NULL) {
++		SUPPLICANT_DBG("error: %s", error);
++		err = parse_supplicant_error(iter);
++	}
++
++	if (data->callback != NULL)
++		data->callback(err, data->interface, data->user_data);
++
++	dbus_free(data);
++}
++
++int g_supplicant_interface_wps_cancel(GSupplicantInterface *interface,
++		GSupplicantInterfaceCallback callback,
++			void *user_data)
++{
++	struct interface_data *data;
++	int ret;
++
++	if (interface == NULL)
++		return -EINVAL;
++
++	if (system_available == FALSE)
++		return -EFAULT;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (data == NULL)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++		SUPPLICANT_INTERFACE ".Interface.WPS", "Cancel",
++		NULL,
++		interface_wps_cancel_result, data, interface);
++
++	if (ret < 0) {
++		g_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++static void network_remove_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	struct interface_connect_data *connect_data;
++	int result = 0;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		result = -EIO;
++		SUPPLICANT_DBG("error: %s", error);
++
++		if (g_strcmp0("org.freedesktop.DBus.Error.UnknownMethod",
++						error) == 0)
++			result = -ECONNABORTED;
++	}
++
++	g_free(data->interface->network_path);
++	data->interface->network_path = NULL;
++
++	remove_network_information(data->interface);
++
++	if (data->network_remove_in_progress == TRUE) {
++		data->network_remove_in_progress = FALSE;
++		connect_data = dbus_malloc0(sizeof(*connect_data));
++		if (!connect_data)
++			return;
++
++		connect_data->interface = data->interface;
++		connect_data->path = g_strdup(data->path);
++		connect_data->callback = data->callback;
++		connect_data->ssid = data->ssid;
++		connect_data->user_data = data->user_data;
++
++		supplicant_dbus_method_call(data->interface->path,
++			SUPPLICANT_INTERFACE ".Interface", "AddNetwork",
++			interface_add_network_params,
++			interface_add_network_result, connect_data,
++			connect_data->interface);
++	} else {
++		if (data->callback)
++			data->callback(result, data->interface, data->user_data);
++	}
++	g_free(data->path);
++	dbus_free(data);
++}
++
++static void network_remove_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	const char *path = data->interface->network_path;
++
++	SUPPLICANT_DBG("path %s", path);
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH, &path);
++}
++
++static int network_remove(struct interface_data *data)
++{
++	GSupplicantInterface *interface = data->interface;
++
++	SUPPLICANT_DBG("");
++
++	return supplicant_dbus_method_call(interface->path,
++			SUPPLICANT_INTERFACE ".Interface", "RemoveNetwork",
++			network_remove_params, network_remove_result, data,
++			interface);
++}
++
++static void interface_disconnect_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int result = 0;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		result = -EIO;
++		SUPPLICANT_DBG("error: %s", error);
++
++		if (g_strcmp0("org.freedesktop.DBus.Error.UnknownMethod",
++						error) == 0)
++			result = -ECONNABORTED;
++	}
++
++	/* If we are disconnecting from previous WPS successful
++	 * association. i.e.: it did not went through AddNetwork,
++	 * and interface->network_path was never set. */
++	if (!data->interface->network_path) {
++		if (data->callback)
++			data->callback(result, data->interface,
++							data->user_data);
++
++		g_free(data->path);
++		dbus_free(data);
++		return;
++	}
++
++	if (result < 0 && data->callback) {
++		data->callback(result, data->interface, data->user_data);
++		data->callback = NULL;
++	}
++
++	if (result != -ECONNABORTED) {
++		if (network_remove(data) < 0) {
++			g_free(data->path);
++			dbus_free(data);
++		}
++	} else {
++		g_free(data->path);
++		dbus_free(data);
++	}
++}
++
++int g_supplicant_interface_disconnect(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++							void *user_data)
++{
++	struct interface_data *data;
++	int ret;
++
++	SUPPLICANT_DBG("");
++
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++			SUPPLICANT_INTERFACE ".Interface", "Disconnect",
++			NULL, interface_disconnect_result, data,
++			interface);
++
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++	}
++
++	return ret;
++}
++
++struct interface_p2p_find_data {
++	GSupplicantInterface *interface;
++	char *path;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantP2PFindParams *p2p_find_params;
++	void *user_data;
++};
++
++static void interface_p2p_find_result(const char *error,
++					DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_find_data *data = user_data;
++	int err = 0;
++
++	if (error != NULL) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++	if (interface_exists(data->interface, data->path)) {
++		if (!data->interface->ready)
++			err = -ENOLINK;
++		if (!err) {
++			data->interface->p2p_finding = true;
++		}
++	}
++
++	if (data->callback != NULL)
++		data->callback(err, data->interface, data->user_data);
++
++	g_free(data->path);
++	dbus_free(data);
++}
++
++static void interface_p2p_find_params(DBusMessageIter *iter, void *user_data)
++{
++	DBusMessageIter dict;
++	struct interface_p2p_find_data *data = user_data;
++	int timeout = 0;
++	char *disc_type = "social";
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	if (data && data->p2p_find_params) {
++		GSupplicantP2PFindParams* params = data->p2p_find_params;
++		supplicant_dbus_dict_append_basic(&dict, "Timeout",
++												DBUS_TYPE_INT32, &params->timeout);
++
++		if(params->disc_type == G_SUPPLICANT_P2P_FIND_START_WITH_FULL) {
++			disc_type = "start_with_full";
++		}
++		else if(params->disc_type == G_SUPPLICANT_P2P_FIND_PROGRESSIVE) {
++			disc_type = "progressive";
++		}
++		else {
++			disc_type = "social";
++		}
++
++		supplicant_dbus_dict_append_basic(&dict, "DiscoveryType",
++											DBUS_TYPE_STRING, &disc_type);
++
++		if (params->frequency != 0)
++			supplicant_dbus_dict_append_basic(&dict, "Frequency",
++											  DBUS_TYPE_INT32, &params->frequency);
++
++		if (params->seek_array != NULL){
++
++			DBusMessageIter entry;
++			DBusMessageIter value;
++			DBusMessageIter array;
++			const char** seek = params->seek_array;
++			const char* key = "Seek";
++
++			dbus_message_iter_open_container(&dict, DBUS_TYPE_DICT_ENTRY, NULL, &entry);
++			dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING, &key);
++
++			dbus_message_iter_open_container(&entry, DBUS_TYPE_VARIANT,
++											 DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING, &value);
++			dbus_message_iter_open_container(&value, DBUS_TYPE_ARRAY, DBUS_TYPE_STRING_AS_STRING, &array);
++
++			// Append items from null terminated array
++			while(*seek)
++			{
++				dbus_message_iter_append_basic(&array, DBUS_TYPE_STRING, seek);
++				seek++;
++			}
++
++			dbus_message_iter_close_container(&value, &array);
++			dbus_message_iter_close_container(&entry, &value);
++
++			dbus_message_iter_close_container(&dict, &entry);
++		}
++	} else
++		supplicant_dbus_dict_append_basic(&dict, "Timeout",
++					DBUS_TYPE_INT32, &timeout);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++int g_supplicant_interface_p2p_find(GSupplicantInterface *interface,
++				GSupplicantP2PFindParams *find_data,
++				GSupplicantInterfaceCallback callback,
++							void *user_data)
++{
++	struct interface_p2p_find_data *data;
++	int ret;
++
++	if (interface == NULL)
++		return -EINVAL;
++
++	if (system_available == FALSE)
++		return -EFAULT;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (data == NULL)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->callback = callback;
++	data->user_data = user_data;
++	data->p2p_find_params = find_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++										SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Find",
++										interface_p2p_find_params, interface_p2p_find_result, data, NULL);
++
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++	}
++
++	return ret;
++}
++
++bool g_supplicant_interface_is_p2p_finding(GSupplicantInterface *interface)
++{
++	if (!interface)
++		return false;
++
++	return interface->p2p_finding;
++}
++
++int g_supplicant_interface_p2p_stop_find(GSupplicantInterface *interface)
++{
++	if (!interface->p2p_finding)
++		return 0;
++
++	SUPPLICANT_DBG("");
++
++	interface->p2p_finding = false;
++
++	return supplicant_dbus_method_call(interface->path,
++		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "StopFind",
++		NULL, NULL, NULL, NULL);
++}
++
++static void interface_p2p_connect_result(const char *error,
++					DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	int err = 0;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		SUPPLICANT_DBG("error: %s", error);
++		err = parse_supplicant_error(iter);
++	}
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	g_free(data->path);
++	g_free(data->peer->wps_pin);
++	g_free(data->peer->wps_method);
++	g_free(data->peer->path);
++	g_free(data->peer);
++	g_free(data);
++}
++
++static void interface_p2p_connect_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_connect_data *data = user_data;
++	const char *wps = data->peer->wps_method?data->peer->wps_method:"pbc";
++	DBusMessageIter dict;
++	int go_intent = 7;
++
++	SUPPLICANT_DBG("");
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	if (data->peer->master)
++		go_intent = 15;
++
++	if (data->peer->wps_method==NULL && data->peer->wps_pin)
++		wps = "pin";
++
++	supplicant_dbus_dict_append_basic(&dict, "peer",
++				DBUS_TYPE_OBJECT_PATH, &data->peer->path);
++	supplicant_dbus_dict_append_basic(&dict, "wps_method",
++				DBUS_TYPE_STRING, &wps);
++	if (data->peer->wps_pin) {
++		supplicant_dbus_dict_append_basic(&dict, "pin",
++				DBUS_TYPE_STRING, &data->peer->wps_pin);
++	}
++
++	supplicant_dbus_dict_append_basic(&dict, "persistent",
++				DBUS_TYPE_BOOLEAN, &data->peer->persistent);
++
++	if (data->peer->go_intent)
++		go_intent = data->peer->go_intent;
++
++	supplicant_dbus_dict_append_basic(&dict, "go_intent",
++				DBUS_TYPE_INT32, &go_intent);
++
++	supplicant_dbus_dict_append_basic(&dict, "join",
++				DBUS_TYPE_BOOLEAN, &data->peer->join);
++
++	supplicant_dbus_dict_append_basic(&dict, "authorize_only",
++				DBUS_TYPE_BOOLEAN, &data->peer->authorize_only);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++int g_supplicant_interface_p2p_connect(GSupplicantInterface *interface,
++					GSupplicantPeerParams *peer_params,
++					GSupplicantInterfaceCallback callback,
++					void *user_data)
++{
++	struct interface_connect_data *data;
++	int ret;
++
++	SUPPLICANT_DBG("");
++
++	if (!interface->p2p_support)
++		return -ENOTSUP;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->peer = peer_params;
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Connect",
++		interface_p2p_connect_params, interface_p2p_connect_result,
++		data, interface);
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++
++int g_supplicant_interface_p2p_disconnect(GSupplicantInterface *interface,
++					GSupplicantPeerParams *peer_params)
++{
++	GSupplicantPeer *peer;
++	int count = 0;
++	GSList *list;
++
++	SUPPLICANT_DBG("");
++
++	if (!interface->p2p_support)
++		return -ENOTSUP;
++
++	peer = g_hash_table_lookup(interface->peer_table, peer_params->path);
++	if (!peer)
++		return -ENODEV;
++
++	for (list = peer->groups; list; list = list->next, count++) {
++		const char *group_obj_path = list->data;
++		GSupplicantInterface *g_interface;
++		GSupplicantGroup *group;
++
++		group = g_hash_table_lookup(group_mapping, group_obj_path);
++		if (!group || !group->interface)
++			continue;
++
++		g_interface = group->interface;
++		supplicant_dbus_method_call(g_interface->path,
++				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++				"Disconnect", NULL, NULL, NULL, g_interface);
++	}
++
++	if (count == 0 && peer->current_group_iface) {
++		supplicant_dbus_method_call(peer->current_group_iface->path,
++				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++				"Disconnect", NULL, NULL, NULL,
++				peer->current_group_iface->path);
++	}
++
++	peer->current_group_iface = NULL;
++
++	return -EINPROGRESS;
++}
++
++static void interface_p2p_disconnect_result(const char *error,
++													DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int err = 0;
++
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	dbus_free(data);
++}
++int g_supplicant_interface_p2p_group_disconnect(GSupplicantInterface *interface,
++													GSupplicantInterfaceCallback callback,
++													void *user_data)
++{
++	struct interface_data *data;
++	int ret;
++
++	if (!interface)
++		return -EINVAL;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++
++	SUPPLICANT_DBG("interface->path : %s\n", interface->path);
++
++	ret = supplicant_dbus_method_call(interface->path,
++									SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++									"Disconnect", NULL,
++									interface_p2p_disconnect_result, data, NULL);
++
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
+ }
+ 
+-static void add_network_security_peap(DBusMessageIter *dict,
+-					GSupplicantSSID *ssid)
++static void interface_p2p_client_remove_result(const char *error,
++							DBusMessageIter *iter, void *user_data)
+ {
+-	char *phase2_auth;
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++	}
++}
+ 
+-	/*
+-	 * For PEAP/TTLS, we at least need
+-	 *              The authority certificate
+-	 *              The 2nd phase authentication method
+-	 *              The 2nd phase passphrase
+-	 *
+-	 * The Client certificate is optional although strongly recommended
+-	 * When setting it, we need in addition
+-	 *              The Client private key file
+-	 *              The Client private key file password
+-	 */
+-	if (!ssid->passphrase)
+-		return;
++static void interface_p2p_client_remove_params(DBusMessageIter *iter, void *user_data)
++{
++	char* peer_path = user_data;
++	DBusMessageIter dict;
+ 
+-	if (!ssid->phase2_auth)
+-		return;
++	supplicant_dbus_dict_open(iter, &dict);
++	supplicant_dbus_dict_append_basic(&dict, "peer",
++					DBUS_TYPE_OBJECT_PATH, &peer_path);
++	supplicant_dbus_dict_close(iter, &dict);
++}
+ 
+-	if (ssid->client_cert_path) {
+-		if (!ssid->private_key_path)
+-			return;
++int g_supplicant_interface_p2p_client_remove(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++					char* peer_path)
++{
++	int ret;
+ 
+-		if (!ssid->private_key_passphrase)
+-			return;
++	if (!interface)
++		return -EINVAL;
+ 
+-		supplicant_dbus_dict_append_basic(dict, "client_cert",
+-						DBUS_TYPE_STRING,
+-						&ssid->client_cert_path);
++	SUPPLICANT_DBG("interface->path : %s\n", interface->path);
+ 
+-		supplicant_dbus_dict_append_basic(dict, "private_key",
+-						DBUS_TYPE_STRING,
+-						&ssid->private_key_path);
++	ret = supplicant_dbus_method_call(interface->path,
++									SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++									"RemoveClient", interface_p2p_client_remove_params,
++									interface_p2p_client_remove_result, (void*) peer_path, NULL);
+ 
+-		supplicant_dbus_dict_append_basic(dict, "private_key_passwd",
+-						DBUS_TYPE_STRING,
+-						&ssid->private_key_passphrase);
++	if (ret < 0) {
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++
++static void interface_p2p_cancel_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int err = 0;
++
++	SUPPLICANT_DBG("");
+ 
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
+ 	}
+ 
+-	if(g_strcmp0(ssid->phase2_auth, "GTC") == 0 && g_strcmp0(ssid->eap, "ttls") == 0)
+-		phase2_auth = g_strdup_printf("autheap=%s", ssid->phase2_auth);
+-	else if (g_str_has_prefix(ssid->phase2_auth, "EAP-")) {
+-		phase2_auth = g_strdup_printf("autheap=%s",
+-					ssid->phase2_auth + strlen("EAP-"));
+-	} else
+-		phase2_auth = g_strdup_printf("auth=%s", ssid->phase2_auth);
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
+ 
+-	supplicant_dbus_dict_append_basic(dict, "password",
+-						DBUS_TYPE_STRING,
+-						&ssid->passphrase);
++	g_free(data->path);
++	dbus_free(data);
++}
+ 
+-	if (ssid->ca_cert_path)
+-		supplicant_dbus_dict_append_basic(dict, "ca_cert",
+-						DBUS_TYPE_STRING,
+-						&ssid->ca_cert_path);
++int g_supplicant_interface_p2p_cancel(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback,
++				void *user_data)
++{
++	struct interface_data *data;
++	int ret;
+ 
+-	supplicant_dbus_dict_append_basic(dict, "phase2",
+-						DBUS_TYPE_STRING,
+-						&phase2_auth);
++	SUPPLICANT_DBG("");
+ 
+-	g_free(phase2_auth);
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	if (!interface->p2p_support)
++		return -ENOTSUP;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++			SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Cancel",
++			NULL, interface_p2p_cancel_result, data, NULL);
++
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
+ }
+ 
+-static void add_network_security_eap(DBusMessageIter *dict,
+-					GSupplicantSSID *ssid)
++static void interface_p2p_flush_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
+ {
+-	char *eap_value;
++	struct interface_data *data = user_data;
++	int err = 0;
+ 
+-	if (!ssid->eap || !ssid->identity)
+-		return;
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
+ 
+-	if (g_strcmp0(ssid->eap, "tls") == 0) {
+-		add_network_security_tls(dict, ssid);
+-	} else if (g_strcmp0(ssid->eap, "peap") == 0 ||
+-				g_strcmp0(ssid->eap, "ttls") == 0) {
+-		add_network_security_peap(dict, ssid);
+-	} else
+-		return;
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
+ 
+-	eap_value = g_ascii_strup(ssid->eap, -1);
++	dbus_free(data);
++}
++int g_supplicant_interface_p2p_flush(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback,
++				void *user_data)
++{
++	struct interface_data *data;
++	int ret;
+ 
+-	supplicant_dbus_dict_append_basic(dict, "eap",
+-						DBUS_TYPE_STRING,
+-						&eap_value);
+-	supplicant_dbus_dict_append_basic(dict, "identity",
+-						DBUS_TYPE_STRING,
+-						&ssid->identity);
+-	if(ssid->anonymous_identity)
+-		supplicant_dbus_dict_append_basic(dict, "anonymous_identity",
+-						     DBUS_TYPE_STRING,
+-						     &ssid->anonymous_identity);
++	if (!interface)
++		return -EINVAL;
+ 
+-	if(ssid->subject_match)
+-		supplicant_dbus_dict_append_basic(dict, "subject_match",
+-						     DBUS_TYPE_STRING,
+-						     &ssid->subject_match);
++	if (!system_available)
++		return -EFAULT;
+ 
+-	if(ssid->altsubject_match)
+-		supplicant_dbus_dict_append_basic(dict, "altsubject_match",
+-						     DBUS_TYPE_STRING,
+-						     &ssid->altsubject_match);
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
+ 
+-	if(ssid->domain_suffix_match)
+-		supplicant_dbus_dict_append_basic(dict, "domain_suffix_match",
+-						     DBUS_TYPE_STRING,
+-						     &ssid->domain_suffix_match);
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
+ 
+-	if(ssid->domain_match)
+-		supplicant_dbus_dict_append_basic(dict, "domain_match",
+-						     DBUS_TYPE_STRING,
+-						     &ssid->domain_match);
++	ret = supplicant_dbus_method_call(interface->path,
++					SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Flush",
++					NULL, interface_p2p_flush_result, data, NULL);
+ 
+-	g_free(eap_value);
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++static void interface_p2p_reject_peer_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_reject_data *data = user_data;
++	int err = 0;
++
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	dbus_free(data);
+ }
+ 
+-static void add_network_security_ciphers(DBusMessageIter *dict,
+-						GSupplicantSSID *ssid)
++static void interface_p2p_reject_params(DBusMessageIter *iter, void *user_data)
+ {
+-	unsigned int p_cipher, g_cipher, i;
+-	char *pairwise, *group;
+-	char *pair_ciphers[4];
+-	char *group_ciphers[5];
++	struct interface_reject_data *data = user_data;
+ 
+-	p_cipher = ssid->pairwise_cipher;
+-	g_cipher = ssid->group_cipher;
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
++							&data->peer->path);
++}
++struct interface_p2p_sd_data {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantP2PSDParams *p2p_sd_params;
++	void *user_data;
++};
++static void interface_p2p_sd_request_params(DBusMessageIter *iter, void *user_data)
++{
++	DBusMessageIter dict;
++	struct interface_p2p_sd_data *data = user_data;
+ 
+-	if (p_cipher == 0 && g_cipher == 0)
+-		return;
++	supplicant_dbus_dict_open(iter, &dict);
++
++	if (data && data->p2p_sd_params) {
++		GSupplicantP2PSDParams* params = data->p2p_sd_params;
++
++		if(params->peer)
++			supplicant_dbus_dict_append_basic(&dict, "peer_object",
++												DBUS_TYPE_OBJECT_PATH, &params->peer);
++
++		if(params->service_type)
++			supplicant_dbus_dict_append_basic(&dict, "service_type",
++												DBUS_TYPE_STRING, &params->service_type);
++
++		if(params->version > 0)
++			supplicant_dbus_dict_append_basic(&dict, "version",
++												DBUS_TYPE_INT32, &params->version);
++
++		if(params->desc)
++			supplicant_dbus_dict_append_basic(&dict, "service",
++												DBUS_TYPE_STRING, &params->desc);
++
++		if(params->query_len > 0)
++			supplicant_dbus_dict_append_fixed_array(&dict, "tlv",
++														DBUS_TYPE_BYTE, &params->query, params->query_len);
++		if(params->service_info != NULL)
++			supplicant_dbus_dict_append_basic(&dict, "service_info",
++												DBUS_TYPE_STRING, &params->service_info);
++		if(params->service_transaction_id != 0)
++			supplicant_dbus_dict_append_basic(&dict, "service_transaction_id",
++												DBUS_TYPE_BYTE, &params->service_transaction_id);
++	}
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++static void interface_p2p_sd_request_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_sd_data *data = user_data;
++	int err = 0;
++	dbus_uint64_t ref = 0;
++
++	if (error != NULL) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++
++	if (data->callback != NULL)
++	{
++		if(err == 0) {
++			dbus_message_iter_get_basic(iter, &ref);
++			((GSupplicantInterfaceCallbackWithData)data->callback)(0, data->interface, data->user_data, &ref);
++		} else {
++			((GSupplicantInterfaceCallbackWithData)data->callback)(err, data->interface, data->user_data, NULL);
++		}
++	}
+ 
+-	i = 0;
++	dbus_free(data);
++}
++int g_supplicant_interface_p2p_sd_request(GSupplicantInterface *interface,
++				GSupplicantP2PSDParams *sd_data,
++				GSupplicantInterfaceCallbackWithData callback,
++				void *user_data)
++{
++	struct interface_p2p_sd_data *data;
++	int ret;
+ 
+-	if (p_cipher & G_SUPPLICANT_PAIRWISE_CCMP)
+-		pair_ciphers[i++] = "CCMP";
++	if (interface == NULL)
++		return -EINVAL;
+ 
+-	if (p_cipher & G_SUPPLICANT_PAIRWISE_TKIP)
+-		pair_ciphers[i++] = "TKIP";
++	if (system_available == FALSE)
++		return -EFAULT;
+ 
+-	if (p_cipher & G_SUPPLICANT_PAIRWISE_NONE)
+-		pair_ciphers[i++] = "NONE";
++	data = dbus_malloc0(sizeof(*data));
++	if (data == NULL)
++		return -ENOMEM;
+ 
+-	pair_ciphers[i] = NULL;
++	data->interface = interface;
++	data->callback = (GSupplicantInterfaceCallback) callback;
++	data->user_data = user_data;
++	data->p2p_sd_params = sd_data;
+ 
+-	i = 0;
++	ret = supplicant_dbus_method_call(interface->path,
++										SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ServiceDiscoveryRequest",
++										interface_p2p_sd_request_params, interface_p2p_sd_request_result, data, NULL);
+ 
+-	if (g_cipher & G_SUPPLICANT_GROUP_CCMP)
+-		group_ciphers[i++] = "CCMP";
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
++	}
+ 
+-	if (g_cipher & G_SUPPLICANT_GROUP_TKIP)
+-		group_ciphers[i++] = "TKIP";
++	return -EINPROGRESS;
++}
++static void interface_p2p_sd_cancel_request_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_sd_data *data = user_data;
++	int err = 0;
+ 
+-	if (g_cipher & G_SUPPLICANT_GROUP_WEP104)
+-		group_ciphers[i++] = "WEP104";
++	if (error != NULL) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
+ 
+-	if (g_cipher & G_SUPPLICANT_GROUP_WEP40)
+-		group_ciphers[i++] = "WEP40";
++	if (data->callback != NULL)
++	{
++		data->callback(err, data->interface, data->user_data);
++	}
+ 
+-	group_ciphers[i] = NULL;
++	dbus_free(data);
++}
+ 
+-	pairwise = g_strjoinv(" ", pair_ciphers);
+-	group = g_strjoinv(" ", group_ciphers);
++static void interface_p2p_sd_cancel_request_params(DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_sd_data *data = user_data;
++	if (data && data->p2p_sd_params) {
++		uint64_t *request_id = (uint64_t*)data->p2p_sd_params;
++		dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT64, request_id);
++	}
++}
++struct p2p_service_data {
++	bool registration;
++	GSupplicantInterface *interface;
++	GSupplicantP2PServiceParams *service;
++	GSupplicantInterfaceCallback callback;
++	void *user_data;
++};
+ 
+-	SUPPLICANT_DBG("cipher %s %s", pairwise, group);
++static void interface_p2p_service_result(const char *error,
++					DBusMessageIter *iter, void *user_data)
++{
++	struct p2p_service_data *data = user_data;
++	int result = 0;
+ 
+-	supplicant_dbus_dict_append_basic(dict, "pairwise",
+-						DBUS_TYPE_STRING,
+-						&pairwise);
+-	supplicant_dbus_dict_append_basic(dict, "group",
+-						DBUS_TYPE_STRING,
+-						&group);
++	SUPPLICANT_DBG("%s result - %s", data->registration ?
++				"Registration" : "Deletion",
++				error ? error : "Success");
++	if (error)
++		result = -EINVAL;
+ 
+-	g_free(pairwise);
+-	g_free(group);
++	if (data->callback)
++		data->callback(result, data->interface, data->user_data);
++
++	g_free(data->service->query);
++	g_free(data->service->response);
++	g_free(data->service->service);
++	g_free(data->service->wfd_ies);
++	g_free(data->service);
++	dbus_free(data);
+ }
+ 
+-static void add_network_security_proto(DBusMessageIter *dict,
+-						GSupplicantSSID *ssid)
++static void interface_p2p_service_params(DBusMessageIter *iter,
++							void *user_data)
+ {
+-	unsigned int protocol, i;
+-	char *proto;
+-	char *protos[3];
++	struct p2p_service_data *data = user_data;
++	GSupplicantP2PServiceParams *service;
++	DBusMessageIter dict;
++	const char *type;
+ 
+-	protocol = ssid->protocol;
++	SUPPLICANT_DBG("");
+ 
+-	if (protocol == 0)
+-		return;
++	service = data->service;
+ 
+-	i = 0;
++	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	if (protocol & G_SUPPLICANT_PROTO_RSN)
+-		protos[i++] = "RSN";
++	if (service->query && service->response) {
++		type = "bonjour";
++		supplicant_dbus_dict_append_basic(&dict, "service_type",
++						DBUS_TYPE_STRING, &type);
++		supplicant_dbus_dict_append_fixed_array(&dict, "query",
++					DBUS_TYPE_BYTE, &service->query,
++					service->query_length);
++		supplicant_dbus_dict_append_fixed_array(&dict, "response",
++					DBUS_TYPE_BYTE, &service->response,
++					service->response_length);
++	} else if (service->version && service->service) {
++		type = "upnp";
++		supplicant_dbus_dict_append_basic(&dict, "service_type",
++						DBUS_TYPE_STRING, &type);
++		supplicant_dbus_dict_append_basic(&dict, "version",
++					DBUS_TYPE_INT32, &service->version);
++		supplicant_dbus_dict_append_basic(&dict, "service",
++					DBUS_TYPE_STRING, &service->service);
++	} else if (service->adv_id > 0) {
++		type = "asp";
+ 
+-	if (protocol & G_SUPPLICANT_PROTO_WPA)
+-		protos[i++] = "WPA";
++		supplicant_dbus_dict_append_basic(&dict, "service_type",
++						DBUS_TYPE_STRING, &type);
+ 
+-	protos[i] = NULL;
++		if (service->service)
++			supplicant_dbus_dict_append_basic(&dict, "service",
++					DBUS_TYPE_STRING, &service->service);
+ 
+-	proto = g_strjoinv(" ", protos);
++		if(service->adv_id != 0)
++			supplicant_dbus_dict_append_basic(&dict, "adv_id",
++			             DBUS_TYPE_UINT32, &service->adv_id);
+ 
+-	SUPPLICANT_DBG("proto %s", proto);
++		supplicant_dbus_dict_append_basic(&dict, "auto_accept",
++		                                  DBUS_TYPE_UINT32, &service->auto_accept);
+ 
+-	supplicant_dbus_dict_append_basic(dict, "proto",
+-						DBUS_TYPE_STRING,
+-						&proto);
++		supplicant_dbus_dict_append_basic(&dict, "service_state",
++		                                  DBUS_TYPE_BYTE, &service->service_state);
+ 
+-	g_free(proto);
+-}
++		supplicant_dbus_dict_append_basic(&dict, "config_method",
++		                                  DBUS_TYPE_UINT16, &service->config_method);
+ 
+-static void add_network_ieee80211w(DBusMessageIter *dict, GSupplicantSSID *ssid,
+-				   GSupplicantMfpOptions ieee80211w)
+-{
+-	supplicant_dbus_dict_append_basic(dict, "ieee80211w", DBUS_TYPE_UINT32,
+-					  &ieee80211w);
++		if(service->service_info)
++			supplicant_dbus_dict_append_basic(&dict, "service_info",
++							DBUS_TYPE_STRING, &service->service_info);
++	}
++	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-static void add_network_security(DBusMessageIter *dict, GSupplicantSSID *ssid)
++static void interface_p2p_delete_service_params(DBusMessageIter *iter,
++							void *user_data)
+ {
+-	GSupplicantMfpOptions ieee80211w;
+-	char *key_mgmt;
++	struct p2p_service_data *data = user_data;
++	GSupplicantP2PServiceParams *service;
++	DBusMessageIter dict;
++	const char *type;
+ 
+-	switch (ssid->security) {
+-	case G_SUPPLICANT_SECURITY_NONE:
+-		key_mgmt = "NONE";
+-		add_network_security_none(dict);
+-		add_network_security_ciphers(dict, ssid);
+-		break;
+-	case G_SUPPLICANT_SECURITY_UNKNOWN:
+-	case G_SUPPLICANT_SECURITY_WEP:
+-		key_mgmt = "NONE";
+-		add_network_security_wep(dict, ssid);
+-		add_network_security_ciphers(dict, ssid);
+-		break;
+-	case G_SUPPLICANT_SECURITY_PSK:
+-		if (ssid->keymgmt & G_SUPPLICANT_KEYMGMT_SAE) {
+-			if (ssid->keymgmt & G_SUPPLICANT_KEYMGMT_WPA_PSK) {
+-				/*
+-				 * WPA3-Personal transition mode: supports both
+-				 * WPA2-Personal (PSK) and WPA3-Personal (SAE)
+-				 */
+-				key_mgmt = "SAE WPA-PSK";
+-				ieee80211w = G_SUPPLICANT_MFP_OPTIONAL;
+-			} else {
+-				key_mgmt = "SAE";
+-				ieee80211w = G_SUPPLICANT_MFP_REQUIRED;
+-			}
+-			add_network_ieee80211w(dict, ssid, ieee80211w);
+-		} else {
+-			key_mgmt = "WPA-PSK";
+-		}
+-		add_network_security_psk(dict, ssid);
+-		add_network_security_ciphers(dict, ssid);
+-		add_network_security_proto(dict, ssid);
+-		break;
+-	case G_SUPPLICANT_SECURITY_IEEE8021X:
+-		key_mgmt = "WPA-EAP";
+-		add_network_security_eap(dict, ssid);
+-		add_network_security_ciphers(dict, ssid);
+-		add_network_security_proto(dict, ssid);
+-		break;
+-	}
++	SUPPLICANT_DBG("");
+ 
+-	supplicant_dbus_dict_append_basic(dict, "key_mgmt",
+-				DBUS_TYPE_STRING, &key_mgmt);
+-}
++	service = data->service;
+ 
+-static void add_network_mode(DBusMessageIter *dict, GSupplicantSSID *ssid)
+-{
+-	dbus_uint32_t mode;
++	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	switch (ssid->mode) {
+-	case G_SUPPLICANT_MODE_UNKNOWN:
+-	case G_SUPPLICANT_MODE_INFRA:
+-		mode = 0;
+-		break;
+-	case G_SUPPLICANT_MODE_IBSS:
+-		mode = 1;
+-		break;
+-	case G_SUPPLICANT_MODE_MASTER:
+-		mode = 2;
+-		break;
+-	}
++	if (service->query && service->response) {
++		type = "bonjour";
++		supplicant_dbus_dict_append_basic(&dict, "service_type",
++						DBUS_TYPE_STRING, &type);
++		supplicant_dbus_dict_append_fixed_array(&dict, "query",
++					DBUS_TYPE_BYTE, &service->query,
++					service->query_length);
++		supplicant_dbus_dict_append_fixed_array(&dict, "response",
++					DBUS_TYPE_BYTE, &service->response,
++					service->response_length);
++	} else if (service->version && service->service) {
++		type = "upnp";
++		supplicant_dbus_dict_append_basic(&dict, "service_type",
++						DBUS_TYPE_STRING, &type);
++		supplicant_dbus_dict_append_basic(&dict, "version",
++					DBUS_TYPE_INT32, &service->version);
++		supplicant_dbus_dict_append_basic(&dict, "service",
++					DBUS_TYPE_STRING, &service->service);
++	} else if (service->adv_id > 0) {
++		type = "asp";
+ 
+-	supplicant_dbus_dict_append_basic(dict, "mode",
+-				DBUS_TYPE_UINT32, &mode);
+-}
++		supplicant_dbus_dict_append_basic(&dict, "service_type",
++						DBUS_TYPE_STRING, &type);
+ 
+-static void interface_add_network_params(DBusMessageIter *iter, void *user_data)
+-{
+-	DBusMessageIter dict;
+-	struct interface_connect_data *data = user_data;
+-	GSupplicantSSID *ssid = data->ssid;
++		if (service->service)
++			supplicant_dbus_dict_append_basic(&dict, "service",
++					DBUS_TYPE_STRING, &service->service);
+ 
+-	supplicant_dbus_dict_open(iter, &dict);
++		if(service->adv_id != 0)
++			supplicant_dbus_dict_append_basic(&dict, "adv_id",
++			             DBUS_TYPE_UINT32, &service->adv_id);
+ 
+-	if (ssid->scan_ssid)
+-		supplicant_dbus_dict_append_basic(&dict, "scan_ssid",
+-					 DBUS_TYPE_UINT32, &ssid->scan_ssid);
++		supplicant_dbus_dict_append_basic(&dict, "auto_accept",
++		                                  DBUS_TYPE_UINT32, &service->auto_accept);
+ 
+-	if (ssid->freq)
+-		supplicant_dbus_dict_append_basic(&dict, "frequency",
+-					 DBUS_TYPE_UINT32, &ssid->freq);
++		supplicant_dbus_dict_append_basic(&dict, "service_state",
++		                                  DBUS_TYPE_BYTE, &service->service_state);
+ 
+-	if (ssid->bgscan)
+-		supplicant_dbus_dict_append_basic(&dict, "bgscan",
+-					DBUS_TYPE_STRING, &ssid->bgscan);
++		supplicant_dbus_dict_append_basic(&dict, "config_method",
++		                                  DBUS_TYPE_UINT16, &service->config_method);
++
++		if(service->service_info)
++			supplicant_dbus_dict_append_basic(&dict, "service_info",
++							DBUS_TYPE_STRING, &service->service_info);
++	}
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++int g_supplicant_interface_p2p_add_service(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback,
++				GSupplicantP2PServiceParams *p2p_service_params,
++				void *user_data)
++{
++	struct p2p_service_data *data;
++	int ret;
++
++	SUPPLICANT_DBG("");
++
++	if (!interface->p2p_support)
++		return -ENOTSUP;
+ 
+-	add_network_mode(&dict, ssid);
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
+ 
+-	add_network_security(&dict, ssid);
++	data->registration = true;
++	data->interface = interface;
++	data->service = p2p_service_params;
++	data->callback = callback;
++	data->user_data = user_data;
+ 
+-	supplicant_dbus_dict_append_fixed_array(&dict, "ssid",
+-					DBUS_TYPE_BYTE, &ssid->ssid,
+-						ssid->ssid_len);
++	ret = supplicant_dbus_method_call(interface->path,
++		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "AddService",
++		interface_p2p_service_params, interface_p2p_service_result,
++		data, interface);
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
++	}
+ 
+-	supplicant_dbus_dict_close(iter, &dict);
++	return -EINPROGRESS;
+ }
+ 
+-static void interface_wps_start_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
++				GSupplicantP2PServiceParams *p2p_service_params)
+ {
+-	struct interface_connect_data *data = user_data;
+-	int err;
++	struct p2p_service_data *data;
++	int ret;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+-	err = 0;
+-	if (error) {
+-		SUPPLICANT_DBG("error: %s", error);
+-		err = parse_supplicant_error(iter);
+-	}
++	if (!interface->p2p_support)
++		return -ENOTSUP;
+ 
+-	if(data->callback)
+-		data->callback(err, data->interface, data->user_data);
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
+ 
+-	g_free(data->path);
+-	g_free(data->ssid);
+-	dbus_free(data);
++	data->interface = interface;
++	data->service = p2p_service_params;
++
++	ret = supplicant_dbus_method_call(interface->path,
++		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "DeleteService",
++		interface_p2p_delete_service_params, interface_p2p_service_result,
++		data, interface);
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
+ }
+ 
+-static void interface_add_wps_params(DBusMessageIter *iter, void *user_data)
++struct interface_p2p_group_add_data {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantP2PGroupAddParams *p2p_group_add_params;
++	void *user_data;
++};
++
++static void interface_p2p_group_add_params(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_connect_data *data = user_data;
+-	GSupplicantSSID *ssid = data->ssid;
+-	const char *role = "enrollee", *type;
+ 	DBusMessageIter dict;
+-
+-	SUPPLICANT_DBG("");
++	struct interface_p2p_group_add_data *data = user_data;
+ 
+ 	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	supplicant_dbus_dict_append_basic(&dict, "Role",
+-						DBUS_TYPE_STRING, &role);
+-
+-	type = "pbc";
+-	if (ssid->pin_wps) {
+-		type = "pin";
+-		supplicant_dbus_dict_append_basic(&dict, "Pin",
+-					DBUS_TYPE_STRING, &ssid->pin_wps);
+-	}
+-
+-	supplicant_dbus_dict_append_basic(&dict, "Type",
+-					DBUS_TYPE_STRING, &type);
+ 
+-	supplicant_dbus_dict_close(iter, &dict);
+-}
++	if (data && data->p2p_group_add_params) {
++		GSupplicantP2PGroupAddParams* params = data->p2p_group_add_params;
+ 
+-static void wps_start(const char *error, DBusMessageIter *iter, void *user_data)
+-{
+-	struct interface_connect_data *data = user_data;
++		if(params->persistent == TRUE) {
++			supplicant_dbus_dict_append_basic(&dict, "persistent",
++												DBUS_TYPE_BOOLEAN, &params->persistent);
++		}
+ 
+-	SUPPLICANT_DBG("");
++		if(params->persistent_group_object != NULL)	{
++			supplicant_dbus_dict_append_basic(&dict, "persistent_group_object",
++												DBUS_TYPE_OBJECT_PATH, &params->persistent_group_object);
++		}
+ 
+-	if (error) {
+-		SUPPLICANT_DBG("error: %s", error);
+-		g_free(data->path);
+-		g_free(data->ssid);
+-		dbus_free(data);
+-		return;
++		if(params->frequency >= 0) {
++			supplicant_dbus_dict_append_basic(&dict, "frequency",
++												DBUS_TYPE_INT32, &params->frequency);
++		}
+ 	}
+ 
+-	supplicant_dbus_method_call(data->interface->path,
+-			SUPPLICANT_INTERFACE ".Interface.WPS", "Start",
+-			interface_add_wps_params,
+-			interface_wps_start_result, data, NULL);
++	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-static void wps_process_credentials(DBusMessageIter *iter, void *user_data)
++static void interface_p2p_group_add_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
+ {
+-	dbus_bool_t credentials = TRUE;
++	struct interface_p2p_group_add_data *data = user_data;
++	int err = 0;
+ 
+-	SUPPLICANT_DBG("");
++	if (error != NULL) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
+ 
+-	dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &credentials);
+-}
++	if (data->callback != NULL)
++		data->callback(err, data->interface, data->user_data);
+ 
++	dbus_free(data);
++}
+ 
+-int g_supplicant_interface_connect(GSupplicantInterface *interface,
+-				GSupplicantSSID *ssid,
++int g_supplicant_interface_p2p_group_add(GSupplicantInterface *interface,
++				GSupplicantP2PGroupAddParams *group_data,
+ 				GSupplicantInterfaceCallback callback,
+ 							void *user_data)
+ {
+-	struct interface_connect_data *data;
+-	struct interface_data *intf_data;
+-	int ret = 0;
+-
+-	SUPPLICANT_DBG("");
++	struct interface_p2p_group_add_data *data;
++	int ret;
+ 
+ 	if (!interface)
+ 		return -EINVAL;
+ 
+-	if (!system_available)
+-		return -EFAULT;
+-
+-	/* TODO: Check if we're already connected and switch */
++	if (!interface->p2p_support)
++		return -ENOTSUP;
+ 
+ 	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
++	if (data == NULL)
+ 		return -ENOMEM;
+ 
+ 	data->interface = interface;
+-	data->path = g_strdup(interface->path);
+ 	data->callback = callback;
+-	data->ssid = ssid;
+ 	data->user_data = user_data;
++	data->p2p_group_add_params = group_data;
+ 
+-	if (ssid->use_wps) {
+-		g_free(interface->wps_cred.key);
+-		memset(&interface->wps_cred, 0,
+-				sizeof(struct _GSupplicantWpsCredentials));
+-
+-		ret = supplicant_dbus_property_set(interface->path,
+-			SUPPLICANT_INTERFACE ".Interface.WPS",
+-			"ProcessCredentials", DBUS_TYPE_BOOLEAN_AS_STRING,
+-			wps_process_credentials, wps_start, data, interface);
+-	} else {
+-		/* By the time there is a request for connect and the network
+-		 * path is not NULL it means that connman has not removed the
+-		 * previous network pointer. This can happen in the case AP
+-		 * deauthenticated client and connman does not remove the
+-		 * previously connected network pointer. This causes supplicant
+-		 * to reallocate the memory for struct wpa_ssid again even if it
+-		 * is the same SSID. This causes memory usage of wpa_supplicnat
+-		 * to go high. The idea here is that if the previously connected
+-		 * network is not removed at the time of next connection attempt
+-		 * check if the network path is not NULL. In case it is non-NULL
+-		 * first remove the network and then once removal is successful, add
+-		 * the network.
+-		 */
+-
+-		if (interface->network_path != NULL) {
+-			g_free(data->path);
+-			dbus_free(data);
+-
+-			/*
+-			 * If this add network is for the same network for
+-			 * which wpa_supplicant already has a profile then do
+-			 * not need to add another profile. Only if the
+-			 * profile that needs to get added is different from
+-			 * what is there in wpa_s delete the current one. A
+-			 * network is identified by its SSID, security_type
+-			 * and passphrase (private passphrase in case security
+-			 * type is 802.11x).
+-			 */
+-			if (compare_network_parameters(interface, ssid)) {
+-				return -EALREADY;
+-			}
+-
+-			intf_data = dbus_malloc0(sizeof(*intf_data));
+-			if (!intf_data)
+-				return -ENOMEM;
+-
+-			intf_data->interface = interface;
+-			intf_data->path = g_strdup(interface->path);
+-			intf_data->callback = callback;
+-			intf_data->ssid = ssid;
+-			intf_data->user_data = user_data;
+-			intf_data->network_remove_in_progress = TRUE;
+-			network_remove(intf_data);
+-		} else {
+-			ret = supplicant_dbus_method_call(interface->path,
+-					SUPPLICANT_INTERFACE ".Interface", "AddNetwork",
+-					interface_add_network_params,
+-					interface_add_network_result, data,
+-					interface);
+-		}
+-        }
++	ret = supplicant_dbus_method_call(interface->path,
++					SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++					"GroupAdd",
++					interface_p2p_group_add_params, interface_p2p_group_add_result,
++					data, NULL);
+ 
+-	if (ret < 0) {
+-		g_free(data->path);
++	if (ret < 0)
+ 		dbus_free(data);
+-		return ret;
+-	}
+ 
+-	return -EINPROGRESS;
++	return ret;
+ }
+ 
+-static void network_remove_result(const char *error,
++struct interface_p2p_wps_data {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantP2PWPSParams *p2p_wps_params;
++	void *user_data;
++};
++
++static void interface_p2p_wps_start_result(const char *error,
+ 				DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_data *data = user_data;
+-	struct interface_connect_data *connect_data;
+-	int result = 0;
++	struct interface_wps_connect_data *data = user_data;
++	int err;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+-	if (error) {
+-		result = -EIO;
++	err = 0;
++	if (error != NULL) {
+ 		SUPPLICANT_DBG("error: %s", error);
+-
+-		if (g_strcmp0("org.freedesktop.DBus.Error.UnknownMethod",
+-						error) == 0)
+-			result = -ECONNABORTED;
++		err = parse_supplicant_error(iter);
+ 	}
+ 
+-	g_free(data->interface->network_path);
+-	data->interface->network_path = NULL;
+-
+-	remove_network_information(data->interface);
+-
+-	if (data->network_remove_in_progress == TRUE) {
+-		data->network_remove_in_progress = FALSE;
+-		connect_data = dbus_malloc0(sizeof(*connect_data));
+-		if (!connect_data)
+-			return;
+-
+-		connect_data->interface = data->interface;
+-		connect_data->path = g_strdup(data->path);
+-		connect_data->callback = data->callback;
+-		connect_data->ssid = data->ssid;
+-		connect_data->user_data = data->user_data;
+-
+-		supplicant_dbus_method_call(data->interface->path,
+-			SUPPLICANT_INTERFACE ".Interface", "AddNetwork",
+-			interface_add_network_params,
+-			interface_add_network_result, connect_data,
+-			connect_data->interface);
+-	} else {
+-		if (data->callback)
+-			data->callback(result, data->interface, data->user_data);
++	if (error != NULL) {
++		if (data->callback != NULL)
++			data->callback(err, data->interface, data->user_data);
+ 	}
+-	g_free(data->path);
++
++	g_free(data->ssid);
+ 	dbus_free(data);
+ }
+ 
+-static void network_remove_params(DBusMessageIter *iter, void *user_data)
++static void interface_p2p_wps_start(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_data *data = user_data;
+-	const char *path = data->interface->network_path;
++	struct interface_p2p_wps_data *data = user_data;
++	GSupplicantP2PWPSParams *params = data->p2p_wps_params;
++
++	DBusMessageIter dict;
++
++	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	SUPPLICANT_DBG("path %s", path);
++	supplicant_dbus_dict_append_basic(&dict, "Role",
++											DBUS_TYPE_STRING, &params->role);
+ 
+-	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH, &path);
+-}
++	supplicant_dbus_dict_append_basic(&dict, "Type",
++											DBUS_TYPE_STRING, &params->type);
+ 
+-static int network_remove(struct interface_data *data)
+-{
+-	GSupplicantInterface *interface = data->interface;
++	if (params->pin != NULL) {
++		supplicant_dbus_dict_append_basic(&dict, "Pin",
++												DBUS_TYPE_STRING, &params->pin);
++	}
+ 
+-	SUPPLICANT_DBG("");
++	if(params->p2p_dev_addr != NULL) {
++		unsigned char *dev_addr = g_try_malloc(6);
++		string_to_byte(params->p2p_dev_addr, dev_addr);
++		supplicant_dbus_dict_append_fixed_array(&dict, "P2PDeviceAddress", DBUS_TYPE_BYTE, &dev_addr, 6);
++		g_free(dev_addr);
++	}
+ 
+-	return supplicant_dbus_method_call(interface->path,
+-			SUPPLICANT_INTERFACE ".Interface", "RemoveNetwork",
+-			network_remove_params, network_remove_result, data,
+-			interface);
++	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-static void interface_disconnect_result(const char *error,
+-				DBusMessageIter *iter, void *user_data)
++
++int g_supplicant_interface_p2p_wps_start(GSupplicantInterface *interface,
++													GSupplicantP2PWPSParams *wps_data,
++													GSupplicantInterfaceCallback callback,
++													void *user_data)
+ {
+-	struct interface_data *data = user_data;
+-	int result = 0;
++	struct interface_p2p_wps_data *data;
++	int ret;
+ 
+-	SUPPLICANT_DBG("");
++	if (interface == NULL)
++		return -EINVAL;
+ 
+-	if (error) {
+-		result = -EIO;
+-		SUPPLICANT_DBG("error: %s", error);
++	if (system_available == FALSE)
++		return -EFAULT;
+ 
+-		if (g_strcmp0("org.freedesktop.DBus.Error.UnknownMethod",
+-						error) == 0)
+-			result = -ECONNABORTED;
+-	}
++	data = dbus_malloc0(sizeof(*data));
++	if (data == NULL)
++		return -ENOMEM;
+ 
+-	/* If we are disconnecting from previous WPS successful
+-	 * association. i.e.: it did not went through AddNetwork,
+-	 * and interface->network_path was never set. */
+-	if (!data->interface->network_path) {
+-		if (data->callback)
+-			data->callback(result, data->interface,
+-							data->user_data);
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++	data->p2p_wps_params = wps_data;
+ 
+-		g_free(data->path);
+-		dbus_free(data);
+-		return;
+-	}
++	SUPPLICANT_DBG("interface->path : %s\n", interface->path);
+ 
+-	if (result < 0 && data->callback) {
+-		data->callback(result, data->interface, data->user_data);
+-		data->callback = NULL;
+-	}
++	ret = supplicant_dbus_method_call(interface->path,
++										SUPPLICANT_INTERFACE ".Interface.WPS", "Start",
++										interface_p2p_wps_start, interface_p2p_wps_start_result, data, NULL);
+ 
+-	if (result != -ECONNABORTED) {
+-		if (network_remove(data) < 0) {
+-			g_free(data->path);
+-			dbus_free(data);
+-		}
+-	} else {
+-		g_free(data->path);
++	if (ret < 0) {
+ 		dbus_free(data);
++		return ret;
+ 	}
++
++	return -EINPROGRESS;
+ }
+ 
+-int g_supplicant_interface_disconnect(GSupplicantInterface *interface,
+-					GSupplicantInterfaceCallback callback,
+-							void *user_data)
++struct interface_p2p_persistent_data {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	GSupplicantSSID *ssid;
++	void *user_data;
++};
++
++static void interface_p2p_remove_persistent_group_params(DBusMessageIter *iter, void *user_data)
+ {
+-	struct interface_data *data;
+-	int ret;
++	struct interface_p2p_persistent_data *data = user_data;
++	const char *path = data->user_data;
+ 
+-	SUPPLICANT_DBG("");
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH, &path);
++}
+ 
+-	if (!interface)
++int g_supplicant_interface_p2p_remove_persistent_group(GSupplicantInterface *interface,
++																		void *user_data)
++{
++	struct interface_p2p_persistent_data *data;
++	int ret;
++
++	if (interface == NULL)
+ 		return -EINVAL;
+ 
+-	if (!system_available)
++	if (system_available == FALSE)
+ 		return -EFAULT;
+ 
+ 	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
++	if (data == NULL)
+ 		return -ENOMEM;
+ 
+ 	data->interface = interface;
+-	data->path = g_strdup(interface->path);
+-	data->callback = callback;
+ 	data->user_data = user_data;
+ 
+ 	ret = supplicant_dbus_method_call(interface->path,
+-			SUPPLICANT_INTERFACE ".Interface", "Disconnect",
+-			NULL, interface_disconnect_result, data,
+-			interface);
+-
++										SUPPLICANT_INTERFACE ".Interface.P2PDevice", "RemovePersistentGroup",
++										interface_p2p_remove_persistent_group_params,
++										NULL, data, NULL);
+ 	if (ret < 0) {
+-		g_free(data->path);
+ 		dbus_free(data);
++		return ret;
+ 	}
+ 
+-	return ret;
++	return -EINPROGRESS;
+ }
+ 
+-static void interface_p2p_find_result(const char *error,
+-					DBusMessageIter *iter, void *user_data)
++static void remove_quote(char *str)
+ {
+-	struct interface_scan_data *data = user_data;
+-	int err = 0;
++	int len = strlen(str);
++	int i=0;
+ 
+-	SUPPLICANT_DBG("error %s", error);
++	for(i=0; i<len-2; i++) {
++		str[i] = str[i+1];
++	}
++	str[len-2] = '\0';
++}
+ 
+-	if (error)
+-		err = -EIO;
++int g_supplicant_interface_p2p_remove_all_persistent_groups(GSupplicantInterface *interface)
++{
++	int ret;
+ 
+-	if (interface_exists(data->interface, data->path)) {
+-		if (!data->interface->ready)
+-			err = -ENOLINK;
+-		if (!err)
+-			data->interface->p2p_finding = true;
++	if (interface == NULL)
++		return -EINVAL;
++
++	SUPPLICANT_DBG("interface path : %s", interface->path);
++
++	if (system_available == FALSE)
++		return -EFAULT;
++
++	ret = supplicant_dbus_method_call(interface->path,
++						SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++						"RemoveAllPersistentGroups",
++						NULL, NULL, NULL, NULL);
++	if (ret < 0) {
++		return ret;
+ 	}
+ 
+-	if (data->callback)
++	return -EINPROGRESS;
++}
++
++static void interface_p2p_add_persistent_group_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_group_add_data *data = user_data;
++	int err = 0;
++
++	if (error != NULL) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++
++	if (data->callback != NULL)
+ 		data->callback(err, data->interface, data->user_data);
+ 
+-	g_free(data->path);
+ 	dbus_free(data);
+ }
+ 
+-static void interface_p2p_find_params(DBusMessageIter *iter, void *user_data)
++static void interface_p2p_add_persistent_group_params(DBusMessageIter *iter, void *user_data)
+ {
+ 	DBusMessageIter dict;
++	struct interface_p2p_persistent_data *data = user_data;
++	GSupplicantSSID *ssid = data->ssid;
++	dbus_uint32_t disabled=2;
++	const char *auth_alg = "OPEN";
+ 
+ 	supplicant_dbus_dict_open(iter, &dict);
++
++	supplicant_dbus_dict_append_basic(&dict, "mode", DBUS_TYPE_UINT32, &ssid->mode);
++
++	supplicant_dbus_dict_append_basic(&dict, "disabled", DBUS_TYPE_UINT32, &disabled);
++
++	supplicant_dbus_dict_append_basic(&dict, "auth_alg", DBUS_TYPE_STRING, &auth_alg);
++
++	supplicant_dbus_dict_append_basic(&dict, "bssid", DBUS_TYPE_STRING, &ssid->bssid);
++
++	supplicant_dbus_dict_append_fixed_array(&dict, "ssid",
++						DBUS_TYPE_BYTE, &ssid->ssid, ssid->ssid_len);
++
++	if(ssid->passphrase != NULL && ssid->passphrase[0] == '\"') {
++		char *passphrase = g_strdup(ssid->passphrase);
++		remove_quote(passphrase);
++		g_free(ssid->passphrase);
++		ssid->passphrase = passphrase;
++	}
++
++	add_network_security(&dict, ssid);
++
+ 	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-int g_supplicant_interface_p2p_find(GSupplicantInterface *interface,
+-					GSupplicantInterfaceCallback callback,
+-							void *user_data)
++int g_supplicant_interface_p2p_add_persistent_group(GSupplicantInterface *interface,
++							GSupplicantSSID *ssid, void *user_data)
+ {
+-	struct interface_scan_data *data;
++	struct interface_p2p_persistent_data *data;
+ 	int ret;
+ 
+-	if (!interface->p2p_support)
+-		return -ENOTSUP;
++	if (interface == NULL)
++		return -EINVAL;
+ 
+-	ret = interface_ready_to_scan(interface);
+-	if (ret && ret != -EALREADY)
+-		return ret;
++	if (system_available == FALSE)
++		return -EFAULT;
+ 
+ 	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
++	if (data == NULL)
+ 		return -ENOMEM;
+ 
+ 	data->interface = interface;
+-	data->path = g_strdup(interface->path);
+-	data->callback = callback;
++	data->ssid = ssid;
+ 	data->user_data = user_data;
++	data->callback = NULL;
+ 
+ 	ret = supplicant_dbus_method_call(interface->path,
+-			SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Find",
+-			interface_p2p_find_params, interface_p2p_find_result,
+-			data, interface);
++					SUPPLICANT_INTERFACE ".Interface.P2PDevice", "AddPersistentGroup",
++					interface_p2p_add_persistent_group_params,
++					interface_p2p_add_persistent_group_result, data, NULL);
+ 	if (ret < 0) {
+-		g_free(data->path);
+ 		dbus_free(data);
++		return ret;
+ 	}
+ 
+-	return ret;
+-}
+-
+-bool g_supplicant_interface_is_p2p_finding(GSupplicantInterface *interface)
+-{
+-	if (!interface)
+-		return false;
+-
+-	return interface->p2p_finding;
++	return -EINPROGRESS;
+ }
+ 
+-int g_supplicant_interface_p2p_stop_find(GSupplicantInterface *interface)
++static void interface_p2p_persistent_group_add_params(DBusMessageIter *iter,
++							void *user_data)
+ {
+-	if (!interface->p2p_finding)
+-		return 0;
++	DBusMessageIter dict;
++	struct interface_connect_data *data = user_data;
++	GSupplicantInterface *interface = data->interface;
+ 
+-	SUPPLICANT_DBG("");
++	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	interface->p2p_finding = false;
++	supplicant_dbus_dict_append_basic(&dict, "persistent_group_object",
++						DBUS_TYPE_OBJECT_PATH, &interface->network_path);
+ 
+-	return supplicant_dbus_method_call(interface->path,
+-		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "StopFind",
+-		NULL, NULL, NULL, NULL);
++	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-static void interface_p2p_connect_result(const char *error,
+-					DBusMessageIter *iter, void *user_data)
++static void interface_p2p_persistent_group_add_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
+ {
+ 	struct interface_connect_data *data = user_data;
+-	int err = 0;
+-
+-	SUPPLICANT_DBG("");
++	int err;
+ 
++	err = 0;
+ 	if (error) {
+-		SUPPLICANT_DBG("error: %s", error);
++		SUPPLICANT_DBG("Group add error %s", error);
+ 		err = parse_supplicant_error(iter);
+ 	}
+ 
+ 	if (data->callback)
+ 		data->callback(err, data->interface, data->user_data);
+ 
+-	g_free(data->path);
+-	g_free(data->peer->wps_pin);
+-	g_free(data->peer->path);
+-	g_free(data->peer);
+-	g_free(data);
++	dbus_free(data);
+ }
+ 
+-static void interface_p2p_connect_params(DBusMessageIter *iter, void *user_data)
++static void interface_p2p_persistent_group_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
+ {
+ 	struct interface_connect_data *data = user_data;
+-	const char *wps = "pbc";
+-	DBusMessageIter dict;
+-	int go_intent = 7;
++	GSupplicantInterface *interface = data->interface;
++	const char *path = NULL;
++	int err;
+ 
+-	SUPPLICANT_DBG("");
++	if (error)
++		goto error;
+ 
+-	supplicant_dbus_dict_open(iter, &dict);
++	dbus_message_iter_get_basic(iter, &path);
++	if (!path)
++		goto error;
+ 
+-	if (data->peer->master)
+-		go_intent = 15;
++	g_free(interface->network_path);
++	interface->network_path = g_strdup(path);
+ 
+-	if (data->peer->wps_pin)
+-		wps = "pin";
++	SUPPLICANT_DBG("data->interface->path : %s\n", data->interface->path);
+ 
+-	supplicant_dbus_dict_append_basic(&dict, "peer",
+-				DBUS_TYPE_OBJECT_PATH, &data->peer->path);
+-	supplicant_dbus_dict_append_basic(&dict, "wps_method",
+-				DBUS_TYPE_STRING, &wps);
+-	if (data->peer->wps_pin) {
+-		supplicant_dbus_dict_append_basic(&dict, "pin",
+-				DBUS_TYPE_STRING, &data->peer->wps_pin);
+-	}
++	supplicant_dbus_method_call(data->interface->path,
++					SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++					"GroupAdd",
++					interface_p2p_persistent_group_add_params,
++					interface_p2p_persistent_group_add_result,
++					data, NULL);
++	return;
+ 
+-	supplicant_dbus_dict_append_basic(&dict, "go_intent",
+-					DBUS_TYPE_INT32, &go_intent);
++	error:
++		SUPPLICANT_DBG("GroupAdd error %s", error);
++		err = parse_supplicant_error(iter);
++		if (data->callback)
++			data->callback(err, data->interface, data->user_data);
++
++		g_free(interface->network_path);
++		interface->network_path = NULL;
++		g_free(data);
++}
++
++static void interface_p2p_persistent_group_params(DBusMessageIter *iter, void *user_data)
++{
++	DBusMessageIter dict;
++	struct interface_connect_data *data = user_data;
++	GSupplicantSSID *ssid = data->ssid;
++	dbus_uint32_t mode = 3;
++	dbus_uint32_t disabled = 2;
++
++	supplicant_dbus_dict_open(iter, &dict);
++
++	supplicant_dbus_dict_append_basic(&dict, "mode", DBUS_TYPE_UINT32, &mode);
++	supplicant_dbus_dict_append_basic(&dict, "disabled",
++						DBUS_TYPE_UINT32, &disabled);
++
++	add_network_security(&dict, ssid);
++
++	//The data structure is set up as a byte buffer, however
++	//SSID->SSID is created by ssid_ap_init - it is a null terminated string.
++	supplicant_dbus_dict_append_basic(&dict, "ssid",
++					DBUS_TYPE_STRING,
++					&(ssid->ssid));
+ 
+ 	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-int g_supplicant_interface_p2p_connect(GSupplicantInterface *interface,
+-					GSupplicantPeerParams *peer_params,
+-					GSupplicantInterfaceCallback callback,
+-					void *user_data)
++int g_supplicant_interface_p2p_persistent_group_add(GSupplicantInterface *interface,
++				GSupplicantSSID *ssid,
++				GSupplicantInterfaceCallback callback,
++							void *user_data)
+ {
+ 	struct interface_connect_data *data;
+ 	int ret;
+ 
+-	SUPPLICANT_DBG("");
++	if (!interface)
++		return -EINVAL;
+ 
+ 	if (!interface->p2p_support)
+ 		return -ENOTSUP;
+@@ -5507,17 +9311,18 @@ int g_supplicant_interface_p2p_connect(GSupplicantInterface *interface,
+ 		return -ENOMEM;
+ 
+ 	data->interface = interface;
+-	data->path = g_strdup(interface->path);
+-	data->peer = peer_params;
+ 	data->callback = callback;
++	data->ssid = ssid;
+ 	data->user_data = user_data;
+ 
+ 	ret = supplicant_dbus_method_call(interface->path,
+-		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "Connect",
+-		interface_p2p_connect_params, interface_p2p_connect_result,
+-		data, interface);
++					SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++					"AddPersistentGroup",
++					interface_p2p_persistent_group_params,
++					interface_p2p_persistent_group_result,
++					data, NULL);
++
+ 	if (ret < 0) {
+-		g_free(data->path);
+ 		dbus_free(data);
+ 		return ret;
+ 	}
+@@ -5525,144 +9330,160 @@ int g_supplicant_interface_p2p_connect(GSupplicantInterface *interface,
+ 	return -EINPROGRESS;
+ }
+ 
+-int g_supplicant_interface_p2p_disconnect(GSupplicantInterface *interface,
+-					GSupplicantPeerParams *peer_params)
++int g_supplicant_interface_p2p_replace_service(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback,
++				GSupplicantP2PServiceParams *p2p_service_params,
++				void *user_data)
+ {
+-	GSupplicantPeer *peer;
+-	int count = 0;
+-	GSList *list;
++      struct p2p_service_data *data;
++	int ret;
+ 
+ 	SUPPLICANT_DBG("");
+ 
+ 	if (!interface->p2p_support)
+ 		return -ENOTSUP;
+ 
+-	peer = g_hash_table_lookup(interface->peer_table, peer_params->path);
+-	if (!peer)
+-		return -ENODEV;
+-
+-	for (list = peer->groups; list; list = list->next, count++) {
+-		const char *group_obj_path = list->data;
+-		GSupplicantInterface *g_interface;
+-		GSupplicantGroup *group;
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
+ 
+-		group = g_hash_table_lookup(group_mapping, group_obj_path);
+-		if (!group || !group->interface)
+-			continue;
++	data->registration = true;
++	data->interface = interface;
++	data->service = p2p_service_params;
++	data->callback = callback;
++	data->user_data = user_data;
+ 
+-		g_interface = group->interface;
+-		supplicant_dbus_method_call(g_interface->path,
+-				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
+-				"Disconnect", NULL, NULL, NULL, g_interface);
+-	}
++	ret = supplicant_dbus_method_call(interface->path,
++										SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ReplaceService",
++										interface_p2p_service_params, interface_p2p_service_result,
++		                                                   data, interface);
+ 
+-	if (count == 0 && peer->current_group_iface) {
+-		supplicant_dbus_method_call(peer->current_group_iface->path,
+-				SUPPLICANT_INTERFACE ".Interface.P2PDevice",
+-				"Disconnect", NULL, NULL, NULL,
+-				peer->current_group_iface->path);
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
+ 	}
+ 
+-	peer->current_group_iface = NULL;
+-
+ 	return -EINPROGRESS;
+ }
+ 
+-struct p2p_service_data {
+-	bool registration;
++struct interface_p2p_asp_provision_data {
+ 	GSupplicantInterface *interface;
+-	GSupplicantP2PServiceParams *service;
+ 	GSupplicantInterfaceCallback callback;
++	void *params; //Either request or response params
+ 	void *user_data;
+ };
+ 
+-static void interface_p2p_service_result(const char *error,
+-					DBusMessageIter *iter, void *user_data)
++static void interface_p2p_asp_provision_result(const char *error,
++											 DBusMessageIter *iter, void *user_data)
+ {
+-	struct p2p_service_data *data = user_data;
+-	int result = 0;
++	struct interface_p2p_asp_provision_data *data = user_data;
++	int err = 0;
+ 
+-	SUPPLICANT_DBG("%s result - %s", data->registration ?
+-				"Registration" : "Deletion",
+-				error ? error : "Success");
+-	if (error)
+-		result = -EINVAL;
++	if (error != NULL) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
+ 
+-	if (data->callback)
+-		data->callback(result, data->interface, data->user_data);
++	if (data->callback != NULL)
++		data->callback(err, data->interface, data->user_data);
+ 
+-	g_free(data->service->query);
+-	g_free(data->service->response);
+-	g_free(data->service->service);
+-	g_free(data->service->wfd_ies);
+-	g_free(data->service);
+ 	dbus_free(data);
+ }
+ 
+-static void interface_p2p_service_params(DBusMessageIter *iter,
+-							void *user_data)
++static void interface_p2p_asp_provision_request_params(DBusMessageIter *iter, void *user_data)
+ {
+-	struct p2p_service_data *data = user_data;
+-	GSupplicantP2PServiceParams *service;
+ 	DBusMessageIter dict;
+-	const char *type;
++	struct interface_p2p_asp_provision_data *data = user_data;
++	GSupplicantP2PASPProvisionRequestParams* params = data->params;
+ 
+-	SUPPLICANT_DBG("");
++	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	service = data->service;
++	if(params->peer)
++		supplicant_dbus_dict_append_basic(&dict, "peer",
++										  DBUS_TYPE_OBJECT_PATH, &params->peer);
++	if(params->config_method)
++		supplicant_dbus_dict_append_basic(&dict, "config_method",
++										  DBUS_TYPE_UINT16, &params->config_method);
++	if(params->advertisement_id)
++		supplicant_dbus_dict_append_basic(&dict, "adv_id",
++										  DBUS_TYPE_UINT32, &params->advertisement_id);
++	if(params->service_mac)
++		supplicant_dbus_dict_append_basic(&dict, "adv_mac",
++										  DBUS_TYPE_STRING, &params->service_mac);
++	if(params->role)
++		supplicant_dbus_dict_append_basic(&dict, "role",
++										  DBUS_TYPE_BYTE, &params->role);
++	if(params->session_id)
++		supplicant_dbus_dict_append_basic(&dict, "session_id",
++										  DBUS_TYPE_UINT32, &params->session_id);
++	if(params->session_mac)
++		supplicant_dbus_dict_append_basic(&dict, "session_mac",
++										  DBUS_TYPE_STRING, &params->session_mac);
++	if(params->service_info)
++		supplicant_dbus_dict_append_basic(&dict, "service_info",
++										  DBUS_TYPE_STRING, &params->service_info);
++
++	supplicant_dbus_dict_close(iter, &dict);
++}
++
++static void interface_p2p_asp_provision_response_params(DBusMessageIter *iter, void *user_data)
++{
++	DBusMessageIter dict;
++	struct interface_p2p_asp_provision_data *data = user_data;
++	GSupplicantP2PASPProvisionResponseParams* params = data->params;
+ 
+ 	supplicant_dbus_dict_open(iter, &dict);
+ 
+-	if (service->query && service->response) {
+-		type = "bonjour";
+-		supplicant_dbus_dict_append_basic(&dict, "service_type",
+-						DBUS_TYPE_STRING, &type);
+-		supplicant_dbus_dict_append_fixed_array(&dict, "query",
+-					DBUS_TYPE_BYTE, &service->query,
+-					service->query_length);
+-		supplicant_dbus_dict_append_fixed_array(&dict, "response",
+-					DBUS_TYPE_BYTE, &service->response,
+-					service->response_length);
+-	} else if (service->version && service->service) {
+-		type = "upnp";
+-		supplicant_dbus_dict_append_basic(&dict, "service_type",
+-						DBUS_TYPE_STRING, &type);
+-		supplicant_dbus_dict_append_basic(&dict, "version",
+-					DBUS_TYPE_INT32, &service->version);
+-		supplicant_dbus_dict_append_basic(&dict, "service",
+-					DBUS_TYPE_STRING, &service->service);
+-	}
++	if(params->peer)
++		supplicant_dbus_dict_append_basic(&dict, "peer",
++										  DBUS_TYPE_OBJECT_PATH, &params->peer);
++	if(params->advertisement_id)
++		supplicant_dbus_dict_append_basic(&dict, "adv_id",
++										  DBUS_TYPE_UINT32, &params->advertisement_id);
++	if(params->service_mac)
++		supplicant_dbus_dict_append_basic(&dict, "adv_mac",
++										  DBUS_TYPE_STRING, &params->service_mac);
++	supplicant_dbus_dict_append_basic(&dict, "status",
++	                                  DBUS_TYPE_INT32, &params->status);
++	supplicant_dbus_dict_append_basic(&dict, "role",
++										  DBUS_TYPE_BYTE, &params->role);
++	if(params->session_id)
++		supplicant_dbus_dict_append_basic(&dict, "session_id",
++										  DBUS_TYPE_UINT32, &params->session_id);
++	if(params->session_mac)
++		supplicant_dbus_dict_append_basic(&dict, "session_mac",
++										  DBUS_TYPE_STRING, &params->session_mac);
+ 
+ 	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
+-int g_supplicant_interface_p2p_add_service(GSupplicantInterface *interface,
+-				GSupplicantInterfaceCallback callback,
+-				GSupplicantP2PServiceParams *p2p_service_params,
+-				void *user_data)
++int g_supplicant_interface_p2p_asp_provision_request(GSupplicantInterface *interface,
++													 GSupplicantP2PASPProvisionRequestParams *params,
++													 GSupplicantInterfaceCallback callback,
++													 void *user_data)
+ {
+-	struct p2p_service_data *data;
++	struct interface_p2p_asp_provision_data *data;
+ 	int ret;
+ 
+-	SUPPLICANT_DBG("");
++	if (interface == NULL)
++		return -EINVAL;
+ 
+-	if (!interface->p2p_support)
+-		return -ENOTSUP;
++	if (system_available == FALSE)
++		return -EFAULT;
+ 
+ 	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
++	if (data == NULL)
+ 		return -ENOMEM;
+ 
+-	data->registration = true;
+ 	data->interface = interface;
+-	data->service = p2p_service_params;
++	data->params = params;
+ 	data->callback = callback;
+ 	data->user_data = user_data;
+ 
+ 	ret = supplicant_dbus_method_call(interface->path,
+-		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "AddService",
+-		interface_p2p_service_params, interface_p2p_service_result,
+-		data, interface);
++									  SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ASPProvisionRequest",
++									  interface_p2p_asp_provision_request_params, interface_p2p_asp_provision_result, data, NULL);
++
+ 	if (ret < 0) {
+ 		dbus_free(data);
+ 		return ret;
+@@ -5671,28 +9492,33 @@ int g_supplicant_interface_p2p_add_service(GSupplicantInterface *interface,
+ 	return -EINPROGRESS;
+ }
+ 
+-int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
+-				GSupplicantP2PServiceParams *p2p_service_params)
++int g_supplicant_interface_p2p_asp_provision_response(GSupplicantInterface *interface,
++                                                      GSupplicantP2PASPProvisionResponseParams *params,
++													 GSupplicantInterfaceCallback callback,
++													 void *user_data)
+ {
+-	struct p2p_service_data *data;
++	struct interface_p2p_asp_provision_data *data;
+ 	int ret;
+ 
+-	SUPPLICANT_DBG("");
++	if (interface == NULL)
++		return -EINVAL;
+ 
+-	if (!interface->p2p_support)
+-		return -ENOTSUP;
++	if (system_available == FALSE)
++		return -EFAULT;
+ 
+ 	data = dbus_malloc0(sizeof(*data));
+-	if (!data)
++	if (data == NULL)
+ 		return -ENOMEM;
+ 
+ 	data->interface = interface;
+-	data->service = p2p_service_params;
++	data->params = params;
++	data->callback = callback;
++	data->user_data = user_data;
+ 
+ 	ret = supplicant_dbus_method_call(interface->path,
+-		SUPPLICANT_INTERFACE ".Interface.P2PDevice", "DeleteService",
+-		interface_p2p_service_params, interface_p2p_service_result,
+-		data, interface);
++									  SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ASPProvisionResponse",
++									  interface_p2p_asp_provision_response_params, interface_p2p_asp_provision_result, data, NULL);
++
+ 	if (ret < 0) {
+ 		dbus_free(data);
+ 		return ret;
+@@ -5700,43 +9526,143 @@ int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
+ 
+ 	return -EINPROGRESS;
+ }
++static void p2p_dev_address_update_cb(const char *key,
++                                  DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int err = 0;
++	unsigned char *mac_bin;
++	int mac_bin_len = 0;
++	DBusMessageIter array;
++
++	if (iter == NULL)
++		return;
++
++	dbus_message_iter_recurse(iter, &array);
++	dbus_message_iter_get_fixed_array(&array, &mac_bin, &mac_bin_len);
++
++	if (mac_bin_len == 6) {
++		memcpy(data->interface->p2p_device_address, mac_bin, mac_bin_len);
++		err = 0;
++	}
++	else {
++		err = -1;
++	}
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	g_free(data);
++}
++int g_supplicant_interface_p2p_read_device_address(GSupplicantInterface *interface,
++                                                   GSupplicantInterfaceCallback callback, void *user_data)
++{
++	struct interface_data *data;
++	int ret;
++
++	if (interface == NULL)
++		return -EINVAL;
++
++	if (system_available == FALSE)
++		return -EINVAL;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (data == NULL)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_property_get(interface->path,
++	                                    SUPPLICANT_INTERFACE ".Interface.P2PDevice",
++	                                    "DeviceAddress",
++	                                    p2p_dev_address_update_cb, data, NULL);
++
++	if (ret < 0)
++		dbus_free(data);
+ 
+-struct p2p_listen_data {
++	return ret;
++}
++const unsigned char *g_supplicant_interface_p2p_get_device_address(GSupplicantInterface *interface)
++{
++	return interface->p2p_device_address;
++}
++struct interface_p2p_listen_data {
++	GSupplicantInterface *interface;
++	GSupplicantInterfaceCallback callback;
++	void *user_data;
+ 	int period;
+ 	int interval;
+ };
+ 
+ static void interface_p2p_listen_params(DBusMessageIter *iter, void *user_data)
+ {
+-	struct p2p_listen_data *params = user_data;
++	struct interface_p2p_listen_data *data = user_data;
+ 	DBusMessageIter dict;
+ 
+ 	supplicant_dbus_dict_open(iter, &dict);
+ 
+ 	supplicant_dbus_dict_append_basic(&dict, "period",
+-					DBUS_TYPE_INT32, &params->period);
++					DBUS_TYPE_INT32, &data->period);
+ 	supplicant_dbus_dict_append_basic(&dict, "interval",
+-					DBUS_TYPE_INT32, &params->interval);
++					DBUS_TYPE_INT32, &data->interval);
+ 	supplicant_dbus_dict_close(iter, &dict);
+ }
+ 
++static void interface_p2p_listen_result(const char *error,
++				DBusMessageIter *iter, void *user_data)
++{
++	struct interface_p2p_listen_data *data = user_data;
++	int err = 0;
++
++	SUPPLICANT_DBG("");
++
++	if (error) {
++		SUPPLICANT_DBG("error %s", error);
++		err = -EIO;
++	}
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	dbus_free(data);
++}
+ int g_supplicant_interface_p2p_listen(GSupplicantInterface *interface,
+-						int period, int interval)
++						int period, int interval, GSupplicantInterfaceCallback callback,
++						void *user_data)
+ {
+-	struct p2p_listen_data params;
++	struct interface_p2p_listen_data *data;
++	int ret=0;
+ 
+ 	SUPPLICANT_DBG("");
+ 
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
+ 	if (!interface->p2p_support)
+ 		return -ENOTSUP;
+ 
+-	params.period = period;
+-	params.interval = interval;
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
+ 
+-	return supplicant_dbus_method_call(interface->path,
++	data->interface = interface;
++	data->callback = callback;
++	data->period = period;
++	data->interval = interval;
++	data->user_data = user_data;
++
++	ret=supplicant_dbus_method_call(interface->path,
+ 			SUPPLICANT_INTERFACE ".Interface.P2PDevice",
+ 			"ExtendedListen", interface_p2p_listen_params,
+-			NULL, &params, NULL);
++			interface_p2p_listen_result, data, NULL);
++	if(ret<0)
++		dbus_free(data);
++	return ret;
+ }
+ 
+ static void widi_ies_params(DBusMessageIter *iter, void *user_data)
+@@ -5972,3 +9898,47 @@ void g_supplicant_unregister(const GSupplicantCallbacks *callbacks)
+ 	callbacks_pointer = NULL;
+ 	eap_methods = 0;
+ }
++static void signal_info_update_cb(const char *key,
++                               DBusMessageIter *iter, void *user_data)
++{
++	struct interface_data *data = user_data;
++	int err = 0;
++
++	supplicant_dbus_property_foreach(iter, interface_signal_info,
++						data->interface);
++
++	if (data->callback)
++		data->callback(err, data->interface, data->user_data);
++
++	g_free(data);
++}
++
++int g_supplicant_interface_update_signal_info(GSupplicantInterface *interface,
++                    GSupplicantInterfaceCallback callback, void *user_data)
++{
++	struct interface_data *data;
++	int ret;
++
++	if (!interface)
++		return -EINVAL;
++
++	if (!system_available)
++		return -EFAULT;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_property_get(interface->path,
++						SUPPLICANT_INTERFACE ".Interface", "SignalInfo",
++						signal_info_update_cb, data, NULL);
++
++	if (ret < 0)
++		dbus_free(data);
++
++	return ret;
++}
+diff --git a/include/dbus.h b/include/dbus.h
+index bcab4189..13f8c700 100644
+--- a/include/dbus.h
++++ b/include/dbus.h
+@@ -45,6 +45,9 @@ extern "C" {
+ #define CONNMAN_SESSION_INTERFACE	CONNMAN_SERVICE ".Session"
+ #define CONNMAN_NOTIFICATION_INTERFACE	CONNMAN_SERVICE ".Notification"
+ #define CONNMAN_PEER_INTERFACE		CONNMAN_SERVICE ".Peer"
++#define CONNMAN_SD_INTERFACE	CONNMAN_SERVICE ".ServiceDiscovery"
++#define CONNMAN_SD_PATH			"/"
++#define CONNMAN_GROUP_INTERFACE		CONNMAN_SERVICE ".Group"
+ 
+ #define CONNMAN_PRIVILEGE_MODIFY	1
+ #define CONNMAN_PRIVILEGE_SECRET	2
+diff --git a/include/device.h b/include/device.h
+index 0fc06bd0..3b65365b 100644
+--- a/include/device.h
++++ b/include/device.h
+@@ -83,6 +83,7 @@ void connman_device_set_index(struct connman_device *device, int index);
+ int connman_device_get_index(struct connman_device *device);
+ void connman_device_set_interface(struct connman_device *device,
+ 						const char *interface);
++const char *connman_device_get_interface(struct connman_device *device);
+ 
+ void connman_device_set_ident(struct connman_device *device,
+ 						const char *ident);
+@@ -102,6 +103,11 @@ int connman_device_set_string(struct connman_device *device,
+ const char *connman_device_get_string(struct connman_device *device,
+ 							const char *key);
+ 
++int connman_device_set_integer(struct connman_device *device,
++							const char *key, int value);
++int connman_device_get_integer(struct connman_device *device,
++							const char *key);
++
+ int connman_device_add_network(struct connman_device *device,
+ 					struct connman_network *network);
+ struct connman_network *connman_device_get_network(struct connman_device *device,
+@@ -123,6 +129,14 @@ struct connman_device *connman_device_create_from_index(int index);
+ struct connman_device *connman_device_find_by_index(int index);
+ int connman_device_reconnect_service(struct connman_device *device);
+ 
++int connman_device_set_integer(struct connman_device *device,
++										const char *key, int value);
++int connman_device_get_integer(struct connman_device *device,
++										const char *key);
++typedef void (*connman_device_request_signal_info_cb)(struct connman_device *device, void *user_data);
++int connman_device_request_signal_info(struct connman_device *device,
++										connman_device_request_signal_info_cb cb, void *user_data);
++
+ struct connman_device_driver {
+ 	const char *name;
+ 	enum connman_device_type type;
+@@ -137,6 +151,11 @@ struct connman_device_driver {
+ 			struct connman_device *device);
+ 	int (*set_regdom) (struct connman_device *device,
+ 						const char *alpha2);
++	int (*start_wps) (struct connman_device *device, const char *pin);
++	int (*cancel_wps) (struct connman_device *device);
++	int (*cancel_p2p) (struct connman_device *device);
++	int (*get_driver_info) (struct connman_device *device);
++	int (*get_signal_info)(struct connman_device *device, connman_device_request_signal_info_cb cb, void *user_data);
+ };
+ 
+ int connman_device_driver_register(struct connman_device_driver *driver);
+diff --git a/include/group.h b/include/group.h
+new file mode 100644
+index 00000000..6d092843
+--- /dev/null
++++ b/include/group.h
+@@ -0,0 +1,74 @@
++#ifndef __CONNMAN_GROUP_H
++#define __CONNMAN_GROUP_H
++
++#include <gsupplicant/gsupplicant.h>
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++
++struct connman_group {
++	int refcount;
++	char *identifier;
++	char *path;
++	GSupplicantInterface *interface;
++	GSupplicantInterface *orig_interface;
++
++	char *name;
++	char *passphrase;
++	char *peer_ip;
++	bool is_group_owner;
++	bool is_persistent;
++	bool tethering;
++	bool autonomous;
++	int freq;
++	bool is_static_ip;
++
++	const char *group_owner;
++	GSList *peer_list;
++	GHashTable *peer_hash;
++	GHashTable *peer_intf;
++};
++
++#define connman_group_ref(group) \
++	connman_group_ref_debug(group, __FILE__, __LINE__, __func__)
++
++#define connman_group_unref(group) \
++	connman_group_unref_debug(group, __FILE__, __LINE__, __func__)
++
++#define P2P_WILDCARD_SSID "DIRECT-"
++#define P2P_WILDCARD_SSID_LEN 7
++#define P2P_MAX_SSID 32
++
++struct connman_group *__connman_group();
++const char* __connman_group_get_path(struct connman_group *group);
++const char* __connman_group_get_identifier(struct connman_group *group);
++const char* __connman_group_get_group_owner(struct connman_group *group);
++int  __connman_group_get_list_length(struct connman_group *group);
++bool __connman_group_is_autonomous(struct connman_group *group);
++
++int __connman_group_accept_connection(struct connman_group *group, GSupplicantP2PWPSParams *wps_params);
++
++bool __connman_group_exist(void);
++void __connman_group_peer_failed(struct connman_group *group);
++
++struct connman_group *__connman_group_lookup_from_ident(const char *identifier);
++
++void __connman_group_list_struct(DBusMessageIter *iter);
++
++struct connman_group* __connman_group_create(GSupplicantInterface *iface, const char *ifname, const char *ssid, const char *passphrase,
++														bool go, bool persistent, const char *go_path, bool autonomous, int freq);
++void __connman_group_remove(GSupplicantInterface *interface);
++void __connman_group_peer_joined(struct connman_group *group, const char *_peer_ident, char *intf_addr, const char *peer_path);
++bool __connman_group_peer_disconnected(struct connman_group *group, char *peer_ident);
++void __connman_group_client_dhcp_ip_assigned(struct connman_group *group);
++
++void __connman_group_init(void);
++void __connman_group_cleanup(void);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* __CONNMAN_GROUP_H */
+diff --git a/include/network.h b/include/network.h
+index 8f9dd94a..1828832a 100644
+--- a/include/network.h
++++ b/include/network.h
+@@ -29,6 +29,8 @@
+ 
+ #include <connman/device.h>
+ #include <connman/ipconfig.h>
++#include <glib.h>
++#include <connman/types.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+@@ -64,6 +66,7 @@ enum connman_network_error {
+ #define CONNMAN_NETWORK_PRIORITY_DEFAULT     0
+ #define CONNMAN_NETWORK_PRIORITY_HIGH      100
+ 
++struct connman_bss;
+ struct connman_network;
+ 
+ struct connman_network *connman_network_create(const char *identifier,
+@@ -121,6 +124,17 @@ int connman_network_set_nameservers(struct connman_network *network,
+ 				const char *nameservers);
+ int connman_network_set_domain(struct connman_network *network,
+ 			             const char *domain);
++int connman_network_set_address(struct connman_network *network,
++                                const unsigned char *addr_octet, unsigned int size);
++const char *connman_network_get_address(struct connman_network *network);
++int connman_network_add_bss(struct connman_network *network,
++                            const unsigned char *id,
++                            short signal,
++                            unsigned short frequency);
++GHashTable *connman_network_get_bss_table(struct connman_network *network);
++short connman_network_get_bss_signal(struct connman_bss *bss);
++unsigned short connman_network_get_bss_frequency(struct connman_bss *bss);
++
+ int connman_network_set_name(struct connman_network *network,
+ 							const char *name);
+ int connman_network_set_strength(struct connman_network *network,
+@@ -147,6 +161,8 @@ int connman_network_set_blob(struct connman_network *network,
+ 			const char *key, const void *data, unsigned int size);
+ const void *connman_network_get_blob(struct connman_network *network,
+ 					const char *key, unsigned int *size);
++connman_bool_t connman_network_get_p2p_network(struct connman_network *network);
++void connman_network_set_p2p_network(struct connman_network *network, connman_bool_t is_p2p_network);
+ 
+ struct connman_device *connman_network_get_device(struct connman_network *network);
+ 
+diff --git a/include/option.h b/include/option.h
+new file mode 100644
+index 00000000..5e97ed4c
+--- /dev/null
++++ b/include/option.h
+@@ -0,0 +1,35 @@
++/*
++ *
++ *  Connection Manager
++ *
++ *  Copyright (C) 2007-2012  Intel Corporation. All rights reserved.
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License version 2 as
++ *  published by the Free Software Foundation.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#ifndef __CONNMAN_OPTION_H
++#define __CONNMAN_OPTION_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++const char *connman_option_get_string(const char *key);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* __CONNMAN_OPTION_H */
+diff --git a/include/peer.h b/include/peer.h
+index 80663932..88c1dae3 100644
+--- a/include/peer.h
++++ b/include/peer.h
+@@ -40,6 +40,9 @@ enum connman_peer_wps_method {
+ 	CONNMAN_PEER_WPS_UNKNOWN         = 0,
+ 	CONNMAN_PEER_WPS_PBC             = 1,
+ 	CONNMAN_PEER_WPS_PIN             = 2,
++	CONNMAN_PEER_WPS_DISPLAY            = 3,
++	CONNMAN_PEER_WPS_KEYBOARD         = 4,
++	CONNMAN_PEER_WPS_P2PS                 = 5
+ };
+ 
+ enum connman_peer_service_type {
+@@ -68,13 +71,20 @@ void connman_peer_set_iface_address(struct connman_peer *peer,
+ 					const unsigned char *iface_address);
+ void connman_peer_set_device(struct connman_peer *peer,
+ 				struct connman_device *device);
++int connman_peer_set_ipaddress(struct connman_peer *peer,
++				const char *address, const char *netmask, const char *gateway);
+ struct connman_device *connman_peer_get_device(struct connman_peer *peer);
+ void connman_peer_set_sub_device(struct connman_peer *peer,
+ 					struct connman_device *device);
+ void connman_peer_set_as_master(struct connman_peer *peer, bool master);
++void connman_peer_set_as_go(struct connman_peer *peer, bool go);
+ int connman_peer_set_state(struct connman_peer *peer,
+ 					enum connman_peer_state new_state);
+-int connman_peer_request_connection(struct connman_peer *peer);
++enum connman_peer_state connman_peer_get_state(struct connman_peer *peer);
++void connman_peer_state_change_by_cancelled(void);
++void connman_peer_request_connection(struct connman_peer *peer, int dev_passwd_id);
++void connman_peer_invitation_request(const char* peer_path,
++					const char* signal, const char* go_dev_addr);
+ void connman_peer_reset_services(struct connman_peer *peer);
+ void connman_peer_add_service(struct connman_peer *peer,
+ 				enum connman_peer_service_type type,
+@@ -86,6 +96,10 @@ void connman_peer_unregister(struct connman_peer *peer);
+ 
+ struct connman_peer *connman_peer_get(struct connman_device *device,
+ 						const char *identifier);
++struct connman_peer *connman_peer_get_by_path(const char *path);
++void connman_peer_get_local_address(gpointer user_data, DBusMessageIter *iter);
++
++void __connman_peer_get_properties_struct(DBusMessageIter *iter, gpointer user_data);
+ 
+ typedef void (* peer_service_registration_cb_t) (int result, void *user_data);
+ 
+@@ -104,12 +118,14 @@ struct connman_peer_driver {
+ 					int specification_length,
+ 					const unsigned char *query,
+ 					int query_length, int version);
++	int (*reject) (struct connman_peer *peer);
+ };
+ 
+ int connman_peer_driver_register(struct connman_peer_driver *driver);
+ void connman_peer_driver_unregister(struct connman_peer_driver *driver);
+ 
+ bool connman_peer_service_is_master(void);
++const char *connman_peer_wps_method2string(enum connman_peer_wps_method method);
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/include/sd.h b/include/sd.h
+new file mode 100644
+index 00000000..c8b6530a
+--- /dev/null
++++ b/include/sd.h
+@@ -0,0 +1,25 @@
++#ifndef __CONNMAN_SD_H
++#define __CONNMAN_SD_H
++
++#include <connman/types.h>
++#include <stdbool.h>
++#include <gsupplicant/gsupplicant.h>
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++
++struct connman_service_discovery;
++
++void __connman_sd_init(GSupplicantInterface *interface, const char *dev_ident);
++void __connman_sd_cleanup(void);
++
++void __connman_sd_response_from_p2p_peer(const char *peer_ident, int reference,
++								unsigned char *tlv, int tlv_len);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* __CONNMAN_SD_H */
+diff --git a/include/technology.h b/include/technology.h
+index 3ea7589f..124dbb07 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -23,6 +23,7 @@
+ #define __CONNMAN_TECHNOLOGY_H
+ 
+ #include <connman/service.h>
++#include <gdbus.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+@@ -49,12 +50,19 @@ bool connman_technology_get_wifi_tethering(const struct connman_technology *tech
+ 					const char **ssid, const char **psk, int *freq);
+ 
+ bool connman_technology_is_tethering_allowed(enum connman_service_type type);
++bool is_technology_enabled(struct connman_technology *technology);
++
++void connman_technology_set_p2p(struct connman_technology *technology, bool enabled);
++void connman_technology_set_p2p_identifier(struct connman_technology *technology,
++							const char *p2p_identifier);
++bool connman_technology_get_enable_p2p_listen(struct connman_technology *technology);
+ bool connman_technology_get_p2p_listen(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen(struct connman_technology *technology,
+ 							bool enabled);
+ unsigned int connman_technology_get_p2p_listen_channel(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen_channel(struct connman_technology *technology,
+ 									unsigned int listen_channel);
++void connman_technology_wps_failed_notify(struct connman_technology *technology);
+ 
+ struct connman_technology_driver {
+ 	const char *name;
+@@ -67,6 +75,8 @@ struct connman_technology_driver {
+ 							const char *ident);
+ 	void (*remove_interface) (struct connman_technology *technology,
+ 								int index);
++	int (*set_p2p_enable) (struct connman_technology *technology,
++								bool status);
+ 	int (*set_tethering) (struct connman_technology *technology,
+ 				const char *bridge, bool enabled);
+ 	int (*set_regdom) (struct connman_technology *technology,
+@@ -83,6 +93,11 @@ struct connman_technology_driver {
+ 						bool enable);
+ 	int (*set_p2p_listen_params) (struct connman_technology *technology,
+ 						int period, int interval);
++	int (*set_p2p_go) (DBusMessage *msg, struct connman_technology *technology,
++						const char *identifier, const char *passphrase);
++	int (*remove_persistent_info) (struct connman_technology *technology,
++						const char *identifier);
++	int (*remove_persistent_info_all) (struct connman_technology *technology);
+ };
+ 
+ int connman_technology_driver_register(struct connman_technology_driver *driver);
+diff --git a/include/types.h b/include/types.h
+new file mode 100644
+index 00000000..0f671ec3
+--- /dev/null
++++ b/include/types.h
+@@ -0,0 +1,45 @@
++/*
++ *
++ *  Connection Manager
++ *
++ *  Copyright (C) 2007-2012  Intel Corporation. All rights reserved.
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License version 2 as
++ *  published by the Free Software Foundation.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#ifndef __CONNMAN_TYPES_H
++#define __CONNMAN_TYPES_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#ifndef	FALSE
++#define	FALSE	(0)
++#endif
++
++#ifndef	TRUE
++#define	TRUE	(!FALSE)
++#endif
++
++typedef int		connman_bool_t;
++typedef unsigned char	connman_uint8_t;
++typedef unsigned short	connman_uint16_t;
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* __CONNMAN_TYPES_H */
+diff --git a/plugins/wifi.c b/plugins/wifi.c
+index e947b169..f2a5302a 100644
+--- a/plugins/wifi.c
++++ b/plugins/wifi.c
+@@ -33,6 +33,8 @@
+ #include <net/ethernet.h>
+ #include <linux/wireless.h>
+ 
++#include <connman/types.h>
++
+ #ifndef IFF_LOWER_UP
+ #define IFF_LOWER_UP	0x10000
+ #endif
+@@ -49,6 +51,7 @@
+ #include <connman/service.h>
+ #include <connman/peer.h>
+ #include <connman/log.h>
++#include <include/option.h>
+ #include <connman/storage.h>
+ #include <include/setting.h>
+ #include <connman/provision.h>
+@@ -58,29 +61,49 @@
+ 
+ #include <gsupplicant/gsupplicant.h>
+ 
++#include "src/connman.h"
++
++#include "include/group.h"
+ #include "src/shared/util.h"
+ 
+ #define CLEANUP_TIMEOUT   8	/* in seconds */
+ #define INACTIVE_TIMEOUT  12	/* in seconds */
+ #define FAVORITE_MAXIMUM_RETRIES 2
++#define WPS_CONNECT_TIMEOUT 120 /* in seconds */
+ 
+ #define BGSCAN_DEFAULT "simple:30:-65:300"
+ #define AUTOSCAN_EXPONENTIAL "exponential:3:300"
+ #define AUTOSCAN_SINGLE "single:3"
+ #define SCAN_MAX_DURATION 10
++#define P2P_PERSISTENT_INFO		"P2PPersistentInfo"
+ 
+ #define P2P_FIND_TIMEOUT 30
+ #define P2P_CONNECTION_TIMEOUT 100
+ #define P2P_LISTEN_PERIOD 500
+ #define P2P_LISTEN_INTERVAL 2000
++#define P2P_PERSISTENT_MAX_COUNT 20
+ 
+ #define ASSOC_STATUS_AUTH_TIMEOUT 16
+ #define ASSOC_STATUS_NO_CLIENT 17
+ #define LOAD_SHAPING_MAX_RETRIES 3
+ 
++static char *p2p_go_identifier = NULL;
++static char *p2p_group_if_prefix = "p2p-";
++static char *p2p_group_ifname = NULL;
++static int p2p_group_ifindex = -1;
++static int pin_requested_ref = -1;
++static int pbc_requested_ref = -1;
++static int p2p_find_ref = -1;
++static int p2p_listen_ref = -1;
++
++struct p2p_listen_data params = { .period = P2P_LISTEN_PERIOD, .interval = P2P_LISTEN_INTERVAL };
++
++static DBusConnection *connection;
+ static struct connman_technology *wifi_technology = NULL;
+ static struct connman_technology *p2p_technology = NULL;
+ 
++extern bool block_auto_connect;
++
+ enum wifi_ap_capability{
+ 	WIFI_AP_UNKNOWN 	= 0,
+ 	WIFI_AP_SUPPORTED 	= 1,
+@@ -155,20 +178,38 @@ struct wifi_data {
+ 	struct autoscan_params *autoscan;
+ 	enum wifi_scanning_type scanning_type;
+ 	GSupplicantScanParams *scan_params;
++	GSupplicantP2PDeviceConfigParams p2p_device_config;
+ 	unsigned int p2p_find_timeout;
+ 	unsigned int p2p_connection_timeout;
+ 	struct connman_peer *pending_peer;
+ 	GSList *peers;
+ 	bool p2p_connecting;
+ 	bool p2p_device;
++	bool p2p_listen_suppressed;
+ 	int servicing;
+ 	int disconnect_code;
+ 	int assoc_code;
++
++	bool wps_active;
++	GSupplicantSSID *wps_ssid;
++	guint wps_timeout;
++	bool wps_start_deferred;
++
++	const char *generated_pin;
++	const char *pin_requested_path;
++	const char *invited_path;
++	GSList *persistent_groups;
++	GHashTable *persistent_peer_ssid;
+ };
+ 
+ struct wifi_network {
+ 	unsigned int keymgmt;
+ };
++struct wifi_cb_data {
++	struct wifi_data *wifi;
++	void *callback;
++	void *user_data;
++};
+ 
+ struct disconnect_data {
+ 	struct wifi_data *wifi;
+@@ -181,9 +222,44 @@ static GList *pending_wifi_device = NULL;
+ static GList *p2p_iface_list = NULL;
+ static bool wfd_service_registered = false;
+ 
++static DBusMessage *group_msg;
++static bool create_group_flag = false;
++
++static int peer_disconnect(struct connman_peer *peer);
++static void p2p_group_finished(GSupplicantInterface *interface);
++static void remove_peers(struct wifi_data *wifi);
+ static void start_autoscan(struct connman_device *device);
++static gboolean p2p_find_stop(gpointer data);
++static GSupplicantSSID *ssid_ap_init(const char *ssid, const char *passphrase);
+ static int tech_set_tethering(struct connman_technology *technology,
++				const char *identifier, const char *passphrase,
+ 				const char *bridge, bool enabled);
++static int apply_p2p_listen_on_iface(gpointer data, gpointer user_data);
++static void leave_p2p_listen_on_iface(gpointer data);
++static int add_persistent_group_info(struct wifi_data *wifi);
++static int p2p_persistent_info_load(GSupplicantInterface *interface,
++		const char *persistent_dir, GSupplicantP2PPersistentGroup *persistent_group);
++
++static void bss_foreach(gpointer key, gpointer value, gpointer user_data)
++{
++	GSupplicantBss *bss;
++	const unsigned char *bssid;
++	dbus_int16_t signal;
++	dbus_uint16_t frequency;
++	struct connman_network *network;
++
++	if (!key || !value || !user_data)
++		return;
++
++	network = (struct connman_network *)user_data;
++	bss = (GSupplicantBss *)value;
++	bssid = g_supplicant_bss_get_bssid(bss);
++	signal = g_supplicant_bss_get_signal(bss);
++	frequency = g_supplicant_bss_get_frequency(bss);
++	DBG("signal %d frequency %d",signal,frequency);
++
++	connman_network_add_bss(network, bssid, signal, frequency);
++}
+ 
+ static int p2p_tech_probe(struct connman_technology *technology)
+ {
+@@ -197,1509 +273,1762 @@ static void p2p_tech_remove(struct connman_technology *technology)
+ 	p2p_technology = NULL;
+ }
+ 
+-static struct connman_technology_driver p2p_tech_driver = {
+-	.name		= "p2p",
+-	.type		= CONNMAN_SERVICE_TYPE_P2P,
+-	.probe		= p2p_tech_probe,
+-	.remove		= p2p_tech_remove,
+-};
+-
+-static bool is_p2p_connecting(void)
++static const char *load_p2p_identifier()
+ {
+-	GList *list;
++	GKeyFile *keyfile = NULL;
++	gchar *identifier = NULL;
++	const char *p2p_identifier = NULL;
+ 
+-	for (list = iface_list; list; list = list->next) {
+-		struct wifi_data *wifi = list->data;
++	keyfile = __connman_storage_load_global();
++	if(!keyfile)
++		return NULL;
+ 
+-		if (wifi->p2p_connecting)
+-			return true;
++	identifier = g_strdup_printf("%s", "WiFi");
++	if (!identifier) {
++		g_key_file_free(keyfile);
++		return NULL;
+ 	}
+ 
+-	return false;
++	p2p_identifier = g_key_file_get_string(keyfile, identifier, "P2PIdentifier", NULL);
++	g_free(identifier);
++
++	if(!p2p_identifier) {
++		g_key_file_free(keyfile);
++		return NULL;
++	}
++
++	if(strlen(p2p_identifier) > 32)
++		p2p_identifier = NULL;
++
++	g_key_file_free(keyfile);
++
++	return p2p_identifier;
+ }
+ 
+-static void add_pending_wifi_device(struct wifi_data *wifi)
++static void save_p2p_identifier(const char *p2p_identifier)
+ {
+-	if (g_list_find(pending_wifi_device, wifi))
++	GKeyFile *keyfile = NULL;
++	gchar *identifier = NULL;
++
++	keyfile = __connman_storage_load_global();
++	if(!keyfile)
+ 		return;
+ 
+-	pending_wifi_device = g_list_append(pending_wifi_device, wifi);
+-}
++	identifier = g_strdup_printf("%s", "WiFi");
++	if (!identifier) {
++		g_key_file_free(keyfile);
++		return;
++	}
+ 
+-static struct wifi_data *get_pending_wifi_data(const char *ifname)
++	g_key_file_set_string(keyfile, identifier, "P2PIdentifier", p2p_identifier);
++	g_free(identifier);
++
++	__connman_storage_save_global(keyfile);
++
++	g_key_file_free(keyfile);
++}
++static int tech_set_p2p_enable(struct connman_technology *technology, bool status)
+ {
+-	GList *list;
++	GList *list = NULL;
++	int err = 0;
++	struct connman_peer *connmanpeer;
+ 
+-	for (list = pending_wifi_device; list; list = list->next) {
+-		struct wifi_data *wifi;
+-		const char *dev_name;
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-		wifi = list->data;
+-		if (!wifi || !wifi->device)
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
++
++		if (!g_supplicant_interface_has_p2p(iface))
+ 			continue;
++		err = g_supplicant_interface_set_p2p_disabled(iface, !status);
+ 
+-		dev_name = connman_device_get_string(wifi->device, "Interface");
+-		if (!g_strcmp0(ifname, dev_name)) {
+-			pending_wifi_device = g_list_delete_link(
+-						pending_wifi_device, list);
+-			return wifi;
++		if (err == 0 && status) {
++			if (connman_technology_get_p2p_listen(technology)) {
++				err = apply_p2p_listen_on_iface(wifi, &params);
++			}
++			if(err == 0)
++				g_supplicant_interface_get_p2p_device_config(iface, &wifi->p2p_device_config);
++		} else if(err == 0 && !status) {
++			if (connman_technology_get_p2p_listen(technology)) {
++				leave_p2p_listen_on_iface(wifi);
++			}
++			if(__connman_peer_get_connected_exists()) {
++				connman_technology_set_p2p(p2p_technology, false);
++				connmanpeer = __connman_get_connected_peer();
++				peer_disconnect(connmanpeer);
++				p2p_group_finished(iface);
++				remove_peers(wifi);
++			}
+ 		}
+ 	}
+ 
+-	return NULL;
++	return err;
+ }
+-
+-static void remove_pending_wifi_device(struct wifi_data *wifi)
++static int tech_set_p2p_identifier(struct connman_technology *technology, const char *p2p_identifier)
+ {
+-	GList *link;
++	GList *list = NULL;
++	char *old_device_name = NULL;
++	char *old_ssid_postfix = NULL;
++	int err = -EOPNOTSUPP;
+ 
+-	link = g_list_find(pending_wifi_device, wifi);
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	if (!link)
+-		return;
++	if (is_technology_enabled(p2p_technology)) {
++		for (list = iface_list; list; list = list->next) {
++			struct wifi_data *wifi = list->data;
++			GSupplicantInterface *iface = wifi->interface;
+ 
+-	pending_wifi_device = g_list_delete_link(pending_wifi_device, link);
+-}
++			if (!g_supplicant_interface_has_p2p(iface))
++				continue;
+ 
+-static void peer_cancel_timeout(struct wifi_data *wifi)
+-{
+-	if (wifi->p2p_connection_timeout > 0)
+-		g_source_remove(wifi->p2p_connection_timeout);
++			if (wifi->p2p_device_config.device_name)
++				old_device_name = wifi->p2p_device_config.device_name;
+ 
+-	wifi->p2p_connection_timeout = 0;
+-	wifi->p2p_connecting = false;
++			if (wifi->p2p_device_config.ssid_postfix)
++				old_ssid_postfix = wifi->p2p_device_config.ssid_postfix;
+ 
+-	if (wifi->pending_peer) {
+-		connman_peer_unref(wifi->pending_peer);
+-		wifi->pending_peer = NULL;
++			wifi->p2p_device_config.device_name = g_strdup(p2p_identifier);
++			wifi->p2p_device_config.ssid_postfix = g_strdup_printf("-%s", p2p_identifier);
++
++			err = g_supplicant_interface_set_p2p_device_configs(iface, &wifi->p2p_device_config, NULL);
++
++			if(err < 0) {
++				g_free(wifi->p2p_device_config.device_name);
++				g_free(wifi->p2p_device_config.ssid_postfix);
++
++				wifi->p2p_device_config.device_name = old_device_name;
++				wifi->p2p_device_config.ssid_postfix = old_ssid_postfix;
++			} else {
++				connman_technology_set_p2p_identifier(technology, wifi->p2p_device_config.device_name);
++				save_p2p_identifier(wifi->p2p_device_config.device_name);
++
++				g_free(old_device_name);
++				g_free(old_ssid_postfix);
++			}
++		}
++	} else {
++		connman_technology_set_p2p_identifier(technology, p2p_identifier);
++		save_p2p_identifier(p2p_identifier);
++		err = 0;
+ 	}
++	return err;
+ }
+-
+-static gboolean peer_connect_timeout(gpointer data)
++static int tech_set_p2p_persistent(struct connman_technology *technology, bool persistent_reconnect)
+ {
+-	struct wifi_data *wifi = data;
++	GList *list = NULL;
++	int err = 0;
+ 
+-	DBG("");
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	if (wifi->p2p_connecting) {
+-		enum connman_peer_state state = CONNMAN_PEER_STATE_FAILURE;
+-		GSupplicantPeer *gs_peer =
+-			g_supplicant_interface_peer_lookup(wifi->interface,
+-				connman_peer_get_identifier(wifi->pending_peer));
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-		if (g_supplicant_peer_has_requested_connection(gs_peer))
+-			state = CONNMAN_PEER_STATE_IDLE;
++		if (!g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-		connman_peer_set_state(wifi->pending_peer, state);
+-	}
++		wifi->p2p_device_config.persistent_reconnect = persistent_reconnect;
+ 
+-	peer_cancel_timeout(wifi);
++		err = g_supplicant_interface_set_p2p_device_configs(iface, &wifi->p2p_device_config, NULL);
++	}
+ 
+-	return FALSE;
++	return err;
+ }
+-
+-static void peer_connect_callback(int result, GSupplicantInterface *interface,
+-							void *user_data)
++static int listen_reg_class_by_channel(int channel)
+ {
+-	struct wifi_data *wifi = user_data;
+-	struct connman_peer *peer = wifi->pending_peer;
++	int listen_reg_class = 0;
++
++	if (channel >= 1 && channel <= 13)
++		listen_reg_class = 81;
++	else if(channel == 14)
++		listen_reg_class = 82;
++	else if(channel >= 36 && channel <= 48)
++		listen_reg_class = 115;
++	else if(channel >= 52 && channel <= 64)
++		listen_reg_class = 118;
++	else if(channel >= 149 && channel <= 161)
++		listen_reg_class = 124;
++	else if(channel >= 165 && channel <= 169)
++		listen_reg_class = 125;
++
++	return listen_reg_class;
++}
++static int tech_set_p2p_listen_channel(struct connman_technology *technology, unsigned int listen_channel)
++{
++	GList *list = NULL;
++	int err = 0;
+ 
+-	DBG("peer %p - %d", peer, result);
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	if (!peer)
+-		return;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-	if (result < 0) {
+-		peer_connect_timeout(wifi);
+-		return;
+-	}
++		if (!g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-	connman_peer_set_state(peer, CONNMAN_PEER_STATE_ASSOCIATION);
++		DBG("listen channel %d", listen_channel);
+ 
+-	wifi->p2p_connection_timeout = g_timeout_add_seconds(
+-						P2P_CONNECTION_TIMEOUT,
+-						peer_connect_timeout, wifi);
++		wifi->p2p_device_config.listen_reg_class = listen_reg_class_by_channel(listen_channel);
++		wifi->p2p_device_config.listen_channel = listen_channel;
++
++		err = g_supplicant_interface_set_p2p_device_configs(iface, &wifi->p2p_device_config, NULL);
++	}
++
++	return err;
+ }
+ 
+-static int peer_connect(struct connman_peer *peer,
+-			enum connman_peer_wps_method wps_method,
+-			const char *wps_pin)
++static int tech_set_p2p_go_intent(struct connman_technology *technology, unsigned int go_intent)
+ {
+-	struct connman_device *device = connman_peer_get_device(peer);
+-	GSupplicantPeerParams *peer_params;
+-	GSupplicantPeer *gs_peer;
+-	struct wifi_data *wifi;
+-	bool pbc, pin;
+-	int ret;
++	GList *list = NULL;
++	int err = 0;
+ 
+-	DBG("peer %p", peer);
+-
+-	if (!device)
+-		return -ENODEV;
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	wifi = connman_device_get_data(device);
+-	if (!wifi || !wifi->interface)
+-		return -ENODEV;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-	if (wifi->p2p_connecting)
+-		return -EBUSY;
++		if (!iface || !g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-	gs_peer = g_supplicant_interface_peer_lookup(wifi->interface,
+-					connman_peer_get_identifier(peer));
+-	if (!gs_peer)
+-		return -EINVAL;
++		DBG("go intent value : %d", go_intent);
+ 
+-	pbc = g_supplicant_peer_is_wps_pbc(gs_peer);
+-	pin = g_supplicant_peer_is_wps_pin(gs_peer);
++		wifi->p2p_device_config.go_intent = go_intent;
+ 
+-	switch (wps_method) {
+-	case CONNMAN_PEER_WPS_UNKNOWN:
+-		if ((pbc && pin) || pin)
+-			return -ENOKEY;
+-		break;
+-	case CONNMAN_PEER_WPS_PBC:
+-		if (!pbc)
+-			return -EINVAL;
+-		wps_pin = NULL;
+-		break;
+-	case CONNMAN_PEER_WPS_PIN:
+-		if (!pin || !wps_pin)
+-			return -EINVAL;
+-		break;
++		err = g_supplicant_interface_set_p2p_device_configs(iface, &wifi->p2p_device_config, NULL);
+ 	}
+ 
+-	peer_params = g_try_malloc0(sizeof(GSupplicantPeerParams));
+-	if (!peer_params)
+-		return -ENOMEM;
++	return err;
++}
+ 
+-	peer_params->path = g_strdup(g_supplicant_peer_get_path(gs_peer));
+-	if (wps_pin)
+-		peer_params->wps_pin = g_strdup(wps_pin);
++static int set_p2p_listen_without_state_change(struct connman_technology *technology, bool enable)
++{
++	GList *list = NULL;
++	int ret = 0;
+ 
+-	peer_params->master = connman_peer_service_is_master();
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	ret = g_supplicant_interface_p2p_connect(wifi->interface, peer_params,
+-						peer_connect_callback, wifi);
+-	if (ret == -EINPROGRESS) {
+-		wifi->pending_peer = connman_peer_ref(peer);
+-		wifi->p2p_connecting = true;
+-	} else if (ret < 0) {
+-		g_free(peer_params->path);
+-		g_free(peer_params->wps_pin);
+-		g_free(peer_params);
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
++
++		if (!iface || !g_supplicant_interface_has_p2p(iface))
++			continue;
++
++		if (enable) {
++			if (!connman_technology_get_enable_p2p_listen(technology))
++				return -EOPNOTSUPP;
++
++			ret = apply_p2p_listen_on_iface(wifi, &params);
++		}
++		else
++			leave_p2p_listen_on_iface(wifi);
+ 	}
+ 
+ 	return ret;
+ }
+ 
+-static int peer_disconnect(struct connman_peer *peer)
+-{
+-	struct connman_device *device = connman_peer_get_device(peer);
+-	GSupplicantPeerParams peer_params = {};
+-	GSupplicantPeer *gs_peer;
+-	struct wifi_data *wifi;
+-	int ret;
+ 
+-	DBG("peer %p", peer);
++static int tech_set_p2p_listen(struct connman_technology *technology, bool enable)
++{
++	GList *list = NULL;
++	int ret = 0;
+ 
+-	if (!device)
+-		return -ENODEV;
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	wifi = connman_device_get_data(device);
+-	if (!wifi)
+-		return -ENODEV;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-	gs_peer = g_supplicant_interface_peer_lookup(wifi->interface,
+-					connman_peer_get_identifier(peer));
+-	if (!gs_peer)
+-		return -EINVAL;
++		if (!iface || !g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-	peer_params.path = g_strdup(g_supplicant_peer_get_path(gs_peer));
+-
+-	ret = g_supplicant_interface_p2p_disconnect(wifi->interface,
+-							&peer_params);
+-	g_free(peer_params.path);
+-
+-	if (ret == -EINPROGRESS) {
+-		peer_cancel_timeout(wifi);
+-		wifi->p2p_device = false;
+-	}
++		if (p2p_find_ref == -1) {
++			if (enable) {
++				ret = apply_p2p_listen_on_iface(wifi, &params);
++				if (!ret)
++					connman_technology_set_p2p_listen(technology, true);
++			} else {
++				leave_p2p_listen_on_iface(wifi);
++				connman_technology_set_p2p_listen(technology, false);
++			}
++		} else {
++			if (enable)
++				connman_technology_set_p2p_listen(technology, true);
++			else {
++				p2p_find_stop(wifi->device);
++				start_autoscan(wifi->device);
++			}
++		}
++	}
+ 
+ 	return ret;
+ }
+ 
+-struct peer_service_registration {
+-	peer_service_registration_cb_t callback;
+-	void *user_data;
+-};
+-
+-static bool is_service_wfd(const unsigned char *specs, int length)
++static int tech_set_p2p_listen_params(struct connman_technology *technology,
++					int period, int interval)
+ {
+-	if (length < 9 || specs[0] != 0 || specs[1] != 0 || specs[2] != 6)
+-		return false;
++	GList *list = NULL;
++	struct wifi_data *wifi = NULL;
++	bool params_changed = false;
++	int ret = 0;
+ 
+-	return true;
+-}
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-static void apply_p2p_listen_on_iface(gpointer data, gpointer user_data)
+-{
+-	struct wifi_data *wifi = data;
++	DBG("period %d interval %d", period, interval);
+ 
+-	if (!wifi->interface ||
++	if ((params.period != period) || (params.interval != interval)) {
++		params_changed = true;
++		params.period = period;
++		params.interval = interval;
++	}
++
++	if (!connman_technology_get_enable_p2p_listen(technology))
++		return 0;
++
++	for (list = iface_list; list; list = list->next) {
++		wifi = list->data;
++
++		if (!wifi->interface ||
+ 			!g_supplicant_interface_has_p2p(wifi->interface))
+-		return;
++			continue;
+ 
+-	if (!wifi->servicing) {
+-		g_supplicant_interface_p2p_listen(wifi->interface,
+-				P2P_LISTEN_PERIOD, P2P_LISTEN_INTERVAL);
++		// Decrement the count if listen is already set
++		if (wifi->servicing && params_changed)
++			wifi->servicing--;
++
++		ret = apply_p2p_listen_on_iface(wifi, &params);
++		if (ret != 0)
++			continue;
++		if (!connman_technology_get_p2p_listen(p2p_technology))
++			connman_technology_set_p2p_listen(p2p_technology, true);
+ 	}
+ 
+-	wifi->servicing++;
++	return 0;
+ }
+ 
+-static void register_wfd_service_cb(int result,
+-				GSupplicantInterface *iface, void *user_data)
++static void remove_persistent_groups_elements(GSupplicantP2PPersistentGroup *pg)
+ {
+-	struct peer_service_registration *reg_data = user_data;
+-
+-	DBG("");
++	if(pg->path)
++		g_free(pg->path);
++	if(pg->group_path)
++		g_free(pg->group_path);
++	if(pg->bssid)
++		g_free(pg->bssid);
++	if(pg->bssid_no_colon)
++		g_free(pg->bssid_no_colon);
++	if(pg->ssid)
++		g_free(pg->ssid);
++	if(pg->psk)
++		g_free(pg->psk);
++
++	g_free(pg);
++	pg = NULL;
++}
+ 
+-	if (result == 0)
+-		g_list_foreach(iface_list, apply_p2p_listen_on_iface, NULL);
++static void free_persistent_groups(gpointer data)
++{
++	struct GSupplicantP2PPersistentGroup *pg = data;
+ 
+-	if (reg_data && reg_data->callback) {
+-		reg_data->callback(result, reg_data->user_data);
+-		g_free(reg_data);
+-	}
++	if (pg != NULL)
++		remove_persistent_groups_elements(pg);
+ }
+ 
+-static GSupplicantP2PServiceParams *fill_in_peer_service_params(
+-				const unsigned char *spec,
+-				int spec_length, const unsigned char *query,
+-				int query_length, int version)
++static void p2p_persistent_group_added(GSupplicantInterface *interface, GSupplicantP2PPersistentGroup *persistent_group)
+ {
+-	GSupplicantP2PServiceParams *params;
++	struct wifi_data *wifi;
++	wifi = g_supplicant_interface_get_data(interface);
+ 
+-	params = g_try_malloc0(sizeof(GSupplicantP2PServiceParams));
+-	if (!params)
+-		return NULL;
++	DBG("ssid %s", persistent_group->ssid);
+ 
+-	if (version > 0) {
+-		params->version = version;
+-		if (spec_length > 0) {
+-			params->service = g_malloc(spec_length);
+-			memcpy(params->service, spec, spec_length);
+-		}
+-	} else if (query_length > 0 && spec_length > 0) {
+-		params->query = g_malloc(query_length);
+-		memcpy(params->query, query, query_length);
+-		params->query_length = query_length;
++	if(wifi == NULL)
++		goto DONE;
+ 
+-		params->response = g_malloc(spec_length);
+-		memcpy(params->response, spec, spec_length);
+-		params->response_length = spec_length;
+-	} else {
+-		if (spec_length > 0) {
+-			params->wfd_ies = g_malloc(spec_length);
+-			memcpy(params->wfd_ies, spec, spec_length);
++	/* newly added persistent_group */
++	if(persistent_group->psk != NULL){
++		wifi->persistent_groups = g_slist_prepend(wifi->persistent_groups, persistent_group);
++		DBG("new group ssid : %s\n", persistent_group->ssid);
++		return;
++	/* added by service file */
++	} else if (persistent_group->bssid != NULL &&  persistent_group->ssid != NULL) {
++		GSList *item;
++		GSupplicantP2PPersistentGroup *exist_pg;
++
++		item = wifi->persistent_groups;
++		while(item != NULL) {
++			exist_pg = item->data;
++			if(g_str_equal(exist_pg->bssid, persistent_group->bssid) && g_str_equal(exist_pg->ssid, persistent_group->ssid)) {
++				DBG("updating existing group: %s\n", persistent_group->ssid);
++				if (exist_pg->path)
++					g_free(exist_pg->path);
++				exist_pg->path = g_strdup(persistent_group->path);
++
++				if (exist_pg->bssid_no_colon)
++					g_free(exist_pg->bssid_no_colon);
++				exist_pg->bssid_no_colon = g_strdup(persistent_group->bssid_no_colon);
++				break;
++			}
++
++			item = g_slist_next(item);
+ 		}
+-		params->wfd_ies_length = spec_length;
++	} else {
++		DBG("Skipping group, need bssid and ssid!");
+ 	}
+ 
+-	return params;
++DONE:
++	free_persistent_groups(persistent_group);
+ }
+ 
+-static void free_peer_service_params(GSupplicantP2PServiceParams *params)
++static void p2p_persistent_group_removed(GSupplicantInterface *interface, const char *persistent_group_path)
+ {
+-	if (!params)
+-		return;
+-
+-	g_free(params->service);
+-	g_free(params->query);
+-	g_free(params->response);
+-	g_free(params->wfd_ies);
++	struct wifi_data *wifi;
++	GSList *item;
++	GSupplicantP2PPersistentGroup *exist_pg, *removed_pg = NULL;
+ 
+-	g_free(params);
+-}
++	wifi = g_supplicant_interface_get_data(interface);
+ 
+-static int peer_register_wfd_service(const unsigned char *specification,
+-				int specification_length,
+-				peer_service_registration_cb_t callback,
+-				void *user_data)
+-{
+-	struct peer_service_registration *reg_data = NULL;
+-	static GSupplicantP2PServiceParams *params;
+-	int ret;
++	DBG("persistent_group_path %s", persistent_group_path);
+ 
+-	DBG("");
++	if(wifi == NULL || wifi->persistent_groups == NULL || persistent_group_path == NULL)
++		return;
+ 
+-	if (wfd_service_registered)
+-		return -EBUSY;
++	item = wifi->persistent_groups;
++	while(item != NULL) {
++		exist_pg = item->data;
+ 
+-	params = fill_in_peer_service_params(specification,
+-					specification_length, NULL, 0, 0);
+-	if (!params)
+-		return -ENOMEM;
++		if(exist_pg->path && g_str_equal(exist_pg->path, persistent_group_path)) {
++			removed_pg = exist_pg;
++			break;
++		}
++		item = g_slist_next(item);
++	}
+ 
+-	reg_data = g_try_malloc0(sizeof(*reg_data));
+-	if (!reg_data) {
+-		ret = -ENOMEM;
+-		goto error;
++	if(removed_pg != NULL){
++		wifi->persistent_groups = g_slist_remove(wifi->persistent_groups, removed_pg);
++		remove_persistent_groups_elements(removed_pg);
+ 	}
++}
+ 
+-	reg_data->callback = callback;
+-	reg_data->user_data = user_data;
++static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technology,
++		const char *identifier, const char *passphrase) {
++	GList *list;
++	struct wifi_tethering_info *info;
++	char p2p_ssid[P2P_MAX_SSID] = {0x00,};
++	int err = 0;
+ 
+-	ret = g_supplicant_set_widi_ies(params,
+-					register_wfd_service_cb, reg_data);
+-	if (ret < 0 && ret != -EINPROGRESS)
+-		goto error;
++	if (!p2p_technology)
++		return -EOPNOTSUPP;
+ 
+-	wfd_service_registered = true;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-	return ret;
+-error:
+-	free_peer_service_params(params);
+-	g_free(reg_data);
++		if (!iface || !g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-	return ret;
+-}
++		if (connman_technology_get_p2p_listen(technology) == TRUE) {
++			leave_p2p_listen_on_iface(wifi);
++			connman_technology_set_p2p_listen(technology, false);
++		} else {
++			if (wifi->device)
++				p2p_find_stop(wifi->device);
++		}
+ 
+-static void register_peer_service_cb(int result,
+-				GSupplicantInterface *iface, void *user_data)
+-{
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
+-	struct peer_service_registration *reg_data = user_data;
++		info = g_try_malloc0(sizeof(struct wifi_tethering_info));
++		if (info == NULL )
++			return -ENOMEM;
+ 
+-	DBG("");
++		info->wifi = wifi;
++		info->technology = technology;
+ 
+-	if (result == 0)
+-		apply_p2p_listen_on_iface(wifi, NULL);
++		if (identifier || passphrase) {
++			snprintf(p2p_ssid, P2P_MAX_SSID, "%s%s", P2P_WILDCARD_SSID, identifier);
++			info->ssid = ssid_ap_init(p2p_ssid, passphrase);
+ 
+-	if (reg_data->callback)
+-		reg_data->callback(result, reg_data->user_data);
++			err = g_supplicant_interface_p2p_persistent_group_add(iface,
++					info->ssid, NULL, info);
+ 
+-	g_free(reg_data);
++		} else {
++			err = g_supplicant_interface_p2p_group_add(iface, NULL,
++					NULL, info);
++		}
++
++		group_msg = dbus_message_ref(msg);
++		create_group_flag = true;
++	}
++
++	return -err;
+ }
+ 
+-static int peer_register_service(const unsigned char *specification,
+-				int specification_length,
+-				const unsigned char *query,
+-				int query_length, int version,
+-				peer_service_registration_cb_t callback,
+-				void *user_data)
++static int p2p_remove_persistent_info(GSupplicantInterface *interface, const char *peer_ident)
+ {
+-	struct peer_service_registration *reg_data;
+-	GSupplicantP2PServiceParams *params;
+-	bool found = false;
+-	int ret, ret_f;
+-	GList *list;
++	struct wifi_data *wifi;
++	GSupplicantP2PPersistentGroup *persistent_group, *removing_pg;
++	char persistent_info_name[28] = "p2p_persistent_";
++	GSList *item;
+ 
+-	DBG("");
++	DBG("peer_ident %s", peer_ident);
+ 
+-	if (specification && !version && !query &&
+-			is_service_wfd(specification, specification_length)) {
+-		return peer_register_wfd_service(specification,
+-				specification_length, callback, user_data);
+-	}
++	wifi = g_supplicant_interface_get_data(interface);
+ 
+-	reg_data = g_try_malloc0(sizeof(*reg_data));
+-	if (!reg_data)
++	if(wifi == NULL)
+ 		return -ENOMEM;
+ 
+-	reg_data->callback = callback;
+-	reg_data->user_data = user_data;
++	p2p_find_stop(wifi->device);
+ 
+-	ret_f = -EOPNOTSUPP;
++	removing_pg = g_try_malloc0(sizeof(GSupplicantP2PPersistentGroup));
++	if(removing_pg == NULL)
++		return -ENOMEM;
+ 
+-	for (list = iface_list; list; list = list->next) {
+-		struct wifi_data *wifi = list->data;
+-		GSupplicantInterface *iface = wifi->interface;
++	strncat(persistent_info_name, peer_ident, strlen(peer_ident));
+ 
+-		if (!g_supplicant_interface_has_p2p(iface))
+-			continue;
++	p2p_persistent_info_load(interface, persistent_info_name, removing_pg);
+ 
+-		params = fill_in_peer_service_params(specification,
+-						specification_length, query,
+-						query_length, version);
+-		if (!params)
++	if(removing_pg->ssid == NULL) {
++		g_free(removing_pg);
++		return -EOPNOTSUPP;
++	}
++
++	item = wifi->persistent_groups;
++	while(item != NULL) {
++		persistent_group = item->data;
++
++		if(persistent_group->ssid == NULL || persistent_group->bssid == NULL)
+ 			continue;
+ 
+-		if (!found) {
+-			ret_f = g_supplicant_interface_p2p_add_service(iface,
+-				register_peer_service_cb, params, reg_data);
+-			if (ret_f == 0 || ret_f == -EINPROGRESS)
+-				found = true;
+-			ret = ret_f;
+-		} else
+-			ret = g_supplicant_interface_p2p_add_service(iface,
+-				register_peer_service_cb, params, NULL);
+-		if (ret != 0 && ret != -EINPROGRESS)
+-			free_peer_service_params(params);
++		if(g_str_equal(persistent_group->ssid, removing_pg->ssid)
++				&& g_str_equal(persistent_group->bssid, removing_pg->bssid)) {
++			removing_pg->path = persistent_group->path;
++			break;
++		}
++		item = g_slist_next(item);
+ 	}
+ 
+-	if (ret_f != 0 && ret_f != -EINPROGRESS)
+-		g_free(reg_data);
++	if(removing_pg->path != NULL) {
++		struct connman_network *network;
+ 
+-	return ret_f;
++		g_supplicant_interface_p2p_remove_persistent_group(interface, removing_pg->path);
++		g_hash_table_remove(wifi->persistent_peer_ssid, peer_ident);
++		g_free(removing_pg);
++		__connman_storage_remove_service(persistent_info_name);
++
++		return 0;
++	}
++
++	g_free(removing_pg);
++
++	return -EOPNOTSUPP;
+ }
+ 
+-static int peer_unregister_wfd_service(void)
++
++static int tech_remove_persistent_info(struct connman_technology *technology, const char *identifier)
+ {
+-	GSupplicantP2PServiceParams *params;
+ 	GList *list;
++	struct wifi_data *wifi;
++	GSupplicantInterface *interface;
++	const char *addr_no_colon;
++	int err = 0;
+ 
+-	if (!wfd_service_registered)
+-		return -EALREADY;
+-
+-	params = fill_in_peer_service_params(NULL, 0, NULL, 0, 0);
+-	if (!params)
+-		return -ENOMEM;
+-
+-	wfd_service_registered = false;
++	if (!is_technology_enabled(p2p_technology))
++		return -EOPNOTSUPP;
+ 
+-	g_supplicant_set_widi_ies(params, NULL, NULL);
++	addr_no_colon = __connman_util_remove_colon_from_mac_addr(identifier);
++	if(addr_no_colon == NULL)
++		return -EINVAL;
+ 
+ 	for (list = iface_list; list; list = list->next) {
+-		struct wifi_data *wifi = list->data;
++		wifi = list->data;
++		interface = wifi->interface;
+ 
+-		if (!g_supplicant_interface_has_p2p(wifi->interface))
++		if (!interface || !g_supplicant_interface_has_p2p(interface))
+ 			continue;
+ 
+-		wifi->servicing--;
+-		if (!wifi->servicing || wifi->servicing < 0) {
+-			g_supplicant_interface_p2p_listen(wifi->interface,
+-									0, 0);
+-			wifi->servicing = 0;
+-		}
++		err = p2p_remove_persistent_info(interface, addr_no_colon);
+ 	}
+ 
+-	return 0;
++	g_free(addr_no_colon);
++
++	return err;
+ }
+ 
+-static int peer_unregister_service(const unsigned char *specification,
+-						int specification_length,
+-						const unsigned char *query,
+-						int query_length, int version)
++static int tech_remove_persistent_info_all(struct connman_technology *technology)
+ {
+-	GSupplicantP2PServiceParams *params;
+-	bool wfd = false;
+ 	GList *list;
+-	int ret;
++	struct wifi_data *wifi = NULL;
++	GSupplicantInterface *interface;
++	gchar **persistents;
++	char *peer_ident;
++	struct connman_network *network;
++	int i;
+ 
+-	if (specification && !version && !query &&
+-			is_service_wfd(specification, specification_length)) {
+-		ret = peer_unregister_wfd_service();
+-		if (ret != 0 && ret != -EINPROGRESS)
+-			return ret;
+-		wfd = true;
+-	}
++	if (!is_technology_enabled(p2p_technology))
++		return -EOPNOTSUPP;
+ 
+ 	for (list = iface_list; list; list = list->next) {
+-		struct wifi_data *wifi = list->data;
+-		GSupplicantInterface *iface = wifi->interface;
+-
+-		if (wfd)
+-			goto stop_listening;
++		wifi = list->data;
++		interface = wifi->interface;
+ 
+-		if (!g_supplicant_interface_has_p2p(iface))
++		if (interface == NULL || !g_supplicant_interface_has_p2p(interface))
+ 			continue;
+ 
+-		params = fill_in_peer_service_params(specification,
+-						specification_length, query,
+-						query_length, version);
+-		if (!params)
++		g_supplicant_interface_p2p_remove_all_persistent_groups(interface);
++	}
++
++	persistents = __connman_storage_get_p2p_persistents();
++	for (i = 0; persistents && persistents[i]; i++) {
++		DBG("loop : %s\n", persistents[i]);
++
++		if (strncmp(persistents[i], "p2p_persistent_", 15) != 0)
+ 			continue;
+ 
+-		ret = g_supplicant_interface_p2p_del_service(iface, params);
+-		if (ret != 0 && ret != -EINPROGRESS)
+-			free_peer_service_params(params);
+-stop_listening:
+-		wifi->servicing--;
+-		if (!wifi->servicing || wifi->servicing < 0) {
+-			g_supplicant_interface_p2p_listen(iface, 0, 0);
+-			wifi->servicing = 0;
+-		}
++		__connman_storage_remove_service(persistents[i]);
++
+ 	}
+ 
+-	return 0;
+-}
++	if (wifi)
++		g_hash_table_remove_all(wifi->persistent_peer_ssid);
+ 
+-static struct connman_peer_driver peer_driver = {
+-	.connect    = peer_connect,
+-	.disconnect = peer_disconnect,
+-	.register_service = peer_register_service,
+-	.unregister_service = peer_unregister_service,
++	if (persistents)
++		g_strfreev(persistents);
++	return 1;
++}
++static struct connman_technology_driver p2p_tech_driver = {
++	.name		= "p2p",
++	.type		= CONNMAN_SERVICE_TYPE_P2P,
++	.probe		= p2p_tech_probe,
++	.remove		= p2p_tech_remove,
++	.set_p2p_enable = tech_set_p2p_enable,
++	.set_p2p_identifier = tech_set_p2p_identifier,
++	.set_p2p_persistent = tech_set_p2p_persistent,
++	.set_p2p_listen_channel = tech_set_p2p_listen_channel,
++	.set_p2p_go_intent = tech_set_p2p_go_intent,
++	.set_p2p_listen = tech_set_p2p_listen,
++	.set_p2p_listen_params = tech_set_p2p_listen_params,
++	.set_p2p_go = tech_set_p2p_go,
++	.remove_persistent_info = tech_remove_persistent_info,
++	.remove_persistent_info_all = tech_remove_persistent_info_all,
+ };
+ 
+-static void handle_tethering(struct wifi_data *wifi)
++static bool is_p2p_connecting(void)
+ {
+-	if (!wifi->tethering)
+-		return;
++	GList *list;
+ 
+-	if (!wifi->bridge)
+-		return;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
+ 
+-	if (wifi->bridged)
+-		return;
++		if (wifi->p2p_connecting)
++			return true;
++	}
+ 
+-	DBG("index %d bridge %s", wifi->index, wifi->bridge);
++	return false;
++}
+ 
+-	if (connman_inet_add_to_bridge(wifi->index, wifi->bridge) < 0)
++static void enable_auto_connect_block(bool block)
++{
++	DBG("block %d", block);
++	if (block)
++		block_auto_connect = true;
++	else {
++		block_auto_connect = false;
++		__connman_service_auto_connect(CONNMAN_SERVICE_CONNECT_REASON_AUTO);
++	}
++}
++
++static void add_pending_wifi_device(struct wifi_data *wifi)
++{
++	if (g_list_find(pending_wifi_device, wifi))
+ 		return;
+ 
+-	wifi->bridged = true;
++	pending_wifi_device = g_list_append(pending_wifi_device, wifi);
+ }
+ 
+-static void wifi_newlink(unsigned flags, unsigned change, void *user_data)
++static struct wifi_data *get_pending_wifi_data(const char *ifname)
+ {
+-	struct connman_device *device = user_data;
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-
+-	if (!wifi)
+-		return;
++	GList *list;
+ 
+-	DBG("index %d flags %d change %d", wifi->index, flags, change);
++	for (list = pending_wifi_device; list; list = list->next) {
++		struct wifi_data *wifi;
++		const char *dev_name;
+ 
+-	if ((wifi->flags & IFF_UP) != (flags & IFF_UP)) {
+-		if (flags & IFF_UP)
+-			DBG("interface up");
+-		else
+-			DBG("interface down");
+-	}
++		wifi = list->data;
++		if (!wifi || !wifi->device)
++			continue;
+ 
+-	if ((wifi->flags & IFF_LOWER_UP) != (flags & IFF_LOWER_UP)) {
+-		if (flags & IFF_LOWER_UP)
+-			DBG("carrier on");
+-		else
+-			DBG("carrier off");
++		dev_name = connman_device_get_string(wifi->device, "Interface");
++		if (!g_strcmp0(ifname, dev_name)) {
++			pending_wifi_device = g_list_delete_link(
++						pending_wifi_device, list);
++			return wifi;
++		}
+ 	}
+ 
+-	if (flags & IFF_LOWER_UP)
+-		handle_tethering(wifi);
+-
+-	wifi->flags = flags;
++	return NULL;
+ }
+ 
+-static int wifi_probe(struct connman_device *device)
++static void remove_pending_wifi_device(struct wifi_data *wifi)
+ {
+-	struct wifi_data *wifi;
+-
+-	DBG("device %p", device);
+-
+-	wifi = g_try_new0(struct wifi_data, 1);
+-	if (!wifi)
+-		return -ENOMEM;
+-
+-	wifi->state = G_SUPPLICANT_STATE_INACTIVE;
+-	wifi->ap_supported = WIFI_AP_UNKNOWN;
+-	wifi->tethering_param = NULL;
+-
+-	connman_device_set_data(device, wifi);
+-	wifi->device = connman_device_ref(device);
++	GList *link;
+ 
+-	wifi->index = connman_device_get_index(device);
+-	wifi->flags = 0;
++	link = g_list_find(pending_wifi_device, wifi);
+ 
+-	wifi->watch = connman_rtnl_add_newlink_watch(wifi->index,
+-							wifi_newlink, device);
+-	if (is_p2p_connecting())
+-		add_pending_wifi_device(wifi);
+-	else
+-		iface_list = g_list_append(iface_list, wifi);
++	if (!link)
++		return;
+ 
+-	return 0;
++	pending_wifi_device = g_list_delete_link(pending_wifi_device, link);
+ }
+ 
+-static void remove_networks(struct connman_device *device,
+-				struct wifi_data *wifi)
++static void peer_cancel_timeout(struct wifi_data *wifi)
+ {
+-	GSList *list;
++	if (wifi->p2p_connection_timeout > 0)
++		g_source_remove(wifi->p2p_connection_timeout);
+ 
+-	for (list = wifi->networks; list; list = list->next) {
+-		struct connman_network *network = list->data;
++	wifi->p2p_connection_timeout = 0;
++	wifi->p2p_connecting = false;
+ 
+-		g_free(connman_network_get_data(network));
+-		connman_device_remove_network(device, network);
+-		connman_network_unref(network);
++	if (wifi->pending_peer) {
++		connman_peer_unref(wifi->pending_peer);
++		wifi->pending_peer = NULL;
+ 	}
+-
+-	g_slist_free(wifi->networks);
+-	wifi->networks = NULL;
+ }
+ 
+-static void remove_peers(struct wifi_data *wifi)
++static gboolean peer_connect_timeout(gpointer data)
+ {
+-	GSList *list;
++	struct wifi_data *wifi = data;
+ 
+-	for (list = wifi->peers; list; list = list->next) {
+-		struct connman_peer *peer = list->data;
++	DBG("");
+ 
+-		connman_peer_unregister(peer);
+-		connman_peer_unref(peer);
++	if (wifi->p2p_connecting) {
++		enum connman_peer_state state = CONNMAN_PEER_STATE_FAILURE;
++		GSupplicantPeer *gs_peer =
++			g_supplicant_interface_peer_lookup(wifi->interface,
++				connman_peer_get_identifier(wifi->pending_peer));
++
++		if (g_supplicant_peer_has_requested_connection(gs_peer))
++			state = CONNMAN_PEER_STATE_IDLE;
++
++		connman_peer_set_state(wifi->pending_peer, state);
+ 	}
+ 
+-	g_slist_free(wifi->peers);
+-	wifi->peers = NULL;
++	peer_cancel_timeout(wifi);
++
++	return FALSE;
+ }
+ 
+-static void reset_autoscan(struct connman_device *device)
++static void peer_connect_callback(int result, GSupplicantInterface *interface,
++							void *user_data)
+ {
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-	struct autoscan_params *autoscan;
++	struct wifi_data *wifi = user_data;
++	struct connman_peer *peer = wifi->pending_peer;
+ 
+-	DBG("");
++	DBG("peer %p - %d", peer, result);
+ 
+-	if (!wifi || !wifi->autoscan)
++	if (!peer)
+ 		return;
+ 
+-	autoscan = wifi->autoscan;
+-
+-	autoscan->interval = 0;
+-
+-	if (autoscan->timeout == 0)
++	if (result < 0) {
++		peer_connect_timeout(wifi);
+ 		return;
++	}
+ 
+-	g_source_remove(autoscan->timeout);
+-	autoscan->timeout = 0;
++	connman_peer_set_state(peer, CONNMAN_PEER_STATE_ASSOCIATION);
+ 
+-	connman_device_unref(device);
++	wifi->p2p_connection_timeout = g_timeout_add_seconds(
++						P2P_CONNECTION_TIMEOUT,
++						peer_connect_timeout, wifi);
+ }
+ 
+-static void stop_autoscan(struct connman_device *device)
++static int peer_connect(struct connman_peer *peer,
++			enum connman_peer_wps_method wps_method,
++			const char *wps_pin)
+ {
+-	const struct wifi_data *wifi = connman_device_get_data(device);
++	struct connman_device *device = connman_peer_get_device(peer);
++	GSupplicantPeerParams *peer_params;
++	GSupplicantPeer *gs_peer;
++	struct wifi_data *wifi;
++	bool pbc, pin;
++	int ret;
+ 
+-	if (!wifi || !wifi->autoscan)
+-		return;
++	DBG("peer %p", peer);
+ 
+-	reset_autoscan(device);
++	if (!device)
++		return -ENODEV;
+ 
+-	connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_WIFI, false);
+-}
++	wifi = connman_device_get_data(device);
++	if (!wifi || !wifi->interface)
++		return -ENODEV;
+ 
+-static void check_p2p_technology(void)
+-{
+-	bool p2p_exists = false;
+-	GList *list;
++	if (wifi->p2p_connecting)
++		return -EBUSY;
+ 
+-	for (list = iface_list; list; list = list->next) {
+-		struct wifi_data *w = list->data;
++	gs_peer = g_supplicant_interface_peer_lookup(wifi->interface,
++					connman_peer_get_identifier(peer));
++	if (!gs_peer)
++		return -EINVAL;
+ 
+-		if (w->interface &&
+-				g_supplicant_interface_has_p2p(w->interface))
+-			p2p_exists = true;
++	pbc = g_supplicant_peer_is_wps_pbc(gs_peer);
++	pin = g_supplicant_peer_is_wps_pin(gs_peer);
++
++	switch (wps_method) {
++	case CONNMAN_PEER_WPS_UNKNOWN:
++		if ((pbc && pin) || pin)
++			return -ENOKEY;
++		break;
++	case CONNMAN_PEER_WPS_PBC:
++		if (!pbc)
++			return -EINVAL;
++		wps_pin = NULL;
++		break;
++	case CONNMAN_PEER_WPS_PIN:
++		if (!pin || !wps_pin)
++			return -EINVAL;
++		break;
+ 	}
+ 
+-	if (!p2p_exists) {
+-		connman_technology_driver_unregister(&p2p_tech_driver);
+-		connman_peer_driver_unregister(&peer_driver);
++	if (connman_technology_get_p2p_listen(p2p_technology)) {
++		leave_p2p_listen_on_iface(wifi);
++		connman_technology_set_p2p_listen(p2p_technology, false);
+ 	}
+-}
+ 
+-static void wifi_remove(struct connman_device *device)
+-{
+-	struct wifi_data *wifi = connman_device_get_data(device);
++	if(p2p_go_identifier != NULL) {
++			struct connman_network *network;
++			const char *wp_pin = NULL;
+ 
+-	DBG("device %p wifi %p", device, wifi);
++			struct connman_group * group = __connman_group_lookup_from_ident(p2p_go_identifier);
++			const char *identifier = connman_peer_get_identifier(peer);
+ 
+-	if (!wifi)
+-		return;
++			network = connman_device_get_network(wifi->device, identifier);
+ 
+-	stop_autoscan(device);
++			if(group != NULL) {
++				GSupplicantP2PWPSParams *wps_params = NULL;
+ 
+-	if (wifi->p2p_device)
+-		p2p_iface_list = g_list_remove(p2p_iface_list, wifi);
+-	else
+-		iface_list = g_list_remove(iface_list, wifi);
++				wps_params = g_try_malloc0(sizeof(GSupplicantP2PWPSParams));
++				if(wps_params == NULL)
++					return -ENOMEM;
+ 
+-	check_p2p_technology();
++				if (network != NULL)
++					wp_pin = connman_network_get_string(network, "WiFi.PinWPS");
+ 
+-	remove_pending_wifi_device(wifi);
++				wps_params->role = "enrollee";
++				if(wp_pin == NULL) {
++					wps_params->type = "pbc";
++					wps_params->p2p_dev_addr = identifier;
++				} else {
++					wps_params->type = "pin";
++					wps_params->pin = wp_pin;
++				}
+ 
+-	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_P2P)) {
+-		g_source_remove(wifi->p2p_find_timeout);
+-		connman_device_unref(wifi->device);
++				ret = __connman_group_accept_connection(group, wps_params);
++
++				if(ret == -EINPROGRESS) {
++					wifi->pending_peer = connman_peer_ref(peer);
++					wifi->p2p_connecting = true;
++				}
++
++				return ret;
++			} else
++				return -ENOMEM;
+ 	}
+ 
+-	if (wifi->p2p_connection_timeout)
+-		g_source_remove(wifi->p2p_connection_timeout);
++	peer_params = g_try_malloc0(sizeof(GSupplicantPeerParams));
++	if (!peer_params)
++		return -ENOMEM;
+ 
+-	remove_networks(device, wifi);
+-	remove_peers(wifi);
++	peer_params->path = g_strdup(g_supplicant_peer_get_path(gs_peer));
++	if (wps_pin)
++		peer_params->wps_pin = g_strdup(wps_pin);
+ 
+-	connman_device_set_powered(device, false);
+-	connman_device_set_data(device, NULL);
+-	connman_device_unref(wifi->device);
+-	connman_rtnl_remove_watch(wifi->watch);
++	peer_params->master = connman_peer_service_is_master();
++	peer_params->authorize_only= FALSE;
++	peer_params->join = FALSE;
+ 
+-	g_supplicant_interface_set_data(wifi->interface, NULL);
++	peer_params->go_intent = wifi->p2p_device_config.go_intent;
++	if(connman_technology_get_p2p_persistent(p2p_technology))
++		peer_params->persistent = TRUE;
++	else
++		peer_params->persistent = FALSE;
++
++	const char* connman_peer_path = __connman_peer_get_path(peer);
++
++	if (wifi->pin_requested_path && g_str_equal(wifi->pin_requested_path, connman_peer_path)
++		&& wifi->generated_pin) {
++		wps_method = CONNMAN_PEER_WPS_DISPLAY;
++		wifi->pin_requested_path = NULL;
++	} else if (wifi->invited_path && g_str_equal(wifi->invited_path, connman_peer_path)) {
++		wps_method = CONNMAN_PEER_WPS_DISPLAY;
++		peer_params->join = TRUE;
++		wifi->invited_path = NULL;
++	}
+ 
+-	g_supplicant_interface_cancel(wifi->interface);
++	peer_params->wps_method= g_strdup(connman_peer_wps_method2string(wps_method));
+ 
+-	if (wifi->scan_params)
+-		g_supplicant_free_scan_params(wifi->scan_params);
++	ret = g_supplicant_interface_p2p_connect(wifi->interface, peer_params,
++						peer_connect_callback, wifi);
++	if (ret == -EINPROGRESS) {
++		wifi->pending_peer = connman_peer_ref(peer);
++		wifi->p2p_connecting = true;
++	} else if (ret < 0) {
++		g_free(peer_params->path);
++		g_free(peer_params->wps_pin);
++		g_free(peer_params->wps_method);
++		g_free(peer_params);
++	}
+ 
+-	g_free(wifi->autoscan);
+-	g_free(wifi->identifier);
+-	g_free(wifi);
++	return ret;
+ }
+ 
+-static bool is_duplicate(GSList *list, gchar *ssid, int ssid_len)
++static void p2p_peers_refresh(struct wifi_data *wifi)
+ {
+-	GSList *iter;
++	GSupplicantInterface *interface = wifi->interface;
++	int err;
+ 
+-	for (iter = list; iter; iter = g_slist_next(iter)) {
+-		struct scan_ssid *scan_ssid = iter->data;
++	err = g_supplicant_interface_p2p_flush(interface, NULL, NULL);
+ 
+-		if (ssid_len == scan_ssid->ssid_len &&
+-				memcmp(ssid, scan_ssid->ssid, ssid_len) == 0)
+-			return true;
++	if (!connman_technology_get_enable_p2p_listen(p2p_technology))
++		return;
++
++	//Do not p2p find from webOS 4.5 platform, since there is no WiFi Direct menu
++	// in settings, so no need to list the peers
++	// if(err == -EINPROGRESS)
++		//p2p_find(wifi->device);
++	if (__connman_get_connected_peer() == NULL && wifi->servicing){
++		leave_p2p_listen_on_iface(wifi);
+ 	}
+ 
+-	return false;
++	err = apply_p2p_listen_on_iface(wifi, &params);
++	if (err == 0)
++		connman_technology_set_p2p_listen(p2p_technology, true);
+ }
+ 
+-static int add_scan_param(gchar *hex_ssid, char *raw_ssid, int ssid_len,
+-			int freq, GSupplicantScanParams *scan_data,
+-			int driver_max_scan_ssids, char *ssid_name)
++static int peer_disconnect(struct connman_peer *peer)
+ {
+-	unsigned int i;
+-	struct scan_ssid *scan_ssid;
+-
+-	if ((driver_max_scan_ssids == 0 ||
+-			driver_max_scan_ssids > scan_data->num_ssids) &&
+-			(hex_ssid || raw_ssid)) {
+-		gchar *ssid;
+-		unsigned int j = 0, hex;
++	struct connman_device *device = connman_peer_get_device(peer);
++	GSupplicantPeer *gs_peer;
++	struct wifi_data *wifi;
++	char* peer_path = NULL;
++	int ret;
+ 
+-		if (hex_ssid) {
+-			size_t hex_ssid_len = strlen(hex_ssid);
++	DBG("peer %p", peer);
+ 
+-			ssid = g_try_malloc0(hex_ssid_len / 2);
+-			if (!ssid)
+-				return -ENOMEM;
++	if (!device)
++		return -ENODEV;
+ 
+-			for (i = 0; i < hex_ssid_len; i += 2) {
+-				sscanf(hex_ssid + i, "%02x", &hex);
+-				ssid[j++] = hex;
+-			}
+-		} else {
+-			ssid = raw_ssid;
+-			j = ssid_len;
++	if (p2p_go_identifier) {
++		struct connman_group *connman_group;
++		bool autonomous;
++		connman_group = __connman_group_lookup_from_ident(p2p_go_identifier);
++		if (connman_group) {
++			autonomous = __connman_group_is_autonomous(connman_group);
++			if (autonomous)
++				return -ENOTSUP;
+ 		}
++	}
+ 
+-		/*
+-		 * If we have already added hidden AP to the list,
+-		 * then do not do it again. This might happen if you have
+-		 * used or are using multiple wifi cards, so in that case
+-		 * you might have multiple service files for same AP.
+-		 */
+-		if (is_duplicate(scan_data->ssids, ssid, j)) {
+-			if (hex_ssid)
+-				g_free(ssid);
+-			return 0;
+-		}
++	wifi = connman_device_get_data(device);
++	if (!wifi)
++		return -ENODEV;
+ 
+-		scan_ssid = g_try_new(struct scan_ssid, 1);
+-		if (!scan_ssid) {
+-			if (hex_ssid)
+-				g_free(ssid);
+-			return -ENOMEM;
+-		}
++	gs_peer = g_supplicant_interface_peer_lookup(wifi->interface,
++					connman_peer_get_identifier(peer));
++	if (!gs_peer)
++		return -EINVAL;
+ 
+-		memcpy(scan_ssid->ssid, ssid, j);
+-		scan_ssid->ssid_len = j;
+-		scan_data->ssids = g_slist_prepend(scan_data->ssids,
+-								scan_ssid);
++	peer_path = g_strdup(g_supplicant_peer_get_path(gs_peer));
+ 
+-		scan_data->num_ssids++;
++	ret = g_supplicant_interface_p2p_client_remove(wifi->interface, NULL, peer_path);
++	g_free(peer_path);
+ 
+-		DBG("SSID %s added to scanned list of %d entries", ssid_name,
+-							scan_data->num_ssids);
++	if (ret == -EINPROGRESS) {
++		peer_cancel_timeout(wifi);
++		wifi->p2p_device = false;
++		__connman_peer_set_static_ip(peer, NULL);
++	}
+ 
+-		if (hex_ssid)
+-			g_free(ssid);
+-	} else
+-		return -EINVAL;
++	if (!__connman_get_connected_peer())
++		p2p_peers_refresh(wifi);
+ 
+-	scan_data->ssids = g_slist_reverse(scan_data->ssids);
++	return ret;
++}
++static gboolean timeout_p2p_listen_state(gpointer user_data)
++{
++	GSupplicantInterface *interface = user_data;
+ 
+-	if (!scan_data->freqs) {
+-		scan_data->freqs = g_try_malloc0(sizeof(uint16_t));
+-		if (!scan_data->freqs) {
+-			g_slist_free_full(scan_data->ssids, g_free);
+-			return -ENOMEM;
+-		}
++	p2p_listen_ref = -1;
+ 
+-		scan_data->num_freqs = 1;
+-		scan_data->freqs[0] = freq;
+-	} else {
+-		bool duplicate = false;
++	if (connman_technology_get_p2p_listen(p2p_technology) == false &&
++			!__connman_peer_get_connected_exists())
++		tech_set_p2p_listen(p2p_technology, true);
+ 
+-		/* Don't add duplicate entries */
+-		for (i = 0; i < scan_data->num_freqs; i++) {
+-			if (scan_data->freqs[i] == freq) {
+-				duplicate = true;
+-				break;
+-			}
+-		}
++	return FALSE;
++}
++static void reject_peer_callback(int result, GSupplicantInterface *interface,
++								void *user_data)
++{
++	struct connman_peer *peer= user_data;
+ 
+-		if (!duplicate) {
+-			scan_data->num_freqs++;
+-			scan_data->freqs = g_try_realloc(scan_data->freqs,
+-				sizeof(uint16_t) * scan_data->num_freqs);
+-			if (!scan_data->freqs) {
+-				g_slist_free_full(scan_data->ssids, g_free);
+-				return -ENOMEM;
+-			}
+-			scan_data->freqs[scan_data->num_freqs - 1] = freq;
+-		}
+-	}
++	DBG("result %d supplicant interface %p peer %p",
++			result, interface, peer);
+ 
+-	return 1;
+-}
++	if (result < 0)
++		return;
+ 
+-static int get_hidden_connections(GSupplicantScanParams *scan_data)
+-{
+-	struct connman_config_entry **entries;
+-	GKeyFile *keyfile;
+-	gchar **services;
+-	char *ssid, *name;
+-	int i, ret;
+-	bool value;
+-	int num_ssids = 0, add_param_failed = 0;
++	/*
++	 * Current wpa_supplicant does not supports to emit the signal which is
++	 * P2P negotiation failure when calling RejectPeer().
++	 * To do this, we should call dummy Connect() after RejectPeer().
++	 */
++	peer_connect(peer, CONNMAN_PEER_WPS_PBC, "");
+ 
+-	services = connman_storage_get_services();
+-	for (i = 0; services && services[i]; i++) {
+-		if (strncmp(services[i], "wifi_", 5) != 0)
+-			continue;
++	if (p2p_listen_ref != -1)
++		g_source_remove(p2p_listen_ref);
+ 
+-		keyfile = connman_storage_load_service(services[i]);
+-		if (!keyfile)
+-			continue;
++	p2p_listen_ref = g_timeout_add(3000, timeout_p2p_listen_state, interface);
++}
++static int peer_reject(struct connman_peer *peer)
++{
++	struct connman_device *device = connman_peer_get_device(peer);
++	GSupplicantPeerParams peer_params = {};
++	GSupplicantPeer *gs_peer;
++	struct wifi_data *wifi;
++	int ret;
+ 
+-		value = g_key_file_get_boolean(keyfile,
+-					services[i], "Hidden", NULL);
+-		if (!value) {
+-			g_key_file_free(keyfile);
+-			continue;
+-		}
++	DBG("peer %p", peer);
+ 
+-		value = g_key_file_get_boolean(keyfile,
+-					services[i], "Favorite", NULL);
+-		if (!value) {
+-			g_key_file_free(keyfile);
+-			continue;
+-		}
++	if (!device)
++		return -ENODEV;
+ 
+-		ssid = g_key_file_get_string(keyfile,
+-					services[i], "SSID", NULL);
++	wifi = connman_device_get_data(device);
++	if (!wifi)
++		return -ENODEV;
+ 
+-		name = g_key_file_get_string(keyfile, services[i], "Name",
+-								NULL);
++	gs_peer = g_supplicant_interface_peer_lookup(wifi->interface,
++					connman_peer_get_identifier(peer));
++	if (!gs_peer)
++		return -EINVAL;
+ 
+-		ret = add_scan_param(ssid, NULL, 0, 0, scan_data, 0, name);
+-		if (ret < 0)
+-			add_param_failed++;
+-		else if (ret > 0)
+-			num_ssids++;
++	peer_params.path = g_strdup(g_supplicant_peer_get_path(gs_peer));
+ 
+-		g_free(ssid);
+-		g_free(name);
+-		g_key_file_free(keyfile);
++	ret = g_supplicant_interface_p2p_disconnect(wifi->interface,
++							&peer_params);
++	g_free(peer_params.path);
++
++	if (ret == -EINPROGRESS) {
++		peer_cancel_timeout(wifi);
++		wifi->p2p_device = false;
+ 	}
+ 
+-	/*
+-	 * Check if there are any hidden AP that needs to be provisioned.
+-	 */
+-	entries = connman_config_get_entries("wifi");
+-	for (i = 0; entries && entries[i]; i++) {
+-		int len;
++	return ret;
++}
+ 
+-		if (!entries[i]->hidden)
+-			continue;
++struct peer_service_registration {
++	peer_service_registration_cb_t callback;
++	void *user_data;
++};
+ 
+-		if (!entries[i]->ssid) {
+-			ssid = entries[i]->name;
+-			len = strlen(ssid);
+-		} else {
+-			ssid = entries[i]->ssid;
+-			len = entries[i]->ssid_len;
+-		}
++static bool is_service_wfd(const unsigned char *specs, int length)
++{
++	if (length < 9 || specs[0] != 0 || specs[1] != 0 || specs[2] != 6)
++		return false;
+ 
+-		if (!ssid)
+-			continue;
++	return true;
++}
+ 
+-		ret = add_scan_param(NULL, ssid, len, 0, scan_data, 0, ssid);
+-		if (ret < 0)
+-			add_param_failed++;
+-		else if (ret > 0)
+-			num_ssids++;
+-	}
++static void apply_p2p_listen_callback(int result, GSupplicantInterface *interface, void *user_data)
++{
++	struct wifi_data *wifi = user_data;
+ 
+-	connman_config_free_entries(entries);
++	if (result < 0) {
++		connman_info("p2p extended listen set failed(%d)", result);
++		wifi->servicing--;
++	}
++}
++static int apply_p2p_listen_on_iface(gpointer data, gpointer user_data)
++{
++	int err = 0;
++	struct wifi_data *wifi = data;
++	struct p2p_listen_data* listenParams = user_data;
+ 
+-	if (add_param_failed > 0)
+-		DBG("Unable to scan %d out of %d SSIDs",
+-					add_param_failed, num_ssids);
++	if (!listenParams)
++		return -EINVAL;
+ 
+-	g_strfreev(services);
++	if (!wifi->interface ||
++			!g_supplicant_interface_has_p2p(wifi->interface))
++		return -ENODEV;
+ 
+-	return num_ssids;
+-}
++	if (connman_setting_get_bool("SupportP2P0Interface") &&
++		g_strcmp0(connman_device_get_string(wifi->device, "Interface"),
++				connman_option_get_string("P2PDevice")) != 0)
++		return -EOPNOTSUPP;
+ 
+-static int get_hidden_connections_params(struct wifi_data *wifi,
+-					GSupplicantScanParams *scan_params)
+-{
+-	int driver_max_ssids, i;
+-	GSupplicantScanParams *orig_params;
++	if (__connman_group_exist())
++		return -EALREADY;
+ 
+-	/*
+-	 * Scan hidden networks so that we can autoconnect to them.
+-	 * We will assume 1 as a default number of ssid to scan.
+-	 */
+-	driver_max_ssids = g_supplicant_interface_get_max_scan_ssids(
+-							wifi->interface);
+-	if (driver_max_ssids == 0)
+-		driver_max_ssids = 1;
++	if (!wifi->servicing) {
++		err = g_supplicant_interface_p2p_listen(wifi->interface,
++				listenParams->period, listenParams->interval, apply_p2p_listen_callback, wifi);
+ 
+-	DBG("max ssids %d", driver_max_ssids);
++		wifi->servicing++;
++	}
++	return err;
++}
+ 
+-	if (!wifi->scan_params) {
+-		wifi->scan_params = g_try_malloc0(sizeof(GSupplicantScanParams));
+-		if (!wifi->scan_params)
+-			return 0;
++static void leave_p2p_listen_on_iface(gpointer data)
++{
++	struct wifi_data *wifi = data;
++	if (!wifi->interface ||
++			!g_supplicant_interface_has_p2p(wifi->interface))
++		return;
+ 
+-		if (get_hidden_connections(wifi->scan_params) == 0) {
+-			g_supplicant_free_scan_params(wifi->scan_params);
+-			wifi->scan_params = NULL;
++	if (connman_setting_get_bool("SupportP2P0Interface") &&
++		g_strcmp0(connman_device_get_string(wifi->device, "Interface"),
++				connman_option_get_string("P2PDevice")) != 0)
++		return;
+ 
+-			return 0;
+-		}
++	wifi->servicing--;
++	if (!wifi->servicing || wifi->servicing < 0) {
++		g_supplicant_interface_p2p_listen(wifi->interface, 0, 0, NULL, wifi);
++		wifi->servicing = 0;
+ 	}
++}
+ 
+-	orig_params = wifi->scan_params;
++static void register_wfd_service_cb(int result,
++				GSupplicantInterface *iface, void *user_data)
++{
++	struct peer_service_registration *reg_data = user_data;
+ 
+-	/* Let's transfer driver_max_ssids params */
+-	for (i = 0; i < driver_max_ssids; i++) {
+-		struct scan_ssid *ssid;
++	DBG("");
+ 
+-		if (!wifi->scan_params->ssids)
+-			break;
++	if (result == 0)
++		g_list_foreach(iface_list, apply_p2p_listen_on_iface, NULL);
+ 
+-		ssid = orig_params->ssids->data;
+-		orig_params->ssids = g_slist_remove(orig_params->ssids, ssid);
+-		scan_params->ssids = g_slist_prepend(scan_params->ssids, ssid);
++	if (reg_data && reg_data->callback) {
++		reg_data->callback(result, reg_data->user_data);
++		g_free(reg_data);
+ 	}
++}
+ 
+-	if (i > 0) {
+-		scan_params->num_ssids = i;
+-		scan_params->ssids = g_slist_reverse(scan_params->ssids);
+-
+-		if (orig_params->num_freqs <= 0)
+-			goto err;
++static GSupplicantP2PServiceParams *fill_in_peer_service_params(
++				const unsigned char *spec,
++				int spec_length, const unsigned char *query,
++				int query_length, int version)
++{
++	GSupplicantP2PServiceParams *params;
+ 
+-		scan_params->freqs =
+-			g_malloc(sizeof(uint16_t) * orig_params->num_freqs);
+-		memcpy(scan_params->freqs, orig_params->freqs,
+-			sizeof(uint16_t) *orig_params->num_freqs);
++	params = g_try_malloc0(sizeof(GSupplicantP2PServiceParams));
++	if (!params)
++		return NULL;
+ 
+-		scan_params->num_freqs = orig_params->num_freqs;
++	if (version > 0) {
++		params->version = version;
++		if (spec_length > 0) {
++			params->service = g_malloc(spec_length);
++			memcpy(params->service, spec, spec_length);
++		}
++	} else if (query_length > 0 && spec_length > 0) {
++		params->query = g_malloc(query_length);
++		memcpy(params->query, query, query_length);
++		params->query_length = query_length;
+ 
+-	} else
+-		goto err;
++		params->response = g_malloc(spec_length);
++		memcpy(params->response, spec, spec_length);
++		params->response_length = spec_length;
++	} else {
++		if (spec_length > 0) {
++			params->wfd_ies = g_malloc(spec_length);
++			memcpy(params->wfd_ies, spec, spec_length);
++		}
++		params->wfd_ies_length = spec_length;
++	}
+ 
+-	orig_params->num_ssids -= scan_params->num_ssids;
++	return params;
++}
+ 
+-	return scan_params->num_ssids;
++static void free_peer_service_params(GSupplicantP2PServiceParams *params)
++{
++	if (!params)
++		return;
+ 
+-err:
+-	g_slist_free_full(scan_params->ssids, g_free);
+-	g_supplicant_free_scan_params(wifi->scan_params);
+-	wifi->scan_params = NULL;
++	g_free(params->service);
++	g_free(params->query);
++	g_free(params->response);
++	g_free(params->wfd_ies);
+ 
+-	return 0;
++	g_free(params);
+ }
+ 
+-static int throw_wifi_scan(struct connman_device *device,
+-			GSupplicantInterfaceCallback callback)
++static int peer_register_wfd_service(const unsigned char *specification,
++				int specification_length,
++				peer_service_registration_cb_t callback,
++				void *user_data)
+ {
+-	struct wifi_data *wifi = connman_device_get_data(device);
++	struct peer_service_registration *reg_data = NULL;
++	static GSupplicantP2PServiceParams *params;
+ 	int ret;
+ 
+-	if (!wifi)
+-		return -ENODEV;
+-
+-	DBG("device %p %p", device, wifi->interface);
++	DBG("");
+ 
+-	if (wifi->tethering)
++	if (wfd_service_registered)
+ 		return -EBUSY;
+ 
+-	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI))
+-		return -EALREADY;
++	params = fill_in_peer_service_params(specification,
++					specification_length, NULL, 0, 0);
++	if (!params)
++		return -ENOMEM;
+ 
+-	connman_device_ref(device);
++	reg_data = g_try_malloc0(sizeof(*reg_data));
++	if (!reg_data) {
++		ret = -ENOMEM;
++		goto error;
++	}
+ 
+-	ret = g_supplicant_interface_scan(wifi->interface, NULL,
+-						callback, device);
+-	if (ret == 0) {
+-		connman_device_set_scanning(device,
+-				CONNMAN_SERVICE_TYPE_WIFI, true);
+-	} else
+-		connman_device_unref(device);
++	reg_data->callback = callback;
++	reg_data->user_data = user_data;
++
++	ret = g_supplicant_set_widi_ies(params,
++					register_wfd_service_cb, reg_data);
++	if (ret < 0 && ret != -EINPROGRESS)
++		goto error;
++
++	wfd_service_registered = true;
++
++	return ret;
++error:
++	free_peer_service_params(params);
++	g_free(reg_data);
+ 
+ 	return ret;
+ }
+ 
+-static void hidden_free(struct hidden_params *hidden)
++static void register_peer_service_cb(int result,
++				GSupplicantInterface *iface, void *user_data)
+ {
+-	if (!hidden)
+-		return;
++	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	struct peer_service_registration *reg_data = user_data;
+ 
+-	if (hidden->scan_params)
+-		g_supplicant_free_scan_params(hidden->scan_params);
+-	g_free(hidden->identity);
+-	g_free(hidden->passphrase);
+-	g_free(hidden->security);
+-	g_free(hidden);
++	DBG("");
++
++	if (result == 0)
++		apply_p2p_listen_on_iface(wifi, NULL);
++
++	if (reg_data && reg_data->callback)
++		reg_data->callback(result, reg_data->user_data);
++
++	g_free(reg_data);
+ }
+ 
+-static void scan_callback(int result, GSupplicantInterface *interface,
+-						void *user_data)
++static int peer_register_service(const unsigned char *specification,
++				int specification_length,
++				const unsigned char *query,
++				int query_length, int version,
++				peer_service_registration_cb_t callback,
++				void *user_data)
+ {
+-	struct connman_device *device = user_data;
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-	bool scanning;
++	struct peer_service_registration *reg_data = NULL;
++	GSupplicantP2PServiceParams *params;
++	bool found = false;
++	int ret, ret_f;
++	GList *list;
+ 
+-	DBG("result %d wifi %p", result, wifi);
++	DBG("");
+ 
+-	if (wifi) {
+-		if (wifi->hidden && !wifi->postpone_hidden) {
+-			connman_network_clear_hidden(wifi->hidden->user_data);
+-			hidden_free(wifi->hidden);
+-			wifi->hidden = NULL;
+-		}
++	if (specification && !version && !query &&
++			is_service_wfd(specification, specification_length)) {
++		return peer_register_wfd_service(specification,
++				specification_length, callback, user_data);
++	}
+ 
+-		if (wifi->scan_params) {
+-			g_supplicant_free_scan_params(wifi->scan_params);
+-			wifi->scan_params = NULL;
+-		}
+-	}
+-
+-	if (result < 0)
+-		connman_device_reset_scanning(device);
+-
+-	/* User is connecting to a hidden AP, let's wait for finished event */
+-	if (wifi && wifi->hidden && wifi->postpone_hidden) {
+-		GSupplicantScanParams *scan_params;
+-		int ret;
++	reg_data = g_try_malloc0(sizeof(*reg_data));
++	if (!reg_data)
++		return -ENOMEM;
+ 
+-		wifi->postpone_hidden = false;
+-		scan_params = wifi->hidden->scan_params;
+-		wifi->hidden->scan_params = NULL;
++	reg_data->callback = callback;
++	reg_data->user_data = user_data;
+ 
+-		reset_autoscan(device);
++	ret_f = -EOPNOTSUPP;
+ 
+-		ret = g_supplicant_interface_scan(wifi->interface, scan_params,
+-							scan_callback, device);
+-		if (ret == 0)
+-			return;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-		/* On error, let's recall scan_callback, which will cleanup */
+-		return scan_callback(ret, interface, user_data);
+-	}
++		if (!g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-	scanning = connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI);
++		params = fill_in_peer_service_params(specification,
++						specification_length, query,
++						query_length, version);
++		if (!params) {
++			ret_f = -ENOMEM;
++			continue;
++		}
+ 
+-	if (scanning) {
+-		connman_device_set_scanning(device,
+-				CONNMAN_SERVICE_TYPE_WIFI, false);
++		if (!found) {
++			ret_f = g_supplicant_interface_p2p_add_service(iface,
++				register_peer_service_cb, params, reg_data);
++			if (ret_f == 0 || ret_f == -EINPROGRESS)
++				found = true;
++			ret = ret_f;
++		} else
++			ret = g_supplicant_interface_p2p_add_service(iface,
++				register_peer_service_cb, params, NULL);
++		if (ret != 0 && ret != -EINPROGRESS)
++			free_peer_service_params(params);
+ 	}
+ 
+-	if (result != -ENOLINK)
+-		start_autoscan(device);
+-
+-	/*
+-	 * If we are here then we were scanning; however, if we are
+-	 * also mid-flight disabling the interface, then wifi_disable
+-	 * has already cleared the device scanning state and
+-	 * unreferenced the device, obviating the need to do it here.
+-	 */
++	if(ret_f != -EINPROGRESS && reg_data)
++		g_free(reg_data);
+ 
+-	if (scanning)
+-		connman_device_unref(device);
++	return ret_f;
+ }
+ 
+-static void scan_callback_hidden(int result,
+-			GSupplicantInterface *interface, void *user_data)
++static int peer_unregister_wfd_service(void)
+ {
+-	struct connman_device *device = user_data;
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-	GSupplicantScanParams *scan_params;
+-	int ret;
++	GSupplicantP2PServiceParams *params;
++	GList *list;
+ 
+-	DBG("result %d wifi %p", result, wifi);
++	if (!wfd_service_registered)
++		return -EALREADY;
+ 
+-	if (!wifi)
+-		goto out;
++	params = fill_in_peer_service_params(NULL, 0, NULL, 0, 0);
++	if (!params)
++		return -ENOMEM;
+ 
+-	/* User is trying to connect to a hidden AP */
+-	if (wifi->hidden && wifi->postpone_hidden)
+-		goto out;
++	wfd_service_registered = false;
+ 
+-	scan_params = g_try_malloc0(sizeof(GSupplicantScanParams));
+-	if (!scan_params)
+-		goto out;
++	g_supplicant_set_widi_ies(params, NULL, NULL);
+ 
+-	if (get_hidden_connections_params(wifi, scan_params) > 0) {
+-		ret = g_supplicant_interface_scan(wifi->interface,
+-							scan_params,
+-							scan_callback_hidden,
+-							device);
+-		if (ret == 0)
+-			return;
+-	}
+ 
+-	g_supplicant_free_scan_params(scan_params);
+ 
+-out:
+-	scan_callback(result, interface, user_data);
++	return 0;
+ }
+ 
+-static gboolean autoscan_timeout(gpointer data)
++static int peer_unregister_service(const unsigned char *specification,
++						int specification_length,
++						const unsigned char *query,
++						int query_length, int version)
+ {
+-	struct connman_device *device = data;
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-	struct autoscan_params *autoscan;
+-	int interval;
+-
+-	if (!wifi)
+-		return FALSE;
++	GSupplicantP2PServiceParams *params;
++	bool wfd = false;
++	GList *list;
++	int ret;
+ 
+-	autoscan = wifi->autoscan;
++	if (specification && !version && !query &&
++			is_service_wfd(specification, specification_length)) {
++		ret = peer_unregister_wfd_service();
++		if (ret != 0 && ret != -EINPROGRESS)
++			return ret;
++		wfd = true;
++	}
+ 
+-	if (autoscan->interval <= 0) {
+-		interval = autoscan->base;
+-		goto set_interval;
+-	} else
+-		interval = autoscan->interval * autoscan->base;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *wifi = list->data;
++		GSupplicantInterface *iface = wifi->interface;
+ 
+-	if (interval > autoscan->limit)
+-		interval = autoscan->limit;
++		if (wfd)
++			continue;
+ 
+-	throw_wifi_scan(wifi->device, scan_callback_hidden);
++		if (!g_supplicant_interface_has_p2p(iface))
++			continue;
+ 
+-	/*
+-	 * In case BackgroundScanning is disabled, interval will reach the
+-	 * limit exactly after the very first passive scanning. It allows
+-	 * to ensure at most one passive scan is performed in such cases.
+-	 */
+-	if (!connman_setting_get_bool("BackgroundScanning") &&
+-					interval == autoscan->limit) {
+-		g_source_remove(autoscan->timeout);
+-		autoscan->timeout = 0;
++		params = fill_in_peer_service_params(specification,
++						specification_length, query,
++						query_length, version);
++		if (!params)
++			continue;
+ 
+-		connman_device_unref(device);
++		ret = g_supplicant_interface_p2p_del_service(iface, params);
++		if (ret != 0 && ret != -EINPROGRESS)
++			free_peer_service_params(params);
+ 
+-		return FALSE;
+ 	}
+ 
+-set_interval:
+-	DBG("interval %d", interval);
+-
+-	autoscan->interval = interval;
+-
+-	autoscan->timeout = g_timeout_add_seconds(interval,
+-						autoscan_timeout, device);
+-
+-	return FALSE;
++	return 0;
+ }
+ 
+-static void start_autoscan(struct connman_device *device)
+-{
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-	struct autoscan_params *autoscan;
+-
+-	DBG("");
++static struct connman_peer_driver peer_driver = {
++	.connect    = peer_connect,
++	.disconnect = peer_disconnect,
++	.register_service = peer_register_service,
++	.unregister_service = peer_unregister_service,
++	.reject = peer_reject,
++};
+ 
+-	if (!wifi)
++static void handle_tethering(struct wifi_data *wifi)
++{
++	if (!wifi->tethering)
+ 		return;
+ 
+-	if (wifi->p2p_device)
++	if (!wifi->bridge)
+ 		return;
+ 
+-	if (wifi->connected)
++	if (wifi->bridged)
+ 		return;
+ 
+-	autoscan = wifi->autoscan;
+-	if (!autoscan)
+-		return;
++	DBG("index %d bridge %s", wifi->index, wifi->bridge);
+ 
+-	if (autoscan->timeout > 0 || autoscan->interval > 0)
++	if (connman_inet_add_to_bridge(wifi->index, wifi->bridge) < 0)
+ 		return;
+ 
+-	connman_device_ref(device);
+-
+-	autoscan_timeout(device);
++	wifi->bridged = true;
+ }
+ 
+-static struct autoscan_params *parse_autoscan_params(const char *params)
++static void wifi_newlink(unsigned flags, unsigned change, void *user_data)
+ {
+-	struct autoscan_params *autoscan;
+-	char **list_params;
+-	int limit;
+-	int base;
++	struct connman_device *device = user_data;
++	struct wifi_data *wifi = connman_device_get_data(device);
+ 
+-	DBG("");
++	if (!wifi)
++		return;
+ 
+-	list_params = g_strsplit(params, ":", 0);
+-	if (list_params == 0)
+-		return NULL;
++	DBG("index %d flags %d change %d", wifi->index, flags, change);
+ 
+-	if (!g_strcmp0(list_params[0], "exponential") &&
+-				g_strv_length(list_params) == 3) {
+-		base = atoi(list_params[1]);
+-		limit = atoi(list_params[2]);
+-	} else if (!g_strcmp0(list_params[0], "single") &&
+-				g_strv_length(list_params) == 2)
+-		base = limit = atoi(list_params[1]);
+-	else {
+-		g_strfreev(list_params);
+-		return NULL;
++	if ((wifi->flags & IFF_UP) != (flags & IFF_UP)) {
++		if (flags & IFF_UP)
++			DBG("interface up");
++		else
++			DBG("interface down");
+ 	}
+ 
+-	DBG("Setup %s autoscanning", list_params[0]);
+-
+-	g_strfreev(list_params);
+-
+-	autoscan = g_try_malloc0(sizeof(struct autoscan_params));
+-	if (!autoscan) {
+-		DBG("Could not allocate memory for autoscan");
+-		return NULL;
++	if ((wifi->flags & IFF_LOWER_UP) != (flags & IFF_LOWER_UP)) {
++		if (flags & IFF_LOWER_UP)
++			DBG("carrier on");
++		else
++			DBG("carrier off");
+ 	}
+ 
+-	DBG("base %d - limit %d", base, limit);
+-	autoscan->base = base;
+-	autoscan->limit = limit;
++	if (flags & IFF_LOWER_UP)
++		handle_tethering(wifi);
+ 
+-	return autoscan;
++	wifi->flags = flags;
+ }
+ 
+-static void setup_autoscan(struct wifi_data *wifi)
++static int wifi_probe(struct connman_device *device)
+ {
+-	/*
+-	 * If BackgroundScanning is enabled, setup exponential
+-	 * autoscanning if it has not been previously done.
+-	 */
+-	if (connman_setting_get_bool("BackgroundScanning")) {
+-		wifi->autoscan = parse_autoscan_params(AUTOSCAN_EXPONENTIAL);
+-		return;
+-	}
++	struct wifi_data *wifi;
+ 
+-	/*
+-	 * On the contrary, if BackgroundScanning is disabled, update autoscan
+-	 * parameters based on the type of scanning that is being performed.
+-	 */
+-	if (wifi->autoscan) {
+-		g_free(wifi->autoscan);
+-		wifi->autoscan = NULL;
+-	}
++	DBG("device %p", device);
+ 
+-	switch (wifi->scanning_type) {
+-	case WIFI_SCANNING_PASSIVE:
+-		/* Do not setup autoscan. */
+-		break;
+-	case WIFI_SCANNING_ACTIVE:
+-		/* Setup one single passive scan after active. */
+-		wifi->autoscan = parse_autoscan_params(AUTOSCAN_SINGLE);
+-		break;
+-	case WIFI_SCANNING_UNKNOWN:
+-		/* Setup autoscan in this case but we should never fall here. */
+-		wifi->autoscan = parse_autoscan_params(AUTOSCAN_SINGLE);
+-		break;
+-	}
++	wifi = g_try_new0(struct wifi_data, 1);
++	if (!wifi)
++		return -ENOMEM;
++
++	wifi->state = G_SUPPLICANT_STATE_INACTIVE;
++	wifi->ap_supported = WIFI_AP_UNKNOWN;
++	wifi->tethering_param = NULL;
++
++	connman_device_set_data(device, wifi);
++	wifi->device = connman_device_ref(device);
++
++	wifi->index = connman_device_get_index(device);
++	wifi->flags = 0;
++
++	wifi->watch = connman_rtnl_add_newlink_watch(wifi->index,
++							wifi_newlink, device);
++
++	wifi->p2p_listen_suppressed = false;
++	wifi->wps_active = FALSE;
++
++	if (is_p2p_connecting())
++		add_pending_wifi_device(wifi);
++	else
++		iface_list = g_list_append(iface_list, wifi);
++
++	return 0;
+ }
+ 
+-static void finalize_interface_creation(struct wifi_data *wifi)
++static void remove_networks(struct connman_device *device,
++				struct wifi_data *wifi)
+ {
+-	DBG("interface is ready wifi %p tethering %d", wifi, wifi->tethering);
++	GSList *list;
+ 
+-	if (!wifi->device) {
+-		connman_error("WiFi device not set");
+-		return;
++	for (list = wifi->networks; list; list = list->next) {
++		struct connman_network *network = list->data;
++
++		g_free(connman_network_get_data(network));
++		connman_device_remove_network(device, network);
++		connman_network_unref(network);
+ 	}
+ 
+-	connman_device_set_powered(wifi->device, true);
++	g_slist_free(wifi->networks);
++	wifi->networks = NULL;
++}
+ 
+-	if (wifi->p2p_device)
+-		return;
++static void remove_peers(struct wifi_data *wifi)
++{
++	GSList *list;
+ 
+-	if (!wifi->autoscan)
+-		setup_autoscan(wifi);
++	for (list = wifi->peers; list; list = list->next) {
++		struct connman_peer *peer = list->data;
+ 
+-	start_autoscan(wifi->device);
++		connman_peer_unregister(peer);
++		connman_peer_unref(peer);
++	}
++
++	g_slist_free(wifi->peers);
++	wifi->peers = NULL;
+ }
+ 
+-static void interface_create_callback(int result,
+-					GSupplicantInterface *interface,
+-							void *user_data)
++static void reset_autoscan(struct connman_device *device)
+ {
+-	struct wifi_data *wifi = user_data;
+-	char *bgscan_range_max;
+-	long value;
++	struct wifi_data *wifi = connman_device_get_data(device);
++	struct autoscan_params *autoscan;
+ 
+-	DBG("result %d ifname %s, wifi %p", result,
+-				g_supplicant_interface_get_ifname(interface),
+-				wifi);
++	DBG("");
+ 
+-	if (result < 0 || !wifi)
++	if (!wifi || !wifi->autoscan)
+ 		return;
+ 
+-	wifi->interface = interface;
+-	g_supplicant_interface_set_data(interface, wifi);
++	autoscan = wifi->autoscan;
+ 
+-	if (g_supplicant_interface_get_ready(interface)) {
+-		wifi->interface_ready = true;
+-		finalize_interface_creation(wifi);
+-	}
++	autoscan->interval = 0;
+ 
+-	/*
+-	 * Set the BSS expiration age to match the long scanning
+-	 * interval to avoid the loss of unconnected networks between
+-	 * two scans.
+-	 */
+-	bgscan_range_max = strrchr(BGSCAN_DEFAULT, ':');
+-	if (!bgscan_range_max || strlen(bgscan_range_max) < 1)
++	if (autoscan->timeout == 0)
+ 		return;
+ 
+-	value = strtol(bgscan_range_max + 1, NULL, 10);
+-	if (value <= 0 || errno == ERANGE)
+-		return;
++	g_source_remove(autoscan->timeout);
++	autoscan->timeout = 0;
+ 
+-	if (g_supplicant_interface_set_bss_expiration_age(interface,
+-					value + SCAN_MAX_DURATION) < 0) {
+-		connman_warn("Failed to set bss expiration age");
+-	}
++	connman_device_unref(device);
+ }
+ 
+-static int wifi_enable(struct connman_device *device)
++static void stop_autoscan(struct connman_device *device)
+ {
+-	struct wifi_data *wifi = connman_device_get_data(device);
+-	int index;
+-	char *interface;
+-	const char *driver = connman_setting_get_string("wifi");
+-	int ret;
++	const struct wifi_data *wifi = connman_device_get_data(device);
+ 
+-	DBG("device %p %p", device, wifi);
++	if (!wifi || !wifi->autoscan)
++		return;
+ 
+-	index = connman_device_get_index(device);
+-	if (!wifi || index < 0)
+-		return -ENODEV;
++	reset_autoscan(device);
+ 
+-	if (is_p2p_connecting())
+-		return -EINPROGRESS;
++	connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_WIFI, false);
++}
+ 
+-	interface = connman_inet_ifname(index);
+-	ret = g_supplicant_interface_create(interface, driver, NULL,
+-						interface_create_callback,
+-							wifi);
+-	g_free(interface);
++static void check_p2p_technology(void)
++{
++	bool p2p_exists = false;
++	GList *list;
+ 
+-	if (ret < 0)
+-		return ret;
++	for (list = iface_list; list; list = list->next) {
++		struct wifi_data *w = list->data;
+ 
+-	return -EINPROGRESS;
++		if (w && w->interface &&
++				g_supplicant_interface_has_p2p(w->interface)) {
++			p2p_exists = true;
++
++			if (w->p2p_listen_suppressed == true ||
++					connman_technology_get_p2p_listen(p2p_technology)) {
++				leave_p2p_listen_on_iface(w);
++				p2p_peers_refresh(w);
++				if (w->p2p_listen_suppressed == true)
++					w->p2p_listen_suppressed = false;
++			}
++		}
++	}
++
++	if (!p2p_exists) {
++		connman_technology_driver_unregister(&p2p_tech_driver);
++		connman_peer_driver_unregister(&peer_driver);
++	}
+ }
+ 
+-static int wifi_disable(struct connman_device *device)
++static void wifi_remove(struct connman_device *device)
+ {
+ 	struct wifi_data *wifi = connman_device_get_data(device);
+-	int ret;
+ 
+ 	DBG("device %p wifi %p", device, wifi);
+ 
+ 	if (!wifi)
+-		return -ENODEV;
++		return;
+ 
+-	wifi->connected = false;
+-	wifi->disconnecting = false;
++	stop_autoscan(device);
+ 
+-	if (wifi->pending_network)
+-		wifi->pending_network = NULL;
++	if (g_list_find(p2p_iface_list, wifi))
++		p2p_iface_list = g_list_remove(p2p_iface_list, wifi);
++	else
++		iface_list = g_list_remove(iface_list, wifi);
+ 
+-	stop_autoscan(device);
++	check_p2p_technology();
+ 
+-	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_P2P)) {
++	remove_pending_wifi_device(wifi);
++
++	if (wifi->p2p_find_timeout) {
+ 		g_source_remove(wifi->p2p_find_timeout);
+-		wifi->p2p_find_timeout = 0;
+-		connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_P2P, false);
+ 		connman_device_unref(wifi->device);
+ 	}
+ 
+-	/* In case of a user scan, device is still referenced */
+-	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI)) {
+-		connman_device_set_scanning(device,
+-				CONNMAN_SERVICE_TYPE_WIFI, false);
+-		connman_device_unref(wifi->device);
+-	}
++	if (wifi->p2p_connection_timeout)
++		g_source_remove(wifi->p2p_connection_timeout);
+ 
+ 	remove_networks(device, wifi);
+ 	remove_peers(wifi);
+ 
+-	ret = g_supplicant_interface_remove(wifi->interface, NULL, NULL);
+-	if (ret < 0)
+-		return ret;
++	connman_device_set_powered(device, false);
++	connman_device_set_data(device, NULL);
++	connman_device_unref(wifi->device);
++	connman_rtnl_remove_watch(wifi->watch);
++	__connman_sd_cleanup();
+ 
+-	return -EINPROGRESS;
+-}
++	g_supplicant_interface_set_data(wifi->interface, NULL);
+ 
+-struct last_connected {
+-	struct timeval modified;
+-	gchar *ssid;
+-	int freq;
+-};
++	g_supplicant_interface_cancel(wifi->interface);
+ 
+-static gint sort_entry(gconstpointer a, gconstpointer b, gpointer user_data)
+-{
+-	struct timeval *aval = (struct timeval *)a;
+-	struct timeval *bval = (struct timeval *)b;
++	if (wifi->scan_params)
++		g_supplicant_free_scan_params(wifi->scan_params);
+ 
+-	/* Note that the sort order is descending */
+-	if (aval->tv_sec < bval->tv_sec)
+-		return 1;
++	if(wifi->p2p_device_config.device_name)
++	{
++		g_free(wifi->p2p_device_config.device_name);
++		wifi->p2p_device_config.device_name = NULL;
++	}
+ 
+-	if (aval->tv_sec > bval->tv_sec)
+-		return -1;
++	if(wifi->p2p_device_config.ssid_postfix)
++	{
++		g_free(wifi->p2p_device_config.ssid_postfix);
++		wifi->p2p_device_config.ssid_postfix = NULL;
++	}
+ 
+-	return 0;
++	if(wifi->persistent_groups){
++		g_slist_free_full(wifi->persistent_groups, free_persistent_groups);
++		wifi->persistent_groups = NULL;
++	}
++
++	g_free(wifi->autoscan);
++	g_free(wifi->identifier);
++	g_free(wifi);
+ }
+ 
+-static void free_entry(gpointer data)
++static bool is_duplicate(GSList *list, gchar *ssid, int ssid_len)
+ {
+-	struct last_connected *entry = data;
++	GSList *iter;
+ 
+-	g_free(entry->ssid);
+-	g_free(entry);
++	for (iter = list; iter; iter = g_slist_next(iter)) {
++		struct scan_ssid *scan_ssid = iter->data;
++
++		if (ssid_len == scan_ssid->ssid_len &&
++				memcmp(ssid, scan_ssid->ssid, ssid_len) == 0)
++			return true;
++	}
++
++	return false;
+ }
+ 
+-static int get_latest_connections(int max_ssids,
+-				GSupplicantScanParams *scan_data)
++static int add_scan_param(gchar *hex_ssid, char *raw_ssid, int ssid_len,
++			int freq, GSupplicantScanParams *scan_data,
++			int driver_max_scan_ssids, char *ssid_name)
+ {
+-	GSequenceIter *iter;
+-	GSequence *latest_list;
+-	struct last_connected *entry;
++	unsigned int i;
++	struct scan_ssid *scan_ssid;
++
++	if ((driver_max_scan_ssids == 0 ||
++			driver_max_scan_ssids > scan_data->num_ssids) &&
++			(hex_ssid || raw_ssid)) {
++		gchar *ssid;
++		unsigned int j = 0, hex;
++
++		if (hex_ssid) {
++			size_t hex_ssid_len = strlen(hex_ssid);
++
++			ssid = g_try_malloc0(hex_ssid_len / 2);
++			if (!ssid)
++				return -ENOMEM;
++
++			for (i = 0; i < hex_ssid_len; i += 2) {
++				sscanf(hex_ssid + i, "%02x", &hex);
++				ssid[j++] = hex;
++			}
++		} else {
++			ssid = raw_ssid;
++			j = ssid_len;
++		}
++
++		/*
++		 * If we have already added hidden AP to the list,
++		 * then do not do it again. This might happen if you have
++		 * used or are using multiple wifi cards, so in that case
++		 * you might have multiple service files for same AP.
++		 */
++		if (is_duplicate(scan_data->ssids, ssid, j)) {
++			if (hex_ssid)
++				g_free(ssid);
++			return 0;
++		}
++
++		scan_ssid = g_try_new(struct scan_ssid, 1);
++		if (!scan_ssid) {
++			if (hex_ssid)
++				g_free(ssid);
++			return -ENOMEM;
++		}
++
++		memcpy(scan_ssid->ssid, ssid, j);
++		scan_ssid->ssid_len = j;
++		scan_data->ssids = g_slist_prepend(scan_data->ssids,
++								scan_ssid);
++
++		scan_data->num_ssids++;
++
++		DBG("SSID %s added to scanned list of %d entries", ssid_name,
++							scan_data->num_ssids);
++
++		if (hex_ssid)
++			g_free(ssid);
++	} else
++		return -EINVAL;
++
++	scan_data->ssids = g_slist_reverse(scan_data->ssids);
++
++	if (!scan_data->freqs) {
++		scan_data->freqs = g_try_malloc0(sizeof(uint16_t));
++		if (!scan_data->freqs) {
++			g_slist_free_full(scan_data->ssids, g_free);
++			return -ENOMEM;
++		}
++
++		scan_data->num_freqs = 1;
++		scan_data->freqs[0] = freq;
++	} else {
++		bool duplicate = false;
++
++		/* Don't add duplicate entries */
++		for (i = 0; i < scan_data->num_freqs; i++) {
++			if (scan_data->freqs[i] == freq) {
++				duplicate = true;
++				break;
++			}
++		}
++
++		if (!duplicate) {
++			scan_data->num_freqs++;
++			scan_data->freqs = g_try_realloc(scan_data->freqs,
++				sizeof(uint16_t) * scan_data->num_freqs);
++			if (!scan_data->freqs) {
++				g_slist_free_full(scan_data->ssids, g_free);
++				return -ENOMEM;
++			}
++			scan_data->freqs[scan_data->num_freqs - 1] = freq;
++		}
++	}
++
++	return 1;
++}
++
++static int get_hidden_connections(GSupplicantScanParams *scan_data)
++{
++	struct connman_config_entry **entries;
+ 	GKeyFile *keyfile;
+-	struct timeval modified;
+ 	gchar **services;
+-	gchar *str;
+-	char *ssid;
+-	int i, freq;
+-	int num_ssids = 0;
+-
+-	latest_list = g_sequence_new(free_entry);
+-	if (!latest_list)
+-		return -ENOMEM;
++	char *ssid, *name;
++	int i, ret;
++	bool value;
++	int num_ssids = 0, add_param_failed = 0;
+ 
+ 	services = connman_storage_get_services();
+ 	for (i = 0; services && services[i]; i++) {
+@@ -1710,499 +2039,1554 @@ static int get_latest_connections(int max_ssids,
+ 		if (!keyfile)
+ 			continue;
+ 
+-		str = g_key_file_get_string(keyfile,
+-					services[i], "Favorite", NULL);
+-		if (!str || g_strcmp0(str, "true")) {
+-			g_free(str);
+-			g_key_file_free(keyfile);
+-			continue;
+-		}
+-		g_free(str);
+-
+-		str = g_key_file_get_string(keyfile,
+-					services[i], "AutoConnect", NULL);
+-		if (!str || g_strcmp0(str, "true")) {
+-			g_free(str);
++		value = g_key_file_get_boolean(keyfile,
++					services[i], "Hidden", NULL);
++		if (!value) {
+ 			g_key_file_free(keyfile);
+ 			continue;
+ 		}
+-		g_free(str);
+ 
+-		str = g_key_file_get_string(keyfile,
+-					services[i], "Modified", NULL);
+-		if (!str) {
++		value = g_key_file_get_boolean(keyfile,
++					services[i], "Favorite", NULL);
++		if (!value) {
+ 			g_key_file_free(keyfile);
+ 			continue;
+ 		}
+-		util_iso8601_to_timeval(str, &modified);
+-		g_free(str);
+ 
+ 		ssid = g_key_file_get_string(keyfile,
+ 					services[i], "SSID", NULL);
+ 
+-		freq = g_key_file_get_integer(keyfile, services[i],
+-					"Frequency", NULL);
+-		if (freq) {
+-			entry = g_try_new(struct last_connected, 1);
+-			if (!entry) {
+-				g_sequence_free(latest_list);
+-				g_key_file_free(keyfile);
+-				g_free(ssid);
+-				return -ENOMEM;
+-			}
+-
+-			entry->ssid = ssid;
+-			entry->modified = modified;
+-			entry->freq = freq;
++		name = g_key_file_get_string(keyfile, services[i], "Name",
++								NULL);
+ 
+-			g_sequence_insert_sorted(latest_list, entry,
+-						sort_entry, NULL);
++		ret = add_scan_param(ssid, NULL, 0, 0, scan_data, 0, name);
++		if (ret < 0)
++			add_param_failed++;
++		else if (ret > 0)
+ 			num_ssids++;
+-		} else
+-			g_free(ssid);
+ 
++		g_free(ssid);
++		g_free(name);
+ 		g_key_file_free(keyfile);
+ 	}
+ 
+-	g_strfreev(services);
++	/*
++	 * Check if there are any hidden AP that needs to be provisioned.
++	 */
++	entries = connman_config_get_entries("wifi");
++	for (i = 0; entries && entries[i]; i++) {
++		int len;
+ 
+-	num_ssids = num_ssids > max_ssids ? max_ssids : num_ssids;
++		if (!entries[i]->hidden)
++			continue;
+ 
+-	iter = g_sequence_get_begin_iter(latest_list);
++		if (!entries[i]->ssid) {
++			ssid = entries[i]->name;
++			len = strlen(ssid);
++		} else {
++			ssid = entries[i]->ssid;
++			len = entries[i]->ssid_len;
++		}
+ 
+-	for (i = 0; i < num_ssids; i++) {
+-		entry = g_sequence_get(iter);
++		if (!ssid)
++			continue;
+ 
+-		DBG("ssid %s freq %d modified %lu", entry->ssid, entry->freq,
+-						entry->modified.tv_sec);
++		ret = add_scan_param(NULL, ssid, len, 0, scan_data, 0, ssid);
++		if (ret < 0)
++			add_param_failed++;
++		else if (ret > 0)
++			num_ssids++;
++	}
+ 
+-		add_scan_param(entry->ssid, NULL, 0, entry->freq, scan_data,
+-						max_ssids, entry->ssid);
++	connman_config_free_entries(entries);
+ 
+-		iter = g_sequence_iter_next(iter);
+-	}
++	if (add_param_failed > 0)
++		DBG("Unable to scan %d out of %d SSIDs",
++					add_param_failed, num_ssids);
++
++	g_strfreev(services);
+ 
+-	g_sequence_free(latest_list);
+ 	return num_ssids;
+ }
+ 
+-static void wifi_update_scanner_type(struct wifi_data *wifi,
+-					enum wifi_scanning_type new_type)
++static int get_hidden_connections_params(struct wifi_data *wifi,
++					GSupplicantScanParams *scan_params)
+ {
+-	DBG("");
+-
+-	if (!wifi || wifi->scanning_type == new_type)
+-		return;
++	int driver_max_ssids, i;
++	GSupplicantScanParams *orig_params;
+ 
+-	wifi->scanning_type = new_type;
++	/*
++	 * Scan hidden networks so that we can autoconnect to them.
++	 * We will assume 1 as a default number of ssid to scan.
++	 */
++	driver_max_ssids = g_supplicant_interface_get_max_scan_ssids(
++							wifi->interface);
++	if (driver_max_ssids == 0)
++		driver_max_ssids = 1;
+ 
+-	setup_autoscan(wifi);
+-}
++	DBG("max ssids %d", driver_max_ssids);
+ 
+-static int wifi_scan_simple(struct connman_device *device)
+-{
+-	struct wifi_data *wifi = connman_device_get_data(device);
++	if (!wifi->scan_params) {
++		wifi->scan_params = g_try_malloc0(sizeof(GSupplicantScanParams));
++		if (!wifi->scan_params)
++			return 0;
+ 
+-	reset_autoscan(device);
++		if (get_hidden_connections(wifi->scan_params) == 0) {
++			g_supplicant_free_scan_params(wifi->scan_params);
++			wifi->scan_params = NULL;
+ 
+-	/* Distinguish between devices performing passive and active scanning */
+-	if (wifi)
+-		wifi_update_scanner_type(wifi, WIFI_SCANNING_PASSIVE);
++			return 0;
++		}
++	}
+ 
+-	return throw_wifi_scan(device, scan_callback_hidden);
+-}
++	orig_params = wifi->scan_params;
+ 
+-static gboolean p2p_find_stop(gpointer data)
+-{
+-	struct connman_device *device = data;
+-	struct wifi_data *wifi = connman_device_get_data(device);
++	/* Let's transfer driver_max_ssids params */
++	for (i = 0; i < driver_max_ssids; i++) {
++		struct scan_ssid *ssid;
+ 
+-	DBG("");
++		if (!wifi->scan_params->ssids)
++			break;
+ 
+-	if (wifi) {
+-		wifi->p2p_find_timeout = 0;
+-
+-		g_supplicant_interface_p2p_stop_find(wifi->interface);
++		ssid = orig_params->ssids->data;
++		orig_params->ssids = g_slist_remove(orig_params->ssids, ssid);
++		scan_params->ssids = g_slist_prepend(scan_params->ssids, ssid);
+ 	}
+ 
+-	connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_P2P, false);
+-
+-	connman_device_unref(device);
+-	start_autoscan(device);
++	if (i > 0) {
++		scan_params->num_ssids = i;
++		scan_params->ssids = g_slist_reverse(scan_params->ssids);
+ 
+-	return FALSE;
+-}
++		if (orig_params->num_freqs <= 0)
++			goto err;
+ 
+-static void p2p_find_callback(int result, GSupplicantInterface *interface,
+-							void *user_data)
+-{
+-	struct connman_device *device = user_data;
+-	struct wifi_data *wifi = connman_device_get_data(device);
++		scan_params->freqs =
++			g_malloc(sizeof(uint16_t) * orig_params->num_freqs);
++		memcpy(scan_params->freqs, orig_params->freqs,
++			sizeof(uint16_t) *orig_params->num_freqs);
+ 
+-	DBG("result %d wifi %p", result, wifi);
++		scan_params->num_freqs = orig_params->num_freqs;
+ 
+-	if (!wifi)
+-		goto error;
++	} else
++		goto err;
+ 
+-	if (wifi->p2p_find_timeout) {
+-		g_source_remove(wifi->p2p_find_timeout);
+-		wifi->p2p_find_timeout = 0;
+-	}
++	orig_params->num_ssids -= scan_params->num_ssids;
+ 
+-	if (result)
+-		goto error;
++	return scan_params->num_ssids;
+ 
+-	wifi->p2p_find_timeout = g_timeout_add_seconds(P2P_FIND_TIMEOUT,
+-							p2p_find_stop, device);
+-	if (!wifi->p2p_find_timeout)
+-		goto error;
++err:
++	g_slist_free_full(scan_params->ssids, g_free);
++	g_supplicant_free_scan_params(wifi->scan_params);
++	wifi->scan_params = NULL;
+ 
+-	return;
+-error:
+-	p2p_find_stop(device);
++	return 0;
+ }
+ 
+-static int p2p_find(struct connman_device *device)
++static void p2p_stop_find(struct wifi_data *wifi)
+ {
+-	struct wifi_data *wifi;
+-	int ret;
+-
+-	DBG("");
+-
+-	if (!p2p_technology)
+-		return -ENOTSUP;
+-
+-	wifi = connman_device_get_data(device);
+-
+-	if (g_supplicant_interface_is_p2p_finding(wifi->interface))
+-		return -EALREADY;
+-
+-	reset_autoscan(device);
+-	connman_device_ref(device);
++	if(p2p_find_ref != -1) {
++		g_source_remove(p2p_find_ref);
++		p2p_find_ref = -1;
++		g_supplicant_interface_p2p_stop_find(wifi->interface);
+ 
+-	ret = g_supplicant_interface_p2p_find(wifi->interface,
+-						p2p_find_callback, device);
+-	if (ret) {
+-		connman_device_unref(device);
+-		start_autoscan(device);
+-	} else {
+-		connman_device_set_scanning(device,
+-				CONNMAN_SERVICE_TYPE_P2P, true);
++		if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++					g_strcmp0(connman_device_get_string(wifi->device, "Interface"),
++							connman_option_get_string("P2PDevice")) == 0) {
++			connman_device_set_scanning(wifi->device, CONNMAN_SERVICE_TYPE_P2P, false);
++		}
++		return;
+ 	}
+ 
+-	return ret;
++	g_supplicant_interface_p2p_stop_find(wifi->interface);
+ }
+ 
+-/*
+- * Note that the hidden scan is only used when connecting to this specific
+- * hidden AP first time. It is not used when system autoconnects to hidden AP.
+- */
+-static int wifi_scan(struct connman_device *device,
+-			struct connman_device_scan_params *params)
++
++static int throw_wifi_scan(struct connman_device *device,
++			GSupplicantInterfaceCallback callback)
+ {
+ 	struct wifi_data *wifi = connman_device_get_data(device);
+-	GSupplicantScanParams *scan_params = NULL;
+-	struct scan_ssid *scan_ssid;
+-	struct hidden_params *hidden;
+ 	int ret;
+-	int driver_max_ssids = 0;
+-	bool do_hidden;
+-	bool scanning;
+ 
+ 	if (!wifi)
+ 		return -ENODEV;
+ 
+-	if (wifi->p2p_device)
+-		return -EBUSY;
++	DBG("device %p %p", device, wifi->interface);
+ 
+ 	if (wifi->tethering)
+ 		return -EBUSY;
+ 
+-	if (params->type == CONNMAN_SERVICE_TYPE_P2P)
+-		return p2p_find(device);
++	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI))
++		return -EALREADY;
+ 
+-	DBG("device %p wifi %p hidden ssid %s", device, wifi->interface,
+-		params->ssid);
++	connman_device_ref(device);
+ 
+-	scanning = connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI);
++	ret = g_supplicant_interface_scan(wifi->interface, NULL,
++						callback, device);
++	if (ret == 0) {
++		connman_device_set_scanning(device,
++				CONNMAN_SERVICE_TYPE_WIFI, true);
++	} else
++		connman_device_unref(device);
+ 
+-	if (!params->ssid || params->ssid_len == 0 || params->ssid_len > 32) {
+-		if (scanning)
+-			return -EALREADY;
++	return ret;
++}
+ 
+-		driver_max_ssids = g_supplicant_interface_get_max_scan_ssids(
+-							wifi->interface);
+-		DBG("max ssids %d", driver_max_ssids);
+-		if (driver_max_ssids == 0)
+-			return wifi_scan_simple(device);
++static void hidden_free(struct hidden_params *hidden)
++{
++	if (!hidden)
++		return;
+ 
+-		do_hidden = false;
+-	} else {
+-		if (scanning && wifi->hidden && wifi->postpone_hidden)
+-			return -EALREADY;
++	if (hidden->scan_params)
++		g_supplicant_free_scan_params(hidden->scan_params);
++	g_free(hidden->identity);
++	g_free(hidden->passphrase);
++	g_free(hidden->security);
++	g_free(hidden);
++}
+ 
+-		do_hidden = true;
+-	}
++static void scan_callback(int result, GSupplicantInterface *interface,
++						void *user_data)
++{
++	struct connman_device *device = user_data;
++	struct wifi_data *wifi = connman_device_get_data(device);
++	bool scanning;
+ 
+-	scan_params = g_try_malloc0(sizeof(GSupplicantScanParams));
+-	if (!scan_params)
+-		return -ENOMEM;
++	DBG("result %d wifi %p", result, wifi);
+ 
+-	if (do_hidden) {
+-		scan_ssid = g_try_new(struct scan_ssid, 1);
+-		if (!scan_ssid) {
+-			g_free(scan_params);
+-			return -ENOMEM;
++	if (wifi) {
++		if (wifi->hidden && !wifi->postpone_hidden) {
++			connman_network_clear_hidden(wifi->hidden->user_data);
++			hidden_free(wifi->hidden);
++			wifi->hidden = NULL;
+ 		}
+ 
+-		memcpy(scan_ssid->ssid, params->ssid, params->ssid_len);
+-		scan_ssid->ssid_len = params->ssid_len;
+-		scan_params->ssids = g_slist_prepend(scan_params->ssids,
+-								scan_ssid);
+-		scan_params->num_ssids = 1;
+-
+-		hidden = g_try_new0(struct hidden_params, 1);
+-		if (!hidden) {
+-			g_supplicant_free_scan_params(scan_params);
+-			return -ENOMEM;
++		if (wifi->scan_params) {
++			g_supplicant_free_scan_params(wifi->scan_params);
++			wifi->scan_params = NULL;
+ 		}
++	}
+ 
+-		if (wifi->hidden) {
+-			hidden_free(wifi->hidden);
+-			wifi->hidden = NULL;
+-		}
++	if (result < 0)
++		connman_device_reset_scanning(device);
+ 
+-		memcpy(hidden->ssid, params->ssid, params->ssid_len);
+-		hidden->ssid_len = params->ssid_len;
+-		hidden->identity = g_strdup(params->identity);
+-		hidden->passphrase = g_strdup(params->passphrase);
+-		hidden->security = g_strdup(params->security);
+-		hidden->user_data = params->user_data;
+-		wifi->hidden = hidden;
++	/* User is connecting to a hidden AP, let's wait for finished event */
++	if (wifi && wifi->hidden && wifi->postpone_hidden) {
++		GSupplicantScanParams *scan_params;
++		int ret;
+ 
+-		if (scanning) {
+-			/* Let's keep this active scan for later,
+-			 * when current scan will be over. */
+-			wifi->postpone_hidden = TRUE;
+-			hidden->scan_params = scan_params;
++		wifi->postpone_hidden = false;
++		scan_params = wifi->hidden->scan_params;
++		wifi->hidden->scan_params = NULL;
+ 
+-			return 0;
+-		}
+-	} else if (wifi->connected) {
+-		g_supplicant_free_scan_params(scan_params);
+-		return wifi_scan_simple(device);
+-	} else if (!params->force_full_scan) {
+-		ret = get_latest_connections(driver_max_ssids, scan_params);
+-		if (ret <= 0) {
+-			g_supplicant_free_scan_params(scan_params);
+-			return wifi_scan_simple(device);
+-		}
+-	}
++		reset_autoscan(device);
+ 
+-	/* Distinguish between devices performing passive and active scanning */
+-	wifi_update_scanner_type(wifi, WIFI_SCANNING_ACTIVE);
++		ret = g_supplicant_interface_scan(wifi->interface, scan_params,
++							scan_callback, device);
++		if (ret == 0)
++			return;
+ 
+-	connman_device_ref(device);
++		/* On error, let's recall scan_callback, which will cleanup */
++		return scan_callback(ret, interface, user_data);
++	}
+ 
+-	reset_autoscan(device);
++	scanning = connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI);
+ 
+-	ret = g_supplicant_interface_scan(wifi->interface, scan_params,
+-						scan_callback, device);
+-	if (ret == 0) {
++	if (scanning) {
+ 		connman_device_set_scanning(device,
+-				CONNMAN_SERVICE_TYPE_WIFI, true);
+-	} else {
+-		g_supplicant_free_scan_params(scan_params);
+-		connman_device_unref(device);
+-
+-		if (do_hidden) {
+-			hidden_free(wifi->hidden);
+-			wifi->hidden = NULL;
+-		}
++				CONNMAN_SERVICE_TYPE_WIFI, false);
+ 	}
+ 
+-	return ret;
++	if (result != -ENOLINK)
++		start_autoscan(device);
++
++	/*
++	 * If we are here then we were scanning; however, if we are
++	 * also mid-flight disabling the interface, then wifi_disable
++	 * has already cleared the device scanning state and
++	 * unreferenced the device, obviating the need to do it here.
++	 */
++
++	if (scanning)
++		connman_device_unref(device);
+ }
+ 
+-static void wifi_stop_scan(enum connman_service_type type,
+-			struct connman_device *device)
++static void scan_callback_hidden(int result,
++			GSupplicantInterface *interface, void *user_data)
+ {
++	struct connman_device *device = user_data;
+ 	struct wifi_data *wifi = connman_device_get_data(device);
++	GSupplicantScanParams *scan_params;
++	int ret;
+ 
+-	DBG("device %p wifi %p", device, wifi);
++	DBG("result %d wifi %p", result, wifi);
+ 
+ 	if (!wifi)
+-		return;
++		goto out;
+ 
+-	if (type == CONNMAN_SERVICE_TYPE_P2P) {
+-		if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_P2P)) {
+-			g_source_remove(wifi->p2p_find_timeout);
+-			p2p_find_stop(device);
+-		}
+-	}
+-}
++	/* User is trying to connect to a hidden AP */
++	if (wifi->hidden && wifi->postpone_hidden)
++		goto out;
+ 
+-static void wifi_regdom_callback(int result,
+-					const char *alpha2,
+-						void *user_data)
+-{
+-	struct connman_device *device = user_data;
++	scan_params = g_try_malloc0(sizeof(GSupplicantScanParams));
++	if (!scan_params)
++		goto out;
+ 
+-	connman_device_regdom_notify(device, result, alpha2);
++	if (get_hidden_connections_params(wifi, scan_params) > 0) {
++		ret = g_supplicant_interface_scan(wifi->interface,
++							scan_params,
++							scan_callback_hidden,
++							device);
++		if (ret == 0)
++			return;
++	}
+ 
+-	connman_device_unref(device);
++	g_supplicant_free_scan_params(scan_params);
++
++out:
++	scan_callback(result, interface, user_data);
+ }
+ 
+-static int wifi_set_regdom(struct connman_device *device, const char *alpha2)
++static gboolean autoscan_timeout(gpointer data)
+ {
++	struct connman_device *device = data;
+ 	struct wifi_data *wifi = connman_device_get_data(device);
+-	int ret;
++	struct autoscan_params *autoscan;
++	int interval;
+ 
+ 	if (!wifi)
+-		return -EINVAL;
++		return FALSE;
+ 
+-	connman_device_ref(device);
++	autoscan = wifi->autoscan;
+ 
+-	ret = g_supplicant_interface_set_country(wifi->interface,
+-						wifi_regdom_callback,
+-							alpha2, device);
+-	if (ret != 0)
+-		connman_device_unref(device);
++	if (autoscan->interval <= 0) {
++		interval = autoscan->base;
++		goto set_interval;
++	} else
++		interval = autoscan->interval * autoscan->base;
+ 
+-	return ret;
+-}
++	if (interval > autoscan->limit)
++		interval = autoscan->limit;
+ 
+-static struct connman_device_driver wifi_ng_driver = {
+-	.name		= "wifi",
+-	.type		= CONNMAN_DEVICE_TYPE_WIFI,
+-	.priority	= CONNMAN_DEVICE_PRIORITY_LOW,
+-	.probe		= wifi_probe,
+-	.remove		= wifi_remove,
+-	.enable		= wifi_enable,
+-	.disable	= wifi_disable,
+-	.scan		= wifi_scan,
+-	.stop_scan	= wifi_stop_scan,
+-	.set_regdom	= wifi_set_regdom,
+-};
++	throw_wifi_scan(wifi->device, scan_callback_hidden);
+ 
+-static void system_ready(void)
+-{
+-	DBG("");
++	/*
++	 * In case BackgroundScanning is disabled, interval will reach the
++	 * limit exactly after the very first passive scanning. It allows
++	 * to ensure at most one passive scan is performed in such cases.
++	 */
++	if (!connman_setting_get_bool("BackgroundScanning") &&
++					interval == autoscan->limit) {
++		g_source_remove(autoscan->timeout);
++		autoscan->timeout = 0;
+ 
+-	if (connman_device_driver_register(&wifi_ng_driver) < 0)
+-		connman_error("Failed to register WiFi driver");
+-}
++		connman_device_unref(device);
+ 
+-static void system_killed(void)
+-{
+-	DBG("");
++		return FALSE;
++	}
+ 
+-	connman_device_driver_unregister(&wifi_ng_driver);
+-}
++set_interval:
++	DBG("interval %d", interval);
+ 
+-static int network_probe(struct connman_network *network)
+-{
+-	DBG("network %p", network);
++	autoscan->interval = interval;
+ 
+-	return 0;
++	autoscan->timeout = g_timeout_add_seconds(interval,
++						autoscan_timeout, device);
++
++	return FALSE;
+ }
+ 
+-static void network_remove(struct connman_network *network)
++static void start_autoscan(struct connman_device *device)
+ {
+-	struct connman_device *device = connman_network_get_device(network);
+-	struct wifi_data *wifi;
++	struct wifi_data *wifi = connman_device_get_data(device);
++	struct autoscan_params *autoscan;
+ 
+-	DBG("network %p", network);
++	DBG("");
+ 
+-	wifi = connman_device_get_data(device);
+ 	if (!wifi)
+ 		return;
+ 
+-	if (wifi->network != network)
++	if (wifi->p2p_device)
+ 		return;
+ 
+-	wifi->network = NULL;
++	if (wifi->connected)
++		return;
++
++	autoscan = wifi->autoscan;
++	if (!autoscan)
++		return;
++
++	if (autoscan->timeout > 0 || autoscan->interval > 0)
++		return;
++
++	connman_device_ref(device);
++
++	autoscan_timeout(device);
+ }
+ 
+-static void connect_callback(int result, GSupplicantInterface *interface,
+-							void *user_data)
++static struct autoscan_params *parse_autoscan_params(const char *params)
+ {
+-	struct connman_network *network = user_data;
++	struct autoscan_params *autoscan;
++	char **list_params;
++	int limit;
++	int base;
+ 
+-	DBG("network %p result %d", network, result);
++	DBG("");
+ 
+-	if (result == -ENOKEY) {
+-		connman_network_set_error(network,
+-					CONNMAN_NETWORK_ERROR_INVALID_KEY);
+-	} else if (result < 0) {
+-		connman_network_set_error(network,
+-					CONNMAN_NETWORK_ERROR_CONFIGURE_FAIL);
++	list_params = g_strsplit(params, ":", 0);
++	if (list_params == 0)
++		return NULL;
++
++	if (!g_strcmp0(list_params[0], "exponential") &&
++				g_strv_length(list_params) == 3) {
++		base = atoi(list_params[1]);
++		limit = atoi(list_params[2]);
++	} else if (!g_strcmp0(list_params[0], "single") &&
++				g_strv_length(list_params) == 2)
++		base = limit = atoi(list_params[1]);
++	else {
++		g_strfreev(list_params);
++		return NULL;
+ 	}
+ 
+-	connman_network_unref(network);
+-}
++	DBG("Setup %s autoscanning", list_params[0]);
+ 
+-static GSupplicantSecurity network_security(const char *security)
+-{
+-	if (g_str_equal(security, "none"))
+-		return G_SUPPLICANT_SECURITY_NONE;
+-	else if (g_str_equal(security, "wep"))
+-		return G_SUPPLICANT_SECURITY_WEP;
+-	else if (g_str_equal(security, "psk"))
+-		return G_SUPPLICANT_SECURITY_PSK;
+-	else if (g_str_equal(security, "wpa"))
+-		return G_SUPPLICANT_SECURITY_PSK;
+-	else if (g_str_equal(security, "rsn"))
+-		return G_SUPPLICANT_SECURITY_PSK;
+-	else if (g_str_equal(security, "ieee8021x"))
+-		return G_SUPPLICANT_SECURITY_IEEE8021X;
++	g_strfreev(list_params);
+ 
+-	return G_SUPPLICANT_SECURITY_UNKNOWN;
+-}
++	autoscan = g_try_malloc0(sizeof(struct autoscan_params));
++	if (!autoscan) {
++		DBG("Could not allocate memory for autoscan");
++		return NULL;
++	}
+ 
+-static void ssid_init(GSupplicantSSID *ssid, struct connman_network *network)
+-{
+-	struct wifi_network *network_data = connman_network_get_data(network);
+-	const char *security;
++	DBG("base %d - limit %d", base, limit);
++	autoscan->base = base;
++	autoscan->limit = limit;
+ 
+-	memset(ssid, 0, sizeof(*ssid));
+-	ssid->mode = G_SUPPLICANT_MODE_INFRA;
+-	ssid->ssid = connman_network_get_blob(network, "WiFi.SSID",
+-						&ssid->ssid_len);
+-	ssid->scan_ssid = 1;
+-	security = connman_network_get_string(network, "WiFi.Security");
+-	ssid->security = network_security(security);
+-	ssid->keymgmt = network_data->keymgmt;
+-	ssid->ieee80211w = G_SUPPLICANT_MFP_OPTIONAL;
+-	ssid->passphrase = connman_network_get_string(network,
+-						"WiFi.Passphrase");
++	return autoscan;
++}
+ 
+-	ssid->eap = connman_network_get_string(network, "WiFi.EAP");
++static void setup_autoscan(struct wifi_data *wifi)
++{
++	/*
++	 * If BackgroundScanning is enabled, setup exponential
++	 * autoscanning if it has not been previously done.
++	 */
++	if (connman_setting_get_bool("BackgroundScanning")) {
++		wifi->autoscan = parse_autoscan_params(AUTOSCAN_EXPONENTIAL);
++		return;
++	}
+ 
+ 	/*
+-	 * If our private key password is unset,
+-	 * we use the supplied passphrase. That is needed
+-	 * for PEAP where 2 passphrases (identity and client
+-	 * cert may have to be provided.
++	 * On the contrary, if BackgroundScanning is disabled, update autoscan
++	 * parameters based on the type of scanning that is being performed.
+ 	 */
+-	if (!connman_network_get_string(network, "WiFi.PrivateKeyPassphrase"))
+-		connman_network_set_string(network,
+-						"WiFi.PrivateKeyPassphrase",
+-						ssid->passphrase);
+-	/* We must have an identity for both PEAP and TLS */
+-	ssid->identity = connman_network_get_string(network, "WiFi.Identity");
++	if (wifi->autoscan) {
++		g_free(wifi->autoscan);
++		wifi->autoscan = NULL;
++	}
+ 
+-	/* Use agent provided identity as a fallback */
+-	if (!ssid->identity || strlen(ssid->identity) == 0)
+-		ssid->identity = connman_network_get_string(network,
+-							"WiFi.AgentIdentity");
++	switch (wifi->scanning_type) {
++	case WIFI_SCANNING_PASSIVE:
++		/* Do not setup autoscan. */
++		break;
++	case WIFI_SCANNING_ACTIVE:
++		/* Setup one single passive scan after active. */
++		wifi->autoscan = parse_autoscan_params(AUTOSCAN_SINGLE);
++		break;
++	case WIFI_SCANNING_UNKNOWN:
++		/* Setup autoscan in this case but we should never fall here. */
++		wifi->autoscan = parse_autoscan_params(AUTOSCAN_SINGLE);
++		break;
++	}
++}
+ 
+-	ssid->anonymous_identity = connman_network_get_string(network,
+-						"WiFi.AnonymousIdentity");
+-	ssid->ca_cert_path = connman_network_get_string(network,
+-							"WiFi.CACertFile");
+-	ssid->subject_match = connman_network_get_string(network,
+-							"WiFi.SubjectMatch");
++static void finalize_interface_creation(struct wifi_data *wifi)
++{
++	DBG("interface is ready wifi %p tethering %d", wifi, wifi->tethering);
++
++	if (!wifi->device) {
++		connman_error("WiFi device not set");
++		return;
++	}
++
++	connman_device_set_powered(wifi->device, true);
++
++	if (wifi->p2p_device)
++		return;
++
++	if (is_technology_enabled(wifi_technology)) {
++		DBG("WiFi is enable, so enable p2p also");
++		if (p2p_technology)
++			connman_technology_set_p2p(p2p_technology, true);
++	}
++//	if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++//		g_strcmp0(g_supplicant_interface_get_ifname(wifi->interface),
++//			connman_option_get_string("P2PDevice")) == 0) {
++                int ret;
++
++                DBG("interface type is p2p interface");
++                ret = g_supplicant_interface_get_p2p_device_config(wifi->interface, &wifi->p2p_device_config);
++                if (ret == 0) {
++                        DBG("interface type is p2p device config");
++
++                        wifi->persistent_peer_ssid = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
++                        add_persistent_group_info(wifi);
++                }
++
++                __connman_group_init();
++
++		__connman_sd_init(wifi->interface, connman_device_get_ident(wifi->device));
++//	}
++
++	if (!wifi->autoscan)
++		setup_autoscan(wifi);
++
++	start_autoscan(wifi->device);
++}
++
++static void interface_create_callback(int result,
++					GSupplicantInterface *interface,
++							void *user_data)
++{
++	struct wifi_data *wifi = user_data;
++	char *bgscan_range_max;
++	long value;
++
++	DBG("result %d ifname %s, wifi %p", result,
++				g_supplicant_interface_get_ifname(interface),
++				wifi);
++
++	if (result < 0 || !wifi)
++		return;
++
++	wifi->interface = interface;
++	g_supplicant_interface_set_data(interface, wifi);
++
++	if (g_supplicant_interface_get_ready(interface)) {
++		wifi->interface_ready = true;
++		finalize_interface_creation(wifi);
++	}
++
++	/*
++	 * Set the BSS expiration age to match the long scanning
++	 * interval to avoid the loss of unconnected networks between
++	 * two scans.
++	 */
++	bgscan_range_max = strrchr(BGSCAN_DEFAULT, ':');
++	if (!bgscan_range_max || strlen(bgscan_range_max) < 1)
++		return;
++
++	value = strtol(bgscan_range_max + 1, NULL, 10);
++	if (value <= 0 || errno == ERANGE)
++		return;
++
++	if (g_supplicant_interface_set_bss_expiration_age(interface,
++					value + SCAN_MAX_DURATION) < 0) {
++		connman_warn("Failed to set bss expiration age");
++	}
++}
++
++static int wifi_enable(struct connman_device *device)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	int index;
++	char *interface;
++	const char *driver = connman_setting_get_string("wifi");
++	int ret;
++
++	DBG("device %p %p", device, wifi);
++
++	index = connman_device_get_index(device);
++	if (!wifi || index < 0)
++		return -ENODEV;
++
++	if (is_p2p_connecting())
++		return -EINPROGRESS;
++
++	interface = connman_inet_ifname(index);
++	const char *wpas_config_file = connman_setting_get_string("WpaSupplicantConfigFile");
++	ret = g_supplicant_interface_create(interface, driver, NULL, wpas_config_file,
++						interface_create_callback,
++							wifi);
++	g_free(interface);
++
++	if (ret < 0)
++		return ret;
++
++	return -EINPROGRESS;
++}
++
++static int wifi_disable(struct connman_device *device)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	int ret;
++
++	DBG("device %p wifi %p", device, wifi);
++
++	if (!wifi)
++		return -ENODEV;
++
++	wifi->connected = false;
++	wifi->disconnecting = false;
++
++	if (wifi->pending_network)
++		wifi->pending_network = NULL;
++
++	stop_autoscan(device);
++
++	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_P2P)) {
++		g_source_remove(wifi->p2p_find_timeout);
++		wifi->p2p_find_timeout = 0;
++		connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_P2P, false);
++		connman_device_unref(wifi->device);
++	}
++
++	/* In case of a user scan, device is still referenced */
++	if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI)) {
++		connman_device_set_scanning(device,
++				CONNMAN_SERVICE_TYPE_WIFI, false);
++		connman_device_unref(wifi->device);
++	}
++
++	remove_networks(device, wifi);
++	remove_peers(wifi);
++
++	ret = g_supplicant_interface_remove(wifi->interface, NULL, NULL);
++	if (ret < 0)
++		return ret;
++
++	return -EINPROGRESS;
++}
++
++struct last_connected {
++	struct timeval modified;
++	gchar *ssid;
++	int freq;
++};
++
++static gint sort_entry(gconstpointer a, gconstpointer b, gpointer user_data)
++{
++	struct timeval *aval = (struct timeval *)a;
++	struct timeval *bval = (struct timeval *)b;
++
++	/* Note that the sort order is descending */
++	if (aval->tv_sec < bval->tv_sec)
++		return 1;
++
++	if (aval->tv_sec > bval->tv_sec)
++		return -1;
++
++	return 0;
++}
++
++static void free_entry(gpointer data)
++{
++	struct last_connected *entry = data;
++
++	g_free(entry->ssid);
++	g_free(entry);
++}
++
++static int get_latest_connections(int max_ssids,
++				GSupplicantScanParams *scan_data)
++{
++	GSequenceIter *iter;
++	GSequence *latest_list;
++	struct last_connected *entry;
++	GKeyFile *keyfile;
++	struct timeval modified;
++	gchar **services;
++	gchar *str;
++	char *ssid;
++	int i, freq;
++	int num_ssids = 0;
++
++	latest_list = g_sequence_new(free_entry);
++	if (!latest_list)
++		return -ENOMEM;
++
++	services = connman_storage_get_services();
++	for (i = 0; services && services[i]; i++) {
++		if (strncmp(services[i], "wifi_", 5) != 0)
++			continue;
++
++		keyfile = connman_storage_load_service(services[i]);
++		if (!keyfile)
++			continue;
++
++		str = g_key_file_get_string(keyfile,
++					services[i], "Favorite", NULL);
++		if (!str || g_strcmp0(str, "true")) {
++			g_free(str);
++			g_key_file_free(keyfile);
++			continue;
++		}
++		g_free(str);
++
++		str = g_key_file_get_string(keyfile,
++					services[i], "AutoConnect", NULL);
++		if (!str || g_strcmp0(str, "true")) {
++			g_free(str);
++			g_key_file_free(keyfile);
++			continue;
++		}
++		g_free(str);
++
++		str = g_key_file_get_string(keyfile,
++					services[i], "Modified", NULL);
++		if (!str) {
++			g_key_file_free(keyfile);
++			continue;
++		}
++		util_iso8601_to_timeval(str, &modified);
++		g_free(str);
++
++		ssid = g_key_file_get_string(keyfile,
++					services[i], "SSID", NULL);
++
++		freq = g_key_file_get_integer(keyfile, services[i],
++					"Frequency", NULL);
++		if (freq) {
++			entry = g_try_new(struct last_connected, 1);
++			if (!entry) {
++				g_sequence_free(latest_list);
++				g_key_file_free(keyfile);
++				g_free(ssid);
++				return -ENOMEM;
++			}
++
++			entry->ssid = ssid;
++			entry->modified = modified;
++			entry->freq = freq;
++
++			g_sequence_insert_sorted(latest_list, entry,
++						sort_entry, NULL);
++			num_ssids++;
++		} else
++			g_free(ssid);
++
++		g_key_file_free(keyfile);
++	}
++
++	g_strfreev(services);
++
++	num_ssids = num_ssids > max_ssids ? max_ssids : num_ssids;
++
++	iter = g_sequence_get_begin_iter(latest_list);
++
++	for (i = 0; i < num_ssids; i++) {
++		entry = g_sequence_get(iter);
++
++		DBG("ssid %s freq %d modified %lu", entry->ssid, entry->freq,
++						entry->modified.tv_sec);
++
++		add_scan_param(entry->ssid, NULL, 0, entry->freq, scan_data,
++						max_ssids, entry->ssid);
++
++		iter = g_sequence_iter_next(iter);
++	}
++
++	g_sequence_free(latest_list);
++	return num_ssids;
++}
++
++static void wifi_update_scanner_type(struct wifi_data *wifi,
++					enum wifi_scanning_type new_type)
++{
++	DBG("");
++
++	if (!wifi || wifi->scanning_type == new_type)
++		return;
++
++	wifi->scanning_type = new_type;
++
++	setup_autoscan(wifi);
++}
++
++static int wifi_scan_simple(struct connman_device *device)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++
++	reset_autoscan(device);
++
++	/* Distinguish between devices performing passive and active scanning */
++	if (wifi)
++		wifi_update_scanner_type(wifi, WIFI_SCANNING_PASSIVE);
++
++	return throw_wifi_scan(device, scan_callback_hidden);
++}
++
++static gboolean p2p_find_stop(gpointer data)
++{
++	struct connman_device *device = data;
++	struct wifi_data *wifi = connman_device_get_data(device);
++
++	DBG("");
++
++	if (wifi) {
++		wifi->p2p_find_timeout = 0;
++
++		g_supplicant_interface_p2p_stop_find(wifi->interface);
++		if (p2p_technology &&
++				(wifi->p2p_listen_suppressed == true ||
++				connman_technology_get_p2p_listen(p2p_technology))) {
++			set_p2p_listen_without_state_change(p2p_technology, true);
++			if (wifi->p2p_listen_suppressed)
++				wifi->p2p_listen_suppressed = false;
++		}
++	}
++
++	connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_P2P, false);
++
++	connman_device_unref(device);
++	start_autoscan(device);
++
++	return FALSE;
++}
++
++static void p2p_find_callback(int result, GSupplicantInterface *interface,
++							void *user_data)
++{
++	struct connman_device *device = user_data;
++	struct wifi_data *wifi = connman_device_get_data(device);
++
++	DBG("result %d wifi %p", result, wifi);
++
++	if (!wifi)
++		goto error;
++
++	if (wifi->p2p_find_timeout) {
++		g_source_remove(wifi->p2p_find_timeout);
++		wifi->p2p_find_timeout = 0;
++	}
++
++	if (result)
++		goto error;
++
++	wifi->p2p_find_timeout = g_timeout_add_seconds(P2P_FIND_TIMEOUT,
++							p2p_find_stop, device);
++	if (!wifi->p2p_find_timeout)
++		goto error;
++
++	p2p_find_ref = -1;
++
++	return;
++error:
++	p2p_find_ref = -1;
++	p2p_find_stop(device);
++}
++
++static gboolean p2p_find_complete(gpointer argv)
++{
++	struct connman_device *device = argv;
++	struct wifi_data *wifi = connman_device_get_data(device);
++	int ret = 0;
++
++	if(!wifi) {
++		p2p_find_ref = -1;
++		return FALSE;
++	}
++
++	if (p2p_technology &&
++			(wifi->p2p_listen_suppressed == true ||
++			connman_technology_get_p2p_listen(p2p_technology))) {
++		set_p2p_listen_without_state_change(p2p_technology, true);
++		if (wifi->p2p_listen_suppressed)
++			wifi->p2p_listen_suppressed = false;
++	}
++
++	p2p_find_ref = -1;
++
++	return FALSE;
++}
++
++static int p2p_find(struct connman_device *device)
++{
++	struct wifi_data *wifi;
++	int ret;
++
++	DBG("");
++
++	if (!p2p_technology)
++		return -ENOTSUP;
++
++	wifi = connman_device_get_data(device);
++
++	if (!wifi || !wifi->interface)
++		return -ENODEV;
++
++	if (g_supplicant_interface_is_p2p_finding(wifi->interface))
++		return -EALREADY;
++
++	if (p2p_technology &&
++		connman_technology_get_p2p_listen(p2p_technology)) {
++		set_p2p_listen_without_state_change(p2p_technology, false);
++		wifi->p2p_listen_suppressed = true;
++	}
++
++	reset_autoscan(device);
++	connman_device_ref(device);
++
++	ret = g_supplicant_interface_p2p_find(wifi->interface, NULL,
++						p2p_find_callback, device);
++	if (ret) {
++		connman_device_unref(device);
++		start_autoscan(device);
++	} else {
++		connman_device_set_scanning(device,
++				CONNMAN_SERVICE_TYPE_P2P, true);
++		p2p_find_ref = g_timeout_add_seconds(wifi->p2p_find_timeout, p2p_find_complete, device);
++	}
++
++	return ret;
++}
++
++/*
++ * Note that the hidden scan is only used when connecting to this specific
++ * hidden AP first time. It is not used when system autoconnects to hidden AP.
++ */
++static int wifi_scan(struct connman_device *device,
++			struct connman_device_scan_params *params)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	GSupplicantScanParams *scan_params = NULL;
++	struct scan_ssid *scan_ssid;
++	struct hidden_params *hidden;
++	int ret;
++	int driver_max_ssids = 0;
++	bool do_hidden;
++	bool scanning;
++
++	if (!wifi)
++		return -ENODEV;
++
++	if (wifi->p2p_device)
++		return -EBUSY;
++
++	if (wifi->tethering)
++		return -EBUSY;
++
++	if (params->type == CONNMAN_SERVICE_TYPE_P2P) {
++			if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++					g_strcmp0(connman_device_get_string(device, "Interface"),
++								connman_option_get_string("P2PDevice")) != 0)
++					return -ENOTSUP;
++
++			if(p2p_find_ref != -1)
++				return -EINPROGRESS;
++			return p2p_find(device);
++	}
++ 
++	DBG("device %p wifi %p hidden ssid %s", device, wifi->interface,
++		params->ssid);
++
++	if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++				g_strcmp0(connman_device_get_string(device, "Interface"),
++						connman_option_get_string("WiFiDevice")) != 0)
++		return -ENOTSUP;
++
++	scanning = connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_WIFI);
++	if (!scanning && (!params->ssid || params->ssid_len == 0 || params->ssid_len > 32))
++		p2p_stop_find(wifi);
++
++	if (p2p_technology &&
++		connman_technology_get_p2p_listen(p2p_technology)) {
++		set_p2p_listen_without_state_change(p2p_technology, false);
++		wifi->p2p_listen_suppressed = true;
++	}
++
++
++	if (!params->ssid || params->ssid_len == 0 || params->ssid_len > 32) {
++		if (scanning)
++			return -EALREADY;
++
++		driver_max_ssids = g_supplicant_interface_get_max_scan_ssids(
++							wifi->interface);
++		DBG("max ssids %d", driver_max_ssids);
++		if (driver_max_ssids == 0)
++			return wifi_scan_simple(device);
++
++		do_hidden = false;
++	} else {
++		if (scanning && wifi->hidden && wifi->postpone_hidden)
++			return -EALREADY;
++
++		do_hidden = true;
++	}
++
++	scan_params = g_try_malloc0(sizeof(GSupplicantScanParams));
++	if (!scan_params)
++		return -ENOMEM;
++
++	if (do_hidden) {
++		scan_ssid = g_try_new(struct scan_ssid, 1);
++		if (!scan_ssid) {
++			g_free(scan_params);
++			return -ENOMEM;
++		}
++
++		memcpy(scan_ssid->ssid, params->ssid, params->ssid_len);
++		scan_ssid->ssid_len = params->ssid_len;
++		scan_params->ssids = g_slist_prepend(scan_params->ssids,
++								scan_ssid);
++		scan_params->num_ssids = 1;
++
++		hidden = g_try_new0(struct hidden_params, 1);
++		if (!hidden) {
++			g_supplicant_free_scan_params(scan_params);
++			return -ENOMEM;
++		}
++
++		if (wifi->hidden) {
++			hidden_free(wifi->hidden);
++			wifi->hidden = NULL;
++		}
++
++		memcpy(hidden->ssid, params->ssid, params->ssid_len);
++		hidden->ssid_len = params->ssid_len;
++		hidden->identity = g_strdup(params->identity);
++		hidden->passphrase = g_strdup(params->passphrase);
++		hidden->security = g_strdup(params->security);
++		hidden->user_data = params->user_data;
++		wifi->hidden = hidden;
++
++		if (scanning) {
++			/* Let's keep this active scan for later,
++			 * when current scan will be over. */
++			wifi->postpone_hidden = TRUE;
++			hidden->scan_params = scan_params;
++
++			return 0;
++		}
++	} else if (wifi->connected) {
++		g_supplicant_free_scan_params(scan_params);
++		return wifi_scan_simple(device);
++	} else if (!params->force_full_scan) {
++		ret = get_latest_connections(driver_max_ssids, scan_params);
++		if (ret <= 0) {
++			g_supplicant_free_scan_params(scan_params);
++			return wifi_scan_simple(device);
++		}
++	}
++
++	/* Distinguish between devices performing passive and active scanning */
++	wifi_update_scanner_type(wifi, WIFI_SCANNING_ACTIVE);
++
++	connman_device_ref(device);
++
++	reset_autoscan(device);
++
++	ret = g_supplicant_interface_scan(wifi->interface, scan_params,
++						scan_callback, device);
++	if (ret == 0) {
++		connman_device_set_scanning(device,
++				CONNMAN_SERVICE_TYPE_WIFI, true);
++	} else {
++		g_supplicant_free_scan_params(scan_params);
++		connman_device_unref(device);
++
++		if (do_hidden) {
++			hidden_free(wifi->hidden);
++			wifi->hidden = NULL;
++		}
++	}
++
++	return ret;
++}
++
++static void wifi_stop_scan(enum connman_service_type type,
++			struct connman_device *device)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++
++	DBG("device %p wifi %p", device, wifi);
++
++	if (!wifi)
++		return;
++
++	if (type == CONNMAN_SERVICE_TYPE_P2P) {
++		if (connman_device_get_scanning(device, CONNMAN_SERVICE_TYPE_P2P)) {
++			g_source_remove(wifi->p2p_find_timeout);
++			p2p_find_stop(device);
++		}
++	}
++}
++
++static void wifi_regdom_callback(int result,
++					const char *alpha2,
++						void *user_data)
++{
++	struct connman_device *device = user_data;
++
++	connman_device_regdom_notify(device, result, alpha2);
++
++	connman_device_unref(device);
++}
++
++static int wifi_set_regdom(struct connman_device *device, const char *alpha2)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	int ret;
++
++	if (!wifi)
++		return -EINVAL;
++
++	connman_device_ref(device);
++
++	ret = g_supplicant_interface_set_country(wifi->interface,
++						wifi_regdom_callback,
++							alpha2, device);
++	if (ret != 0)
++		connman_device_unref(device);
++
++	return ret;
++}
++
++static gboolean start_wps_timeout(gpointer user_data)
++{
++	struct wifi_data *wifi = user_data;
++
++	DBG("");
++
++	wifi->wps_timeout = 0;
++	wifi->wps_active = FALSE;
++
++	/* if we already assigned a network we have to remove it too */
++	wifi->network = NULL;
++
++	connman_technology_wps_failed_notify(wifi_technology);
++
++	return FALSE;
++}
++static bool is_wifi_valid (struct wifi_data *wifi)
++{
++	GList *list;
++
++	DBG("");
++
++	if (wifi == NULL)
++		return FALSE;
++
++	for (list = iface_list; list; list = list->next) {
++		if (list->data == wifi)
++			return TRUE;
++	}
++
++	DBG("wifi %p not found", wifi);
++
++	return FALSE;
++}
++static void cancel_wps_callback(int result, GSupplicantInterface *interface,
++                            void *user_data)
++{
++	struct wifi_data *wifi = user_data;
++
++	DBG("result %d", result);
++
++	if (!is_wifi_valid(wifi))
++		return;
++
++	/* if we already assigned a network we have to remove it too */
++	if (wifi->network) {
++		connman_network_set_bool(wifi->network, "WiFi.UseWPS", FALSE);
++		connman_network_set_connected(wifi->network, FALSE);
++		wifi->network = NULL;
++	}
++
++	if (wifi->wps_timeout > 0) {
++		g_source_remove(wifi->wps_timeout);
++		wifi->wps_timeout = 0;
++	}
++
++	wifi->wps_active = FALSE;
++	/* already freed within gsupplicant layer */
++	wifi->wps_ssid = NULL;
++
++	enable_auto_connect_block(FALSE);
++}
++static int cancel_wps(struct wifi_data *wifi)
++{
++	int ret;
++
++	DBG("wifi %p", wifi);
++
++	ret = g_supplicant_interface_wps_cancel(wifi->interface, cancel_wps_callback, wifi);
++	if (ret == -EALREADY || ret == -EINPROGRESS)
++		ret = 0;
++
++	return ret;
++}
++static gboolean wps_timeout_cb(gpointer user_data)
++{
++	struct wifi_data *wifi = user_data;
++
++	DBG("");
++
++	if (!is_wifi_valid(wifi))
++		return FALSE;
++
++	cancel_wps(wifi);
++
++	connman_technology_wps_failed_notify(wifi_technology);
++
++	return FALSE;
++}
++static void wps_start_callback(int result, GSupplicantInterface *interface,
++                            void *user_data)
++{
++	struct wifi_data *wifi = user_data;
++
++	DBG("result %d", result);
++
++	if (result == 0)
++		return;
++
++	if (!is_wifi_valid(wifi))
++		return;
++
++	/* if we're at this place something went wrong an we have to clean up */
++	if (wifi->wps_timeout > 0) {
++		g_source_remove(wifi->wps_timeout);
++		wifi->wps_timeout = 0;
++	}
++
++	wifi->wps_active = FALSE;
++
++	connman_technology_wps_failed_notify(wifi_technology);
++}
++static int start_wps(struct wifi_data *wifi)
++{
++	int ret;
++
++	connman_info("start wps connection");
++
++	wifi->wps_timeout = g_timeout_add_seconds(WPS_CONNECT_TIMEOUT,
++							wps_timeout_cb, wifi);
++
++	ret = g_supplicant_interface_connect(wifi->interface, wifi->wps_ssid,
++						wps_start_callback, wifi);
++	if (ret == -EALREADY || ret == -EINPROGRESS)
++		ret = 0;
++
++	return ret;
++}
++static gboolean deferred_wps_start(struct wifi_data *wifi)
++{
++	DBG("WPS active %d", wifi->wps_active);
++
++	if(wifi->wps_active == FALSE)
++		return FALSE;
++
++	if(wifi->wps_start_deferred) {
++		wifi->network = NULL;
++		start_wps(wifi);
++		wifi->wps_start_deferred = FALSE;
++		return TRUE;
++	}
++
++	return FALSE;
++}
++static int wifi_start_wps(struct connman_device *device, const char *pin)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	GSupplicantSSID *ssid;
++	int ret=0;
++
++	if (wifi->wps_active == TRUE)
++		return -EINPROGRESS;
++
++	DBG("");
++
++	ssid = g_try_malloc0(sizeof(GSupplicantSSID));
++	if (ssid == NULL)
++		return -ENOMEM;
++
++	ssid->use_wps = TRUE;
++	if(strlen(pin) == 0)
++		ssid->pin_wps = NULL;
++	else
++		ssid->pin_wps = g_strdup(pin);
++
++	wifi->wps_active = TRUE;
++	wifi->wps_ssid = ssid;
++
++	enable_auto_connect_block(TRUE);
++
++	/* if we're still disconnecting wait until we're completely disconnected */
++	if (wifi->disconnecting) {
++		DBG("Defering WPS until disconnect is done");
++		wifi->wps_start_deferred = TRUE;
++		return 0;
++	}
++
++	/* This is ahead of what will happen if we have an associating network
++	 * at this point. Once we issue the StartWPS command to wpa-supplicant
++	 * the network will be disconnected and we will receive the interface
++	 * state change signal. As we're in the middle of the WPS process we
++	 * don't handle that there ... */
++	if (wifi->network) {
++		connman_network_set_connected(wifi->network, FALSE);
++		connman_network_set_associating(wifi->network, FALSE);
++		wifi->network = NULL;
++	}
++
++	return start_wps(wifi);
++}
++static int wifi_cancel_wps(struct connman_device *device)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++
++	DBG("");
++
++	if (wifi->wps_active == FALSE)
++		return 0;
++
++	return cancel_wps(wifi);
++}
++static void cancel_p2p_callback(int result, GSupplicantInterface *interface,
++							void *user_data)
++{
++	struct connman_device *device = user_data;
++
++	DBG("result %d", result);
++
++	if (!device)
++		return;
++
++	//Do not p2p find on webOS 4.5 platform
++	//p2p_find(device);
++}
++static int wifi_cancel_p2p(struct connman_device *device)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	int ret = 0;
++
++	if (!wifi || !wifi->device)
++		return -EINVAL;
++
++	DBG("");
++
++	if (p2p_go_identifier != NULL) {
++		/* disconnect the group only if there are no existing connected peers */
++			struct connman_group *group = __connman_group_lookup_from_ident(p2p_go_identifier);
++
++			if (group != NULL) {
++
++				if (__connman_group_get_list_length(group) == 0)
++					__connman_group_peer_failed(group);
++
++				return 0;
++			}
++	}
++
++	ret = g_supplicant_interface_p2p_cancel(wifi->interface, cancel_p2p_callback, wifi->device);
++	if (ret == -EALREADY || ret == -EINPROGRESS) {
++		ret = 0;
++
++		connman_peer_state_change_by_cancelled();
++	}
++
++	return ret;
++}
++static void signal_info_cb(int result, GSupplicantInterface *interface, void *user_data)
++{
++	struct wifi_cb_data *data = user_data;
++	connman_device_request_signal_info_cb cb = data->callback;
++	unsigned int value;
++
++	if (result < 0)
++		goto done;
++
++	value = g_supplicant_interface_get_rssi(interface);
++	connman_device_set_integer(data->wifi->device, "WiFi.RSSI", value);
++
++	value = g_supplicant_interface_get_link_speed(interface);
++	connman_device_set_integer(data->wifi->device, "WiFi.LinkSpeed", value);
++
++	value = g_supplicant_interface_get_frequency(interface);
++	connman_device_set_integer(data->wifi->device, "WiFi.Frequency", value);
++
++	value = g_supplicant_interface_get_noise(interface);
++	connman_device_set_integer(data->wifi->device, "WiFi.Noise", value);
++
++done:
++	cb(data->wifi->device, data->user_data);
++
++	g_free(data);
++}
++static int wifi_get_signal_info(struct connman_device *device, connman_device_request_signal_info_cb cb, void *user_data)
++{
++	struct wifi_data *wifi = connman_device_get_data(device);
++	struct wifi_cb_data *data;
++
++	if (!wifi)
++		return -EINVAL;
++
++	data = g_new0(struct wifi_cb_data, 1);
++	if (!data)
++		return -ENOMEM;
++
++	data->callback = cb;
++	data->user_data = user_data;
++	data->wifi = wifi;
++
++	return g_supplicant_interface_update_signal_info(wifi->interface, signal_info_cb, data);
++}
++static struct connman_device_driver wifi_ng_driver = {
++	.name		= "wifi",
++	.type		= CONNMAN_DEVICE_TYPE_WIFI,
++	.priority	= CONNMAN_DEVICE_PRIORITY_LOW,
++	.probe		= wifi_probe,
++	.remove		= wifi_remove,
++	.enable		= wifi_enable,
++	.disable	= wifi_disable,
++	.scan		= wifi_scan,
++	.stop_scan	= wifi_stop_scan,
++	.set_regdom	= wifi_set_regdom,
++	.start_wps	= wifi_start_wps,
++	.cancel_wps	= wifi_cancel_wps,
++	.cancel_p2p	= wifi_cancel_p2p,
++	.get_signal_info = wifi_get_signal_info,
++};
++
++static void system_ready(void)
++{
++	DBG("");
++
++	if (connman_device_driver_register(&wifi_ng_driver) < 0)
++		connman_error("Failed to register WiFi driver");
++}
++
++static void system_killed(void)
++{
++	DBG("");
++
++	connman_device_driver_unregister(&wifi_ng_driver);
++}
++
++static int network_probe(struct connman_network *network)
++{
++	DBG("network %p", network);
++
++	return 0;
++}
++
++static int network_connect(struct connman_network *network);
++
++static gboolean perform_deferred_connect_after_disconnect(struct wifi_data *wifi)
++{
++	if (wifi->pending_network != NULL) {
++		network_connect(wifi->pending_network);
++		wifi->pending_network = NULL;
++		return TRUE;
++	}
++
++	if (deferred_wps_start(wifi)) {
++		return TRUE;
++	}
++
++	return FALSE;
++}
++
++static void network_remove(struct connman_network *network)
++{
++	struct connman_device *device = connman_network_get_device(network);
++	struct wifi_data *wifi;
++
++	DBG("network %p", network);
++
++	wifi = connman_device_get_data(device);
++	if (!wifi)
++		return;
++
++	if (wifi->network != network)
++		return;
++	else {
++		wifi->disconnecting = FALSE;
++		perform_deferred_connect_after_disconnect(wifi);
++	}
++
++	wifi->network = NULL;
++}
++
++static void connect_callback(int result, GSupplicantInterface *interface,
++							void *user_data)
++{
++	struct connman_network *network = user_data;
++
++	DBG("network %p result %d", network, result);
++
++	if (result == -ENOKEY) {
++		connman_network_set_error(network,
++					CONNMAN_NETWORK_ERROR_INVALID_KEY);
++	} else if (result < 0) {
++		connman_network_set_error(network,
++					CONNMAN_NETWORK_ERROR_CONFIGURE_FAIL);
++	}
++
++	connman_network_unref(network);
++}
++
++static GSupplicantSecurity network_security(const char *security)
++{
++	if (g_str_equal(security, "none"))
++		return G_SUPPLICANT_SECURITY_NONE;
++	else if (g_str_equal(security, "wep"))
++		return G_SUPPLICANT_SECURITY_WEP;
++	else if (g_str_equal(security, "psk"))
++		return G_SUPPLICANT_SECURITY_PSK;
++	else if (g_str_equal(security, "wpa"))
++		return G_SUPPLICANT_SECURITY_PSK;
++	else if (g_str_equal(security, "rsn"))
++		return G_SUPPLICANT_SECURITY_PSK;
++	else if (g_str_equal(security, "ieee8021x"))
++		return G_SUPPLICANT_SECURITY_IEEE8021X;
++
++	return G_SUPPLICANT_SECURITY_UNKNOWN;
++}
++
++static void ssid_init(GSupplicantSSID *ssid, struct connman_network *network)
++{
++	struct wifi_network *network_data = connman_network_get_data(network);
++	const char *security;
++
++	memset(ssid, 0, sizeof(*ssid));
++	ssid->mode = G_SUPPLICANT_MODE_INFRA;
++	ssid->ssid = connman_network_get_blob(network, "WiFi.SSID",
++						&ssid->ssid_len);
++	ssid->scan_ssid = 1;
++	security = connman_network_get_string(network, "WiFi.Security");
++	ssid->security = network_security(security);
++	
++	ssid->passphrase = connman_network_get_string(network,
++						"WiFi.Passphrase");
++
++	ssid->eap = connman_network_get_string(network, "WiFi.EAP");
++
++	/*
++	 * If our private key password is unset,
++	 * we use the supplied passphrase. That is needed
++	 * for PEAP where 2 passphrases (identity and client
++	 * cert may have to be provided.
++	 */
++	if (!connman_network_get_string(network, "WiFi.PrivateKeyPassphrase"))
++		connman_network_set_string(network,
++						"WiFi.PrivateKeyPassphrase",
++						ssid->passphrase);
++	/* We must have an identity for both PEAP and TLS */
++	ssid->identity = connman_network_get_string(network, "WiFi.Identity");
++
++	/* Use agent provided identity as a fallback */
++	if (!ssid->identity || strlen(ssid->identity) == 0)
++		ssid->identity = connman_network_get_string(network,
++							"WiFi.AgentIdentity");
++
++	ssid->anonymous_identity = connman_network_get_string(network,
++						"WiFi.AnonymousIdentity");
++	ssid->ca_cert_path = connman_network_get_string(network,
++							"WiFi.CACertFile");
++	ssid->subject_match = connman_network_get_string(network,
++							"WiFi.SubjectMatch");
+ 	ssid->altsubject_match = connman_network_get_string(network,
+ 							"WiFi.AltSubjectMatch");
+ 	ssid->domain_suffix_match = connman_network_get_string(network,
+@@ -2217,1082 +3601,2342 @@ static void ssid_init(GSupplicantSSID *ssid, struct connman_network *network)
+ 						"WiFi.PrivateKeyPassphrase");
+ 	ssid->phase2_auth = connman_network_get_string(network, "WiFi.Phase2");
+ 
+-	ssid->use_wps = connman_network_get_bool(network, "WiFi.UseWPS");
+-	ssid->pin_wps = connman_network_get_string(network, "WiFi.PinWPS");
++	ssid->use_wps = connman_network_get_bool(network, "WiFi.UseWPS");
++	ssid->pin_wps = connman_network_get_string(network, "WiFi.PinWPS");
++
++	if (connman_setting_get_bool("BackgroundScanning"))
++		ssid->bgscan = BGSCAN_DEFAULT;
++}
++
++static int network_connect(struct connman_network *network)
++{
++	struct connman_device *device = connman_network_get_device(network);
++	struct wifi_data *wifi;
++	GSupplicantInterface *interface;
++	GSupplicantSSID *ssid;
++
++	DBG("network %p", network);
++
++	if (!device)
++		return -ENODEV;
++
++	wifi = connman_device_get_data(device);
++	if (!wifi)
++		return -ENODEV;
++
++	if (wifi->wps_active)
++		return -EINPROGRESS;
++
++	ssid = g_try_malloc0(sizeof(GSupplicantSSID));
++	if (!ssid)
++		return -ENOMEM;
++
++	interface = wifi->interface;
++
++	p2p_stop_find(wifi);
++	ssid_init(ssid, network);
++
++	if (wifi->disconnecting) {
++		wifi->pending_network = network;
++		g_free(ssid);
++	} else {
++		wifi->network = connman_network_ref(network);
++		wifi->retries = 0;
++
++		if (p2p_technology && is_technology_enabled(p2p_technology) &&
++			connman_technology_get_p2p_listen(p2p_technology) == true) {
++			set_p2p_listen_without_state_change(p2p_technology, false);
++
++			wifi->p2p_listen_suppressed = true;
++			if (p2p_find_ref == -1)
++				g_supplicant_interface_p2p_stop_find(wifi->interface);
++		}
++		return g_supplicant_interface_connect(interface, ssid,
++						connect_callback, network);
++	}
++
++	return -EINPROGRESS;
++}
++
++static void disconnect_callback(int result, GSupplicantInterface *interface,
++								void *user_data)
++{
++	struct disconnect_data *dd = user_data;
++	struct connman_network *network = dd->network;
++	struct wifi_data *wifi = dd->wifi;
++
++	g_free(dd);
++
++	DBG("result %d supplicant interface %p wifi %p networks: current %p "
++		"pending %p disconnected %p", result, interface, wifi,
++		wifi->network, wifi->pending_network, network);
++
++	if (result == -ECONNABORTED) {
++		DBG("wifi interface no longer available");
++		return;
++	}
++
++	if (g_slist_find(wifi->networks, network))
++		connman_network_set_connected(network, false);
++
++	wifi->disconnecting = false;
++
++	if (network != wifi->network) {
++		if (network == wifi->pending_network)
++			wifi->pending_network = NULL;
++		DBG("current wifi network has changed since disconnection");
++		return;
++	}
++
++	wifi->network = NULL;
++
++	wifi->disconnecting = false;
++	wifi->connected = false;
++
++	if (perform_deferred_connect_after_disconnect(wifi) == FALSE)
++	{
++		start_autoscan(wifi->device);
++	}
++
++	start_autoscan(wifi->device);
++}
++
++static int network_disconnect(struct connman_network *network)
++{
++	struct connman_device *device = connman_network_get_device(network);
++	struct disconnect_data *dd;
++	struct wifi_data *wifi;
++	int err;
++
++	DBG("network %p", network);
++
++	wifi = connman_device_get_data(device);
++	if (!wifi || !wifi->interface)
++		return -ENODEV;
++
++	connman_network_set_associating(network, false);
++
++	if (wifi->disconnecting)
++		return -EALREADY;
++
++	wifi->disconnecting = true;
++
++	dd = g_malloc0(sizeof(*dd));
++	dd->wifi = wifi;
++	dd->network = network;
++
++	err = g_supplicant_interface_disconnect(wifi->interface,
++						disconnect_callback, dd);
++	if (err < 0) {
++		wifi->disconnecting = false;
++		g_free(dd);
++	}
++
++	return err;
++}
++
++static struct connman_network_driver network_driver = {
++	.name		= "wifi",
++	.type		= CONNMAN_NETWORK_TYPE_WIFI,
++	.priority	= CONNMAN_NETWORK_PRIORITY_LOW,
++	.probe		= network_probe,
++	.remove		= network_remove,
++	.connect	= network_connect,
++	.disconnect	= network_disconnect,
++};
++
++static void interface_added(GSupplicantInterface *interface)
++{
++	const char *ifname = g_supplicant_interface_get_ifname(interface);
++	const char *driver = g_supplicant_interface_get_driver(interface);
++	struct wifi_data *wifi;
++
++	wifi = g_supplicant_interface_get_data(interface);
++	if (!wifi) {
++		wifi = get_pending_wifi_data(ifname);
++		if (!wifi)
++			return;
++
++		wifi->interface = interface;
++		g_supplicant_interface_set_data(interface, wifi);
++		p2p_iface_list = g_list_append(p2p_iface_list, wifi);
++		wifi->p2p_device = true;
++	}
++
++	DBG("ifname %s driver %s wifi %p tethering %d",
++			ifname, driver, wifi, wifi->tethering);
++
++	if (!wifi->device) {
++		connman_error("WiFi device not set");
++		return;
++	}
++
++	connman_device_set_powered(wifi->device, true);
++}
++
++static bool is_idle(struct wifi_data *wifi)
++{
++	DBG("state %d", wifi->state);
++
++	switch (wifi->state) {
++	case G_SUPPLICANT_STATE_UNKNOWN:
++	case G_SUPPLICANT_STATE_DISABLED:
++	case G_SUPPLICANT_STATE_DISCONNECTED:
++	case G_SUPPLICANT_STATE_INACTIVE:
++	case G_SUPPLICANT_STATE_SCANNING:
++		return true;
++
++	case G_SUPPLICANT_STATE_AUTHENTICATING:
++	case G_SUPPLICANT_STATE_ASSOCIATING:
++	case G_SUPPLICANT_STATE_ASSOCIATED:
++	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
++	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
++	case G_SUPPLICANT_STATE_COMPLETED:
++		return false;
++	}
++
++	return false;
++}
++
++static bool is_idle_wps(GSupplicantInterface *interface,
++						struct wifi_data *wifi)
++{
++	/* First, let's check if WPS processing did not went wrong */
++	if (g_supplicant_interface_get_wps_state(interface) ==
++		G_SUPPLICANT_WPS_STATE_FAIL)
++		return false;
++
++	/* Unlike normal connection, being associated while processing wps
++	 * actually means that we are idling. */
++	switch (wifi->state) {
++	case G_SUPPLICANT_STATE_UNKNOWN:
++	case G_SUPPLICANT_STATE_DISABLED:
++	case G_SUPPLICANT_STATE_DISCONNECTED:
++	case G_SUPPLICANT_STATE_INACTIVE:
++	case G_SUPPLICANT_STATE_SCANNING:
++	case G_SUPPLICANT_STATE_ASSOCIATED:
++		return true;
++	case G_SUPPLICANT_STATE_AUTHENTICATING:
++	case G_SUPPLICANT_STATE_ASSOCIATING:
++	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
++	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
++	case G_SUPPLICANT_STATE_COMPLETED:
++		return false;
++	}
++
++	return false;
++}
++
++static bool handle_wps_completion(GSupplicantInterface *interface,
++					struct connman_network *network,
++					struct connman_device *device,
++					struct wifi_data *wifi)
++{
++	bool wps;
++
++	wps = connman_network_get_bool(network, "WiFi.UseWPS");
++	if (wps) {
++		const unsigned char *ssid, *wps_ssid;
++		unsigned int ssid_len, wps_ssid_len;
++		struct disconnect_data *dd;
++		const char *wps_key;
++
++		if (wifi->wps_active == FALSE) {
++			/* Checking if we got associated with requested
++			 * network */
++			ssid = connman_network_get_blob(network, "WiFi.SSID",
++							&ssid_len);
++
++		wps_ssid = g_supplicant_interface_get_wps_ssid(
++			interface, &wps_ssid_len);
++
++		if (!wps_ssid || wps_ssid_len != ssid_len ||
++				memcmp(ssid, wps_ssid, ssid_len) != 0) {
++			dd = g_malloc0(sizeof(*dd));
++			dd->wifi = wifi;
++			dd->network = network;
++
++			connman_network_set_associating(network, false);
++			g_supplicant_interface_disconnect(wifi->interface,
++						disconnect_callback, dd);
++			return false;
++		}
++		}
++
++		wps_key = g_supplicant_interface_get_wps_key(interface);
++		connman_network_set_string(network, "WiFi.Passphrase",
++					wps_key);
++
++		connman_network_set_string(network, "WiFi.PinWPS", NULL);
++	}
++
++	return true;
++}
++
++static bool handle_assoc_status_code(GSupplicantInterface *interface,
++                                     struct wifi_data *wifi)
++{
++	if (wifi->state == G_SUPPLICANT_STATE_ASSOCIATING &&
++			wifi->assoc_code == ASSOC_STATUS_NO_CLIENT &&
++			wifi->load_shaping_retries < LOAD_SHAPING_MAX_RETRIES) {
++		wifi->load_shaping_retries ++;
++		return TRUE;
++	}
++	wifi->load_shaping_retries = 0;
++	return FALSE;
++}
++
++static bool handle_4way_handshake_failure(GSupplicantInterface *interface,
++					struct connman_network *network,
++					struct wifi_data *wifi)
++{
++	struct connman_service *service;
++
++	if ((wifi->state != G_SUPPLICANT_STATE_4WAY_HANDSHAKE) &&
++			!((wifi->state == G_SUPPLICANT_STATE_ASSOCIATING) &&
++				(wifi->assoc_code == ASSOC_STATUS_AUTH_TIMEOUT)))
++		return false;
++
++	if (wifi->connected)
++		return false;
++
++	service = connman_service_lookup_from_network(network);
++	if (!service)
++		return false;
++
++	wifi->retries++;
++
++	if (connman_service_get_favorite(service)) {
++		if (wifi->retries < FAVORITE_MAXIMUM_RETRIES)
++			return true;
++	}
++
++	wifi->retries = 0;
++	connman_network_set_error(network, CONNMAN_NETWORK_ERROR_INVALID_KEY);
++
++	return false;
++}
++
++static void wps_state(GSupplicantInterface *interface)
++{
++	struct wifi_data *wifi;
++	GSupplicantWpsState state = g_supplicant_interface_get_wps_state(interface);
++	const char *wps_ssid, *ssid;
++	unsigned int wps_ssid_len, ssid_len;
++	GSList *list;
++	struct connman_network *found_network = NULL;
++
++	wifi = g_supplicant_interface_get_data(interface);
++
++	if(wifi==NULL)
++		return;
++
++	if (wifi->wps_active == FALSE)
++		return;
++
++	wps_ssid = g_supplicant_interface_get_wps_ssid(interface, &wps_ssid_len);
++
++	DBG("wifi %p wps state %d ssid %s", wifi, state, wps_ssid);
++
++	g_source_remove(wifi->wps_timeout);
++	wifi->wps_timeout = 0;
++
++	switch (state) {
++	case G_SUPPLICANT_WPS_STATE_UNKNOWN:
++		return;
++	case G_SUPPLICANT_WPS_STATE_FAIL:
++	wifi->wps_active = FALSE;
++	connman_technology_wps_failed_notify(wifi_technology);
++	return;
++	}
++
++	for (list = wifi->networks; list != NULL; list = list->next) {
++		struct connman_network *network = list->data;
++
++		ssid = connman_network_get_blob(network, "WiFi.SSID", &ssid_len);
++
++		if (ssid != NULL && wps_ssid_len == ssid_len &&
++		    memcmp(ssid, wps_ssid, ssid_len) == 0) {
++			DBG("found network %s", ssid);
++			connman_network_set_bool(network, "WiFi.UseWPS", TRUE);
++			found_network = network;
++			break;
++		}
++	}
++
++	if (found_network == NULL) {
++		DBG("didn't found a network for ssid %s", wps_ssid);
++		g_supplicant_interface_disconnect(wifi->interface,
++		disconnect_callback, wifi);
++		return;
++	}
++
++	/* we've found the correct network so we connect as normal
++	 * in our connection process */
++	wifi->network = found_network;
++}
++
++static void interface_state(GSupplicantInterface *interface)
++{
++	struct connman_network *network;
++	struct connman_device *device;
++	struct wifi_data *wifi;
++	GSupplicantState state = g_supplicant_interface_get_state(interface);
++	bool wps;
++	GSList *list;
++	bool old_connected;
++	const char *wps_ssid, *ssid;
++	unsigned int wps_ssid_len, ssid_len;
++
++	wifi = g_supplicant_interface_get_data(interface);
++
++	DBG("wifi %p interface state %d", wifi, state);
++
++	if (!wifi)
++		return;
++
++	device = wifi->device;
++	if (!device)
++		return;
++
++	if (state == G_SUPPLICANT_STATE_COMPLETED) {
++		if (wifi->tethering_param) {
++			g_free(wifi->tethering_param->ssid);
++			g_free(wifi->tethering_param);
++			wifi->tethering_param = NULL;
++		}
++
++		if (wifi->tethering)
++			stop_autoscan(device);
++	}
++
++	if (g_supplicant_interface_get_ready(interface) &&
++					!wifi->interface_ready) {
++		wifi->interface_ready = true;
++		finalize_interface_creation(wifi);
++	}
++
++	network = wifi->network;
++	if (!network)
++		return;
++
++	wps_ssid = g_supplicant_interface_get_wps_ssid(interface, &wps_ssid_len);
++	if (!network && wifi->wps_active && wps_ssid_len) {
++		for (list = wifi->networks; list != NULL; list = list->next) {
++			struct connman_network *connected_network = list->data;
++
++			ssid = connman_network_get_blob(connected_network, "WiFi.SSID", &ssid_len);
++			if (ssid != NULL && wps_ssid_len == ssid_len &&
++				memcmp(ssid, wps_ssid, ssid_len) == 0) {
++				DBG("found network %s", ssid);
++				connman_network_set_bool(connected_network, "WiFi.UseWPS", TRUE);
++				wifi->network = connected_network;
++				network = wifi->network;
++				break;
++			}
++		}
++	}
++
++	switch (state) {
++	case G_SUPPLICANT_STATE_SCANNING:
++		if (wifi->connected)
++			connman_network_set_connected(network, false);
++
++		break;
++
++	case G_SUPPLICANT_STATE_AUTHENTICATING:
++	case G_SUPPLICANT_STATE_ASSOCIATING:
++		stop_autoscan(device);
++
++		connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_WIFI,FALSE);
++		if (!wifi->connected)
++			connman_network_set_associating(network, true);
++
++		break;
++
++	case G_SUPPLICANT_STATE_COMPLETED:
++		/* though it should be already stopped: */
++		stop_autoscan(device);
++
++		connman_device_set_scanning(device,CONNMAN_SERVICE_TYPE_WIFI,FALSE);
++		if (!handle_wps_completion(interface, network, device, wifi))
++			break;
++
++		connman_network_set_connected(network, true);
++
++		wifi->disconnect_code = 0;
++		wifi->assoc_code = 0;
++		wifi->load_shaping_retries = 0;
++		wifi->wps_active = FALSE;
++		break;
++
++	case G_SUPPLICANT_STATE_DISCONNECTED:
++		/*
++		 * If we're in one of the idle modes, we have
++		 * not started association yet and thus setting
++		 * those ones to FALSE could cancel an association
++		 * in progress.
++		 */
++		wps = connman_network_get_bool(network, "WiFi.UseWPS");
++		if (wps)
++			if (is_idle_wps(interface, wifi))
++				break;
++
++		if (is_idle(wifi))
++			break;
++
++		if (handle_assoc_status_code(interface, wifi))
++			break;
++
++		/* If previous state was 4way-handshake, then
++		 * it's either: psk was incorrect and thus we retry
++		 * or if we reach the maximum retries we declare the
++		 * psk as wrong */
++		if (handle_4way_handshake_failure(interface,
++						network, wifi))
++			break;
++
++		/* See table 8-36 Reason codes in IEEE Std 802.11 */
++		switch (wifi->disconnect_code) {
++		case 6: /* Class 2 frame received from nonauthenticated STA */
++			connman_network_set_error(network,
++						CONNMAN_NETWORK_ERROR_BLOCKED);
++			break;
++
++		default:
++			break;
++		}
++
++		if (network != wifi->pending_network) {
++			connman_network_set_connected(network, false);
++			connman_network_set_associating(network, false);
++		}
++		wifi->disconnecting = false;
++
++		if (!deferred_wps_start(wifi))
++		{
++			/* Set connected to false to allow autoscan to start. */
++			wifi->connected = FALSE;
++		    start_autoscan(device);
++		}
++
++		break;
++
++	case G_SUPPLICANT_STATE_INACTIVE:
++		connman_network_set_associating(network, false);
++		start_autoscan(device);
++
++		break;
++
++	case G_SUPPLICANT_STATE_UNKNOWN:
++	case G_SUPPLICANT_STATE_DISABLED:
++	case G_SUPPLICANT_STATE_ASSOCIATED:
++	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
++	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
++		break;
++	}
++
++	old_connected = wifi->connected;
++	wifi->state = state;
++
++	/* Saving wpa_s state policy:
++	 * If connected and if the state changes are roaming related:
++	 * --> We stay connected
++	 * If completed
++	 * --> We are connected
++	 * All other case:
++	 * --> We are not connected
++	 * */
++	switch (state) {
++	case G_SUPPLICANT_STATE_AUTHENTICATING:
++	case G_SUPPLICANT_STATE_ASSOCIATING:
++	case G_SUPPLICANT_STATE_ASSOCIATED:
++	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
++	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
++		if (wifi->connected)
++			connman_warn("Probably roaming right now!"
++						" Staying connected...");
++		break;
++	case G_SUPPLICANT_STATE_SCANNING:
++		wifi->connected = false;
++
++		if (old_connected)
++			start_autoscan(device);
++		break;
++	case G_SUPPLICANT_STATE_COMPLETED:
++		wifi->connected = true;
++		break;
++	default:
++		wifi->connected = false;
++		break;
++	}
++
++	DBG("DONE");
++}
++
++static void interface_removed(GSupplicantInterface *interface)
++{
++	const char *ifname = g_supplicant_interface_get_ifname(interface);
++	struct wifi_data *wifi;
++	int err;
++
++	DBG("ifname %s", ifname);
++	GSList *list;
++
++	for (list = iface_list; list; list = list->next) {
++		wifi = list->data;
++		GSupplicantInterface *p2p_interface = wifi->interface;
++
++		if (!p2p_interface || !g_supplicant_interface_has_p2p(p2p_interface))
++			continue;
++
++		if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++				g_strcmp0(g_supplicant_interface_get_ifname(p2p_interface),
++					connman_option_get_string("P2PDevice")) != 0)
++			continue;
++
++		if (connman_technology_get_p2p_listen(p2p_technology) == false &&
++				!__connman_peer_get_connected_exists()) {
++			if (!connman_technology_get_enable_p2p_listen(p2p_technology))
++				break;
++			err = apply_p2p_listen_on_iface(wifi, &params);
++			if (err == 0)
++				connman_technology_set_p2p_listen(p2p_technology, true);
++		}
++	}
++
++	wifi = g_supplicant_interface_get_data(interface);
++
++	if (wifi)
++		wifi->interface = NULL;
++
++	if (wifi && wifi->tethering)
++		return;
++
++	if (!wifi || !wifi->device) {
++		DBG("wifi interface already removed");
++		return;
++	}
++
++	connman_device_set_powered(wifi->device, false);
++
++	check_p2p_technology();
++}
++
++static void set_device_type(const char *type, char dev_type[17])
++{
++	const char *oui = "0050F204";
++	const char *category = "0001";
++	const char *sub_category = "0000";
++
++	if (!g_strcmp0(type, "handset")) {
++		category = "000A";
++		sub_category = "0005";
++	} else if (!g_strcmp0(type, "vm") || !g_strcmp0(type, "container"))
++		sub_category = "0001";
++	else if (!g_strcmp0(type, "server"))
++		sub_category = "0002";
++	else if (!g_strcmp0(type, "laptop"))
++		sub_category = "0005";
++	else if (!g_strcmp0(type, "desktop"))
++		sub_category = "0006";
++	else if (!g_strcmp0(type, "tablet"))
++		sub_category = "0009";
++	else if (!g_strcmp0(type, "watch"))
++		category = "00FF";
++
++	snprintf(dev_type, 17, "%s%s%s", category, oui, sub_category);
++}
++
++static void p2ps_prov_start(GSupplicantInterface *interface,  GSupplicantPeer *peer, GSupplicantP2PSProvisionSignalParams* params)
++{
++	struct wifi_data *wifi;
++	const char *identifier;
++	struct connman_network *connman_network;
++
++	wifi = g_supplicant_interface_get_data(interface);
++	identifier = g_supplicant_peer_get_identifier(peer);
++
++	DBG("identifier %s", identifier);
++
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (connman_network == NULL)
++		return;
++
++	//wfds_on_p2ps_prov_start(connman_network, params);
++}
++
++static void p2ps_prov_done(GSupplicantInterface *interface,  GSupplicantPeer *peer, GSupplicantP2PSProvisionSignalParams* params)
++{
++	struct wifi_data *wifi;
++	const char *identifier;
++	struct connman_network *connman_network;
++
++	wifi = g_supplicant_interface_get_data(interface);
++	identifier = g_supplicant_peer_get_identifier(peer);
++
++	DBG("identifier %s", identifier);
++
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (connman_network == NULL)
++		return;
++
++	//wfds_on_p2ps_prov_done(connman_network, params);
++}
++
++static GSupplicantSSID *ssid_persistent_init(GSupplicantP2PPersistentGroup *persistent_group, int go)
++{
++	GSupplicantSSID *p_ssid;
++
++	p_ssid = g_try_malloc0(sizeof(GSupplicantSSID));
++	if (p_ssid == NULL)
++		return NULL;
++
++	if(go == 1)
++		p_ssid->mode = G_SUPPLICANT_MODE_MASTER;
++	else
++		p_ssid->mode = G_SUPPLICANT_MODE_UNKNOWN;
++	p_ssid->ssid = g_strdup(persistent_group->ssid);
++	p_ssid->ssid_len = strlen(persistent_group->ssid);
++	p_ssid->scan_ssid = 0;
++	p_ssid->bssid = g_strdup(persistent_group->bssid);
++	p_ssid->passphrase= g_strdup(persistent_group->psk);
++
++	p_ssid->security = G_SUPPLICANT_SECURITY_PSK;
++	p_ssid->protocol = G_SUPPLICANT_PROTO_RSN;
++	p_ssid->pairwise_cipher = G_SUPPLICANT_PAIRWISE_CCMP;
++	p_ssid->group_cipher = G_SUPPLICANT_GROUP_CCMP;
++
++	return p_ssid;
++}
++
++static int p2p_persistent_info_load(GSupplicantInterface *interface, const char *persistent_dir, GSupplicantP2PPersistentGroup *persistent_group)
++{
++	GKeyFile *keyfile;
++	const char *ssid=NULL, *bssid=NULL, *psk=NULL, *role=NULL, *mac_address=NULL;
++	int ret = -1;
++	unsigned long long connectedtime=0;
++
++	keyfile = __connman_storage_open_service(persistent_dir);
++	if(keyfile == NULL)
++		return -EIO;
++
++	ssid = g_key_file_get_string(keyfile, P2P_PERSISTENT_INFO, "SSID", NULL);
++	bssid = g_key_file_get_string(keyfile, P2P_PERSISTENT_INFO, "BSSID", NULL);
++	psk = g_key_file_get_string(keyfile, P2P_PERSISTENT_INFO, "PSK", NULL);
++	role = g_key_file_get_string(keyfile, P2P_PERSISTENT_INFO, "Role", NULL);
++	mac_address = g_key_file_get_string(keyfile, P2P_PERSISTENT_INFO, "MAC", NULL);
++	connectedtime = g_key_file_get_uint64(keyfile, P2P_PERSISTENT_INFO, "ConnectedTime", NULL);
++
++	g_key_file_free(keyfile);
++
++	if (mac_address) {
++		struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
++		if (wifi) {
++			char * p2p_ident = __connman_util_insert_colon_to_mac_addr(connman_device_get_ident(wifi->device));
++			if (strncmp(mac_address, p2p_ident, 17) != 0) {
++				// P2P MAC address changed, so removing this p2p service
++				__connman_storage_remove_service(persistent_dir);
++				g_free(p2p_ident);
++				goto cleanup;
++			}
++			g_free(p2p_ident);
++		}
++	}
++
++	if(ssid != NULL && bssid != NULL && psk != NULL) {
++		DBG("ssid : %s bssid : %s psk : %s connectedtime : %llu\n", ssid, bssid, psk, connectedtime);
++
++		persistent_group->interface = interface;
++		persistent_group->ssid = g_strdup(ssid);
++		persistent_group->bssid = g_strdup(bssid);
++		persistent_group->psk = g_strdup(psk);
++		persistent_group->connected_time = connectedtime;
++
++		if(g_str_equal(role, "GO")) {
++			persistent_group->go = TRUE;
++			ret = 1;
++		} else if(g_str_equal(role, "Client")) {
++			persistent_group->go = FALSE;
++			ret = 0;
++		} else
++			ret = -1;
++	}
++
++cleanup:
++	g_free(mac_address);
++	g_free(role);
++	g_free(psk);
++	g_free(bssid);
++	g_free(ssid);
++	return ret;
++}
++
++static void ssid_persistent_free(GSupplicantSSID *p_ssid)
++{
++	if (p_ssid == NULL)
++		return;
++
++	if (p_ssid->ssid)
++		g_free(p_ssid->ssid);
++	if (p_ssid->bssid)
++		g_free(p_ssid->bssid);
++	if (p_ssid->passphrase)
++		g_free(p_ssid->passphrase);
++
++	g_free(p_ssid);
++	p_ssid = NULL;
++}
++
++
++static int add_persistent_group_info(struct wifi_data *wifi)
++{
++	GSupplicantInterface *interface;
++	gchar **persistents;
++	GSupplicantP2PPersistentGroup *persistent_group;
++	int go;
++	char *peer;
++	int i;
++
++	if(wifi == NULL)
++		return -ENOMEM;
++
++	interface = wifi->interface;
++
++	if(interface == NULL)
++		return -ENOMEM;
++
++	persistents = __connman_storage_get_p2p_persistents();
++        if (!persistents)
++            return -ENOMEM;
++
++	for (i = 0; persistents && persistents[i]; i++) {
++		persistent_group = g_try_malloc0(sizeof(GSupplicantP2PPersistentGroup));
++		if(persistent_group == NULL) {
++			g_strfreev(persistents);
++			return -ENOMEM;
++		}
++
++		if (strncmp(persistents[i], "p2p_persistent_", 15) != 0) {
++			g_free(persistent_group);
++			continue;
++		}
++
++		go = p2p_persistent_info_load(interface, persistents[i], persistent_group);
++		if(go < 0) {
++			g_free(persistent_group);
++			continue;
++		}
++		else {
++			GSupplicantSSID *p_ssid = ssid_persistent_init(persistent_group, go);
++
++			if(p_ssid == NULL) {
++				g_free(persistent_group);
++				continue;
++			}
++
++			wifi->persistent_groups = g_slist_prepend(wifi->persistent_groups, persistent_group);
++
++			g_supplicant_interface_p2p_add_persistent_group(interface, p_ssid, &go);
++
++			peer = strrchr(persistents[i], '_') + 1;
++			g_hash_table_replace(wifi->persistent_peer_ssid, peer, persistent_group->ssid);
++			ssid_persistent_free(p_ssid);
++		}
++	}
++        g_strfreev(persistents);
++	return 1;
++}
++static void p2p_support(GSupplicantInterface *interface)
++{
++	char dev_type[17] = {};
++	const char *hostname;
++
++	DBG("");
++
++	if (!interface)
++		return;
++
++	if (!g_supplicant_interface_has_p2p(interface))
++		return;
++
++	if (connman_technology_driver_register(&p2p_tech_driver) < 0) {
++		DBG("Could not register P2P technology driver");
++		return;
++	}
++
++	hostname = connman_utsname_get_hostname();
++	if (!hostname)
++		hostname = "ConnMan";
++
++	set_device_type(connman_machine_get_type(), dev_type);
++	g_supplicant_interface_set_p2p_device_config(interface,
++							hostname, dev_type);
++	connman_peer_driver_register(&peer_driver);
++}
++
++static void p2p_device_config_loaded(GSupplicantInterface *interface)
++{
++	struct wifi_data *wifi = NULL;
++	char dev_type[17] = {};
++	char hostname[HOST_NAME_MAX+1] = {0};
++	const char *p2p_identifier;
++	char *old_device_name = NULL, *old_ssid_postfix = NULL;
++	int result;
++
++	wifi = g_supplicant_interface_get_data(interface);
++
++	if (!wifi)
++		return;
++
++	p2p_identifier = load_p2p_identifier();
++	if (wifi->p2p_device_config.device_name)
++		old_device_name = wifi->p2p_device_config.device_name;
++
++	if (wifi->p2p_device_config.ssid_postfix)
++		old_ssid_postfix = wifi->p2p_device_config.ssid_postfix;
++
++	if (!p2p_identifier) {
++		if (gethostname(hostname, HOST_NAME_MAX) < 0)
++			return;
++
++		wifi->p2p_device_config.device_name = g_strdup(hostname);
++	}
++	else
++		wifi->p2p_device_config.device_name = g_strdup(p2p_identifier);
++
++	if (wifi->p2p_device_config.device_name) {
++		/* we have to add a hyphen here as wpa-supplicant just adds the postifx to the
++		 * automatically created SSID */
++		wifi->p2p_device_config.ssid_postfix = g_strdup_printf("-%s", wifi->p2p_device_config.device_name);
++	}
++
++	/**
++	 * TV icon type listed as Laptop. Reason is the machine type related interface org.freedesktop.hostname1
++	 * is not used ,commenting the below source ,using the type from wpa_supplicant as it is
++	 */
++	/*	set_device_type(connman_machine_get_type(), dev_type);
++	 dev_type_str2bin(dev_type, wifi->p2p_device_config.pri_dev_type);*/
++
++	result = g_supplicant_interface_set_p2p_device_configs(interface, &wifi->p2p_device_config, NULL);
++	if (result < 0) {
++		g_free(wifi->p2p_device_config.device_name);
++		g_free(wifi->p2p_device_config.ssid_postfix);
++		wifi->p2p_device_config.device_name = old_device_name;
++		wifi->p2p_device_config.ssid_postfix = old_ssid_postfix;
++	}
++
++	connman_technology_set_p2p_identifier(p2p_technology, wifi->p2p_device_config.device_name);
++	if (old_device_name != wifi->p2p_device_config.device_name)
++		g_free(old_device_name);
++	if (old_ssid_postfix != wifi->p2p_device_config.ssid_postfix)
++		g_free(old_ssid_postfix);
++
++    g_free(p2p_identifier);
++}
++
++static void scan_started(GSupplicantInterface *interface)
++{
++	DBG("");
++}
++
++static void scan_finished(GSupplicantInterface *interface)
++{
++	DBG("");
++}
++
++static void ap_create_fail(GSupplicantInterface *interface)
++{
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
++	int ret;
++
++	if ((wifi->tethering) && (wifi->tethering_param)) {
++		DBG("%s create AP fail \n",
++				g_supplicant_interface_get_ifname(wifi->interface));
++
++		connman_inet_remove_from_bridge(wifi->index, wifi->bridge);
++		wifi->ap_supported = WIFI_AP_NOT_SUPPORTED;
++		wifi->tethering = false;
++
++		ret = tech_set_tethering(wifi->tethering_param->technology,
++				wifi->tethering_param->ssid->ssid,
++				wifi->tethering_param->ssid->passphrase,
++				wifi->bridge, true);
++
++		if ((ret == -EOPNOTSUPP) && (wifi_technology)) {
++			connman_technology_tethering_notify(wifi_technology,false);
++		}
++
++		g_free(wifi->tethering_param->ssid);
++		g_free(wifi->tethering_param);
++		wifi->tethering_param = NULL;
++	}
++}
++
++static unsigned char calculate_strength(GSupplicantNetwork *supplicant_network)
++{
++	unsigned char strength;
++
++	strength = 120 + g_supplicant_network_get_signal(supplicant_network);
++	if (strength > 100)
++		strength = 100;
++
++	return strength;
++}
++
++static unsigned char calculate_peer_strength(GSupplicantPeer *peer)
++{
++	unsigned char strength;
++
++	strength = 120 + g_supplicant_peer_get_level(peer);
++	if (strength > 100)
++		strength = 100;
++
++	return strength;
++}
++
++static void network_added(GSupplicantNetwork *supplicant_network)
++{
++	struct connman_network *network;
++	GSupplicantInterface *interface;
++	struct wifi_data *wifi;
++	struct wifi_network *network_data;
++	const char *name, *identifier, *security, *group, *mode;
++	const unsigned char *ssid;
++	unsigned int ssid_len;
++	bool wps;
++	bool wps_pbc;
++	bool wps_ready;
++	bool wps_advertizing;
++	GHashTable *bss_table;
++
++	mode = g_supplicant_network_get_mode(supplicant_network);
++	identifier = g_supplicant_network_get_identifier(supplicant_network);
++
++	DBG("%s", identifier);
++
++	if (!g_strcmp0(mode, "adhoc"))
++		return;
++
++	interface = g_supplicant_network_get_interface(supplicant_network);
++	wifi = g_supplicant_interface_get_data(interface);
++	name = g_supplicant_network_get_name(supplicant_network);
++	security = g_supplicant_network_get_security(supplicant_network);
++	group = g_supplicant_network_get_identifier(supplicant_network);
++	wps = g_supplicant_network_get_wps(supplicant_network);
++	wps_pbc = g_supplicant_network_is_wps_pbc(supplicant_network);
++	wps_ready = g_supplicant_network_is_wps_active(supplicant_network);
++	wps_advertizing = g_supplicant_network_is_wps_advertizing(
++							supplicant_network);
++	bss_table = g_supplicant_network_get_bss_table(supplicant_network);
++
++	if (!wifi)
++		return;
++
++	ssid = g_supplicant_network_get_ssid(supplicant_network, &ssid_len);
++
++	network = connman_device_get_network(wifi->device, identifier);
++
++	if (!network) {
++		network = connman_network_create(identifier,
++						CONNMAN_NETWORK_TYPE_WIFI);
++		if (!network)
++			return;
++
++		connman_network_set_index(network, wifi->index);
++
++		if (connman_device_add_network(wifi->device, network) < 0) {
++			connman_network_unref(network);
++			return;
++		}
++
++		wifi->networks = g_slist_prepend(wifi->networks, network);
++
++		network_data = g_new0(struct wifi_network, 1);
++		connman_network_set_data(network, network_data);
++	}
++
++	network_data = connman_network_get_data(network);
++	network_data->keymgmt =
++		g_supplicant_network_get_keymgmt(supplicant_network);
++
++	if (name && name[0] != '\0')
++		connman_network_set_name(network, name);
++
++	connman_network_set_blob(network, "WiFi.SSID",
++						ssid, ssid_len);
++	connman_network_set_string(network, "WiFi.Security", security);
++	connman_network_set_strength(network,
++				calculate_strength(supplicant_network));
++	connman_network_set_bool(network, "WiFi.WPS", wps);
++	connman_network_set_bool(network, "WiFi.WPSAdvertising",
++				wps_advertizing);
++
++	if (wps) {
++		/* Is AP advertizing for WPS association?
++		 * If so, we decide to use WPS by default */
++		if (wps_ready && wps_pbc &&
++						wps_advertizing)
++			connman_network_set_bool(network, "WiFi.UseWPS", true);
++	}
++
++	connman_network_set_frequency(network,
++			g_supplicant_network_get_frequency(supplicant_network));
++
++	connman_network_set_available(network, true);
++	connman_network_set_string(network, "WiFi.Mode", mode);
++
++	if (ssid)
++		connman_network_set_group(network, group);
++
++	if (wifi->hidden && ssid) {
++		if (!g_strcmp0(wifi->hidden->security, security) &&
++				wifi->hidden->ssid_len == ssid_len &&
++				!memcmp(wifi->hidden->ssid, ssid, ssid_len)) {
++			connman_network_connect_hidden(network,
++					wifi->hidden->identity,
++					wifi->hidden->passphrase,
++					wifi->hidden->user_data);
++			wifi->hidden->user_data = NULL;
++			hidden_free(wifi->hidden);
++			wifi->hidden = NULL;
++		}
++	}
++
++	connman_network_set_address(network, g_supplicant_network_get_bssid(supplicant_network), 6);
+ 
+-	if (connman_setting_get_bool("BackgroundScanning"))
+-		ssid->bgscan = BGSCAN_DEFAULT;
++	if (bss_table)
++		g_hash_table_foreach(bss_table, bss_foreach, network);
+ }
+ 
+-static int network_connect(struct connman_network *network)
++static void network_removed(GSupplicantNetwork *network)
+ {
+-	struct connman_device *device = connman_network_get_device(network);
+-	struct wifi_data *wifi;
+ 	GSupplicantInterface *interface;
+-	GSupplicantSSID *ssid;
++	struct wifi_data *wifi;
++	const char *name, *identifier;
++	struct connman_network *connman_network;
+ 
+-	DBG("network %p", network);
++	interface = g_supplicant_network_get_interface(network);
++	wifi = g_supplicant_interface_get_data(interface);
++	identifier = g_supplicant_network_get_identifier(network);
++	name = g_supplicant_network_get_name(network);
+ 
+-	if (!device)
+-		return -ENODEV;
++	DBG("name %s", name);
+ 
+-	wifi = connman_device_get_data(device);
+ 	if (!wifi)
+-		return -ENODEV;
+-
+-	ssid = g_try_malloc0(sizeof(GSupplicantSSID));
+-	if (!ssid)
+-		return -ENOMEM;
+-
+-	interface = wifi->interface;
+-
+-	ssid_init(ssid, network);
++		return;
+ 
+-	if (wifi->disconnecting) {
+-		wifi->pending_network = network;
+-		g_free(ssid);
+-	} else {
+-		wifi->network = connman_network_ref(network);
+-		wifi->retries = 0;
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
++		return;
+ 
+-		return g_supplicant_interface_connect(interface, ssid,
+-						connect_callback, network);
+-	}
++	wifi->networks = g_slist_remove(wifi->networks, connman_network);
+ 
+-	return -EINPROGRESS;
++	g_free(connman_network_get_data(connman_network));
++	connman_device_remove_network(wifi->device, connman_network);
++	connman_network_unref(connman_network);
+ }
+ 
+-static void disconnect_callback(int result, GSupplicantInterface *interface,
+-								void *user_data)
++static void network_changed(GSupplicantNetwork *network, const char *property)
+ {
+-	struct disconnect_data *dd = user_data;
+-	struct connman_network *network = dd->network;
+-	struct wifi_data *wifi = dd->wifi;
++	GSupplicantInterface *interface;
++	struct wifi_data *wifi;
++	const char *name, *identifier;
++	struct connman_network *connman_network;
++	bool update_needed;
++	GHashTable *bss_table;
+ 
+-	g_free(dd);
++	if (p2p_find_ref != -1)
++		return;
+ 
+-	DBG("result %d supplicant interface %p wifi %p networks: current %p "
+-		"pending %p disconnected %p", result, interface, wifi,
+-		wifi->network, wifi->pending_network, network);
++	interface = g_supplicant_network_get_interface(network);
++	wifi = g_supplicant_interface_get_data(interface);
++	identifier = g_supplicant_network_get_identifier(network);
++	name = g_supplicant_network_get_name(network);
++	bss_table = g_supplicant_network_get_bss_table(network);
+ 
+-	if (result == -ECONNABORTED) {
+-		DBG("wifi interface no longer available");
++	DBG("name %s", name);
++
++	if (!wifi)
+ 		return;
+-	}
+ 
+-	if (g_slist_find(wifi->networks, network))
+-		connman_network_set_connected(network, false);
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
++		return;
+ 
+-	wifi->disconnecting = false;
++	connman_network_set_address(connman_network, g_supplicant_network_get_bssid(network), 6);
+ 
+-	if (network != wifi->network) {
+-		if (network == wifi->pending_network)
+-			wifi->pending_network = NULL;
+-		DBG("current wifi network has changed since disconnection");
+-		return;
+-	}
++	if (bss_table)
++		g_hash_table_foreach(bss_table, bss_foreach, connman_network);
+ 
+-	wifi->network = NULL;
++	if (g_str_equal(property, "WPSCapabilities")) {
++		bool wps;
++		bool wps_pbc;
++		bool wps_ready;
++		bool wps_advertizing;
+ 
+-	wifi->connected = false;
++		wps = g_supplicant_network_get_wps(network);
++		wps_pbc = g_supplicant_network_is_wps_pbc(network);
++		wps_ready = g_supplicant_network_is_wps_active(network);
++		wps_advertizing =
++			g_supplicant_network_is_wps_advertizing(network);
+ 
+-	if (wifi->pending_network) {
+-		network_connect(wifi->pending_network);
+-		wifi->pending_network = NULL;
+-	}
++		connman_network_set_bool(connman_network, "WiFi.WPS", wps);
++		connman_network_set_bool(connman_network,
++				"WiFi.WPSAdvertising", wps_advertizing);
+ 
+-	start_autoscan(wifi->device);
++		if (wps) {
++			/*
++			 * Is AP advertizing for WPS association?
++			 * If so, we decide to use WPS by default
++			 */
++			if (wps_ready && wps_pbc && wps_advertizing)
++				connman_network_set_bool(connman_network,
++							"WiFi.UseWPS", true);
++		}
++
++		update_needed = true;
++	} else if (g_str_equal(property, "Signal")) {
++		connman_network_set_strength(connman_network,
++					calculate_strength(network));
++		update_needed = true;
++	} else
++		update_needed = false;
++
++	if (update_needed)
++		connman_network_update(connman_network);
+ }
+ 
+-static int network_disconnect(struct connman_network *network)
++static void network_associated(GSupplicantNetwork *network)
+ {
+-	struct connman_device *device = connman_network_get_device(network);
+-	struct disconnect_data *dd;
++	GSupplicantInterface *interface;
+ 	struct wifi_data *wifi;
+-	int err;
++	struct connman_network *connman_network;
++	const char *identifier;
+ 
+-	DBG("network %p", network);
++	DBG("");
+ 
+-	wifi = connman_device_get_data(device);
+-	if (!wifi || !wifi->interface)
+-		return -ENODEV;
++	interface = g_supplicant_network_get_interface(network);
++	if (!interface)
++		return;
+ 
+-	connman_network_set_associating(network, false);
++	wifi = g_supplicant_interface_get_data(interface);
++	if (!wifi)
++		return;
+ 
+-	if (wifi->disconnecting)
+-		return -EALREADY;
++	/* P2P networks must not be treated as WiFi networks */
++	if (wifi->p2p_connecting || wifi->p2p_device)
++		return;
+ 
+-	wifi->disconnecting = true;
++	identifier = g_supplicant_network_get_identifier(network);
+ 
+-	dd = g_malloc0(sizeof(*dd));
+-	dd->wifi = wifi;
+-	dd->network = network;
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
++		return;
+ 
+-	err = g_supplicant_interface_disconnect(wifi->interface,
+-						disconnect_callback, dd);
+-	if (err < 0) {
+-		wifi->disconnecting = false;
+-		g_free(dd);
+-	}
++	if (wifi->network) {
++		if (wifi->network == connman_network)
++			return;
+ 
+-	return err;
+-}
++		/*
++		 * This should never happen, we got associated with
++		 * a network different than the one we were expecting.
++		 */
++		DBG("Associated to %p while expecting %p",
++					connman_network, wifi->network);
+ 
+-static struct connman_network_driver network_driver = {
+-	.name		= "wifi",
+-	.type		= CONNMAN_NETWORK_TYPE_WIFI,
+-	.priority	= CONNMAN_NETWORK_PRIORITY_LOW,
+-	.probe		= network_probe,
+-	.remove		= network_remove,
+-	.connect	= network_connect,
+-	.disconnect	= network_disconnect,
+-};
++		connman_network_set_associating(wifi->network, false);
++	}
+ 
+-static void interface_added(GSupplicantInterface *interface)
+-{
+-	const char *ifname = g_supplicant_interface_get_ifname(interface);
+-	const char *driver = g_supplicant_interface_get_driver(interface);
+-	struct wifi_data *wifi;
++	DBG("Reconnecting to previous network %p from wpa_s", connman_network);
+ 
+-	wifi = g_supplicant_interface_get_data(interface);
+-	if (!wifi) {
+-		wifi = get_pending_wifi_data(ifname);
+-		if (!wifi)
+-			return;
++	wifi->network = connman_network_ref(connman_network);
++	wifi->retries = 0;
+ 
+-		wifi->interface = interface;
+-		g_supplicant_interface_set_data(interface, wifi);
+-		p2p_iface_list = g_list_append(p2p_iface_list, wifi);
+-		wifi->p2p_device = true;
+-	}
++	/*
++	 * Interface state changes callback (interface_state) is always
++	 * called before network_associated callback thus we need to call
++	 * interface_state again in order to process the new state now that
++	 * we have the network properly set.
++	 */
++	interface_state(interface);
++}
+ 
+-	DBG("ifname %s driver %s wifi %p tethering %d",
+-			ifname, driver, wifi, wifi->tethering);
++static void sta_authorized(GSupplicantInterface *interface,
++					const char *addr)
++{
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 
+-	if (!wifi->device) {
+-		connman_error("WiFi device not set");
++	DBG("wifi %p station %s authorized", wifi, addr);
++
++	if (!wifi || !wifi->tethering)
+ 		return;
+-	}
+ 
+-	connman_device_set_powered(wifi->device, true);
++	__connman_tethering_client_register(addr);
+ }
+ 
+-static bool is_idle(struct wifi_data *wifi)
++static void sta_deauthorized(GSupplicantInterface *interface,
++					const char *addr)
+ {
+-	DBG("state %d", wifi->state);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 
+-	switch (wifi->state) {
+-	case G_SUPPLICANT_STATE_UNKNOWN:
+-	case G_SUPPLICANT_STATE_DISABLED:
+-	case G_SUPPLICANT_STATE_DISCONNECTED:
+-	case G_SUPPLICANT_STATE_INACTIVE:
+-	case G_SUPPLICANT_STATE_SCANNING:
+-		return true;
++	DBG("wifi %p station %s deauthorized", wifi, addr);
+ 
+-	case G_SUPPLICANT_STATE_AUTHENTICATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATED:
+-	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_COMPLETED:
+-		return false;
+-	}
++	if (!wifi || !wifi->tethering)
++		return;
+ 
+-	return false;
++	__connman_tethering_client_unregister(addr);
+ }
+ 
+-static bool is_idle_wps(GSupplicantInterface *interface,
+-						struct wifi_data *wifi)
++static void station_added(const char *mac)
+ {
+-	/* First, let's check if WPS processing did not went wrong */
+-	if (g_supplicant_interface_get_wps_state(interface) ==
+-		G_SUPPLICANT_WPS_STATE_FAIL)
+-		return false;
+-
+-	/* Unlike normal connection, being associated while processing wps
+-	 * actually means that we are idling. */
+-	switch (wifi->state) {
+-	case G_SUPPLICANT_STATE_UNKNOWN:
+-	case G_SUPPLICANT_STATE_DISABLED:
+-	case G_SUPPLICANT_STATE_DISCONNECTED:
+-	case G_SUPPLICANT_STATE_INACTIVE:
+-	case G_SUPPLICANT_STATE_SCANNING:
+-	case G_SUPPLICANT_STATE_ASSOCIATED:
+-		return true;
+-	case G_SUPPLICANT_STATE_AUTHENTICATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATING:
+-	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_COMPLETED:
+-		return false;
+-	}
++	int stacount = 0;
++	connman_technology_tethering_add_station(CONNMAN_SERVICE_TYPE_WIFI, mac);
+ 
+-	return false;
++	stacount = __connman_tethering_sta_count();
++	__connman_technology_sta_count_changed(CONNMAN_SERVICE_TYPE_WIFI, stacount);
+ }
+ 
+-static bool handle_wps_completion(GSupplicantInterface *interface,
+-					struct connman_network *network,
+-					struct connman_device *device,
+-					struct wifi_data *wifi)
++static void station_removed(const char *mac)
+ {
+-	bool wps;
++	int stacount = 0;
+ 
+-	wps = connman_network_get_bool(network, "WiFi.UseWPS");
+-	if (wps) {
+-		const unsigned char *ssid, *wps_ssid;
+-		unsigned int ssid_len, wps_ssid_len;
+-		struct disconnect_data *dd;
+-		const char *wps_key;
++	connman_technology_tethering_remove_station(mac);
+ 
+-		/* Checking if we got associated with requested
+-		 * network */
+-		ssid = connman_network_get_blob(network, "WiFi.SSID",
+-						&ssid_len);
++	stacount = __connman_tethering_sta_count();
++	__connman_technology_sta_count_changed(CONNMAN_SERVICE_TYPE_WIFI, stacount);
++}
+ 
+-		wps_ssid = g_supplicant_interface_get_wps_ssid(
+-			interface, &wps_ssid_len);
++static void p2p_sd_asp_response(GSupplicantInterface *interface, GSupplicantPeer *peer,
++								unsigned char transaction_id,
++								unsigned int advertisement_id,
++								unsigned char service_status,
++								dbus_uint16_t config_method,
++								const char* service_name,
++								const char* service_info)
++{
++	/*
++	wfds_on_service_discovery_response(peer,
++										transaction_id,
++										advertisement_id,
++										service_status,
++										config_method,
++										service_name,
++										service_info);
++	*/
++}
+ 
+-		if (!wps_ssid || wps_ssid_len != ssid_len ||
+-				memcmp(ssid, wps_ssid, ssid_len) != 0) {
+-			dd = g_malloc0(sizeof(*dd));
+-			dd->wifi = wifi;
+-			dd->network = network;
++static void p2p_sd_response(GSupplicantInterface *interface, GSupplicantPeer *peer,
++				int indicator, unsigned char *tlv, int tlv_len)
++{
++	struct wifi_data *wifi;
++	const char *identifier;
+ 
+-			connman_network_set_associating(network, false);
+-			g_supplicant_interface_disconnect(wifi->interface,
+-						disconnect_callback, dd);
+-			return false;
+-		}
++	if (p2p_technology == NULL)
++		return;
+ 
+-		wps_key = g_supplicant_interface_get_wps_key(interface);
+-		connman_network_set_string(network, "WiFi.Passphrase",
+-					wps_key);
++	wifi = g_supplicant_interface_get_data(interface);
+ 
+-		connman_network_set_string(network, "WiFi.PinWPS", NULL);
+-	}
++	identifier =  strrchr(g_supplicant_peer_get_path(peer), '/') + 1;
+ 
+-	return true;
++	__connman_sd_response_from_p2p_peer(identifier, indicator, tlv, tlv_len);
+ }
+ 
+-static bool handle_assoc_status_code(GSupplicantInterface *interface,
+-                                     struct wifi_data *wifi)
++static void apply_peer_services(GSupplicantPeer *peer,
++				struct connman_peer *connman_peer)
+ {
+-	if (wifi->state == G_SUPPLICANT_STATE_ASSOCIATING &&
+-			wifi->assoc_code == ASSOC_STATUS_NO_CLIENT &&
+-			wifi->load_shaping_retries < LOAD_SHAPING_MAX_RETRIES) {
+-		wifi->load_shaping_retries ++;
+-		return TRUE;
++	const unsigned char *data;
++	int length;
++
++	DBG("");
++
++	connman_peer_reset_services(connman_peer);
++
++	data = g_supplicant_peer_get_widi_ies(peer, &length);
++	if (data) {
++		connman_peer_add_service(connman_peer,
++			CONNMAN_PEER_SERVICE_WIFI_DISPLAY, data, length);
+ 	}
+-	wifi->load_shaping_retries = 0;
+-	return FALSE;
+ }
+ 
+-static bool handle_4way_handshake_failure(GSupplicantInterface *interface,
+-					struct connman_network *network,
+-					struct wifi_data *wifi)
++static void peer_found(GSupplicantPeer *peer)
+ {
+-	struct connman_service *service;
++	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	struct connman_peer *connman_peer;
+ 
+-	if ((wifi->state != G_SUPPLICANT_STATE_4WAY_HANDSHAKE) &&
+-			!((wifi->state == G_SUPPLICANT_STATE_ASSOCIATING) &&
+-				(wifi->assoc_code == ASSOC_STATUS_AUTH_TIMEOUT)))
+-		return false;
++	struct connman_network *connman_network;
+ 
+-	if (wifi->connected)
+-		return false;
++	const char *identifier, *name, *path, *pri_dev_type;;
++	dbus_uint16_t config_methods;
++	int ret;
+ 
+-	service = connman_service_lookup_from_network(network);
+-	if (!service)
+-		return false;
++	identifier = g_supplicant_peer_get_identifier(peer);
++	name = g_supplicant_peer_get_name(peer);
+ 
+-	wifi->retries++;
++	path = g_supplicant_peer_get_path(peer);
++	config_methods = g_supplicant_peer_get_config_methods(peer);
++	pri_dev_type = g_supplicant_peer_get_pri_dev_type(peer);
+ 
+-	if (connman_service_get_favorite(service)) {
+-		if (wifi->retries < FAVORITE_MAXIMUM_RETRIES)
+-			return true;
++	DBG("ident: %s", identifier);
++
++	connman_network = connman_device_get_network(wifi->device, identifier);
++
++	if (connman_network == NULL) {
++		DBG("creating new network");
++		connman_network = connman_network_create(identifier, CONNMAN_NETWORK_TYPE_WIFI);
++		if (connman_network == NULL)
++			return;
++
++		connman_network_set_index(connman_network, wifi->index);
++
++		connman_network_set_name(connman_network, name);
++		connman_network_set_string(connman_network, "Path", path);
++		connman_network_set_p2p_network(connman_network, TRUE);
++		if (connman_device_add_network(wifi->device, connman_network) < 0) {
++			connman_network_unref(connman_network);
++			return;
++		}
++
++		wifi->networks = g_slist_prepend(wifi->networks, connman_network);
++	} else {
++		DBG("network already exists, just update it");
++
++		connman_network_set_name(connman_network, name);
++		__connman_service_update_from_network(connman_network);
+ 	}
+ 
+-	wifi->retries = 0;
+-	connman_network_set_error(network, CONNMAN_NETWORK_ERROR_INVALID_KEY);
++	connman_peer = connman_peer_get(wifi->device, identifier);
++	if (connman_peer)
++		return;
+ 
+-	return false;
+-}
++	connman_peer = connman_peer_create(identifier);
++	connman_peer_set_name(connman_peer, name);
++	connman_peer_set_device(connman_peer, wifi->device);
++	connman_peer_set_strength(connman_peer, calculate_peer_strength(peer));
++	connman_peer_set_config_methods(connman_peer, config_methods);
++	connman_peer_set_pri_dev_type(connman_peer, pri_dev_type);
+ 
+-static void interface_state(GSupplicantInterface *interface)
+-{
+-	struct connman_network *network;
+-	struct connman_device *device;
+-	struct wifi_data *wifi;
+-	GSupplicantState state = g_supplicant_interface_get_state(interface);
+-	bool wps;
+-	bool old_connected;
++	apply_peer_services(peer, connman_peer);
+ 
+-	wifi = g_supplicant_interface_get_data(interface);
++	ret = connman_peer_register(connman_peer);
++	if (ret < 0 && ret != -EALREADY)
++		connman_peer_unref(connman_peer);
++	else
++		wifi->peers = g_slist_prepend(wifi->peers, connman_peer);
++}
+ 
+-	DBG("wifi %p interface state %d", wifi, state);
++static void peer_lost(GSupplicantPeer *peer)
++{
++	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	struct connman_peer *connman_peer;
++	const char *identifier;
++	struct connman_network *connman_network;
+ 
+ 	if (!wifi)
+ 		return;
+ 
+-	device = wifi->device;
+-	if (!device)
++	identifier = g_supplicant_peer_get_identifier(peer);
++
++	if (!identifier)
+ 		return;
+ 
+-	if (state == G_SUPPLICANT_STATE_COMPLETED) {
+-		if (wifi->tethering_param) {
+-			g_free(wifi->tethering_param->ssid);
+-			g_free(wifi->tethering_param);
+-			wifi->tethering_param = NULL;
+-		}
++	DBG("ident: %s", identifier);
+ 
+-		if (wifi->tethering)
+-			stop_autoscan(device);
++	connman_peer = connman_peer_get(wifi->device, identifier);
++	connman_network = connman_device_get_network(wifi->device, identifier);
++
++	if (connman_peer) {
++		if (wifi->p2p_connecting &&
++				wifi->pending_peer == connman_peer) {
++			peer_connect_timeout(wifi);
++		}
++		connman_peer_unregister(connman_peer);
++		connman_peer_unref(connman_peer);
+ 	}
+ 
+-	if (g_supplicant_interface_get_ready(interface) &&
+-					!wifi->interface_ready) {
+-		wifi->interface_ready = true;
+-		finalize_interface_creation(wifi);
++	if (connman_network) {
++		wifi->networks = g_slist_remove(wifi->networks, connman_network);
++
++		connman_device_remove_network(wifi->device, connman_network);
++		connman_network_unref(connman_network);
+ 	}
+ 
+-	network = wifi->network;
+-	if (!network)
+-		return;
++	wifi->peers = g_slist_remove(wifi->peers, connman_peer);
++}
+ 
+-	switch (state) {
+-	case G_SUPPLICANT_STATE_SCANNING:
+-		if (wifi->connected)
+-			connman_network_set_connected(network, false);
++GSList * __connman_service_connected_peer_list(struct wifi_data *wifi)
++{
++	GSList *list;
++	GSList *connected_peers = NULL;
++	int cnt = 0;
+ 
+-		break;
++	for (list = wifi->peers; list; list = list->next)
++	{
++		struct connman_peer *peer = list->data;
++		if (peer == NULL)
++			continue;
+ 
+-	case G_SUPPLICANT_STATE_AUTHENTICATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATING:
+-		stop_autoscan(device);
++		if (connman_peer_get_state(peer) == CONNMAN_PEER_STATE_READY)
++			connected_peers = g_slist_prepend(connected_peers, peer);
++	}
++	return connected_peers;
++}
+ 
+-		if (!wifi->connected)
+-			connman_network_set_associating(network, true);
++static char * p2p_persistent_info_find_oldest(const char *identifier, GList * connected_p2pList, struct wifi_data *wifi)
++{
++	gchar **persistents = NULL;
++	int i = 0;
++	char *peer_ident = NULL;
++	char *oldest_identifier = NULL;
++	guint64 oldest_time = 0;
++	GList *list;
++	char *connected_identifier = NULL;
++	connman_bool_t same = 0;
+ 
+-		break;
++	persistents = __connman_storage_get_p2p_persistents();
++	for (i = 0; persistents && persistents[i]; i++)
++	{
++		if (strncmp(persistents[i], "p2p_persistent_", 15) != 0)
++			continue;
+ 
+-	case G_SUPPLICANT_STATE_COMPLETED:
+-		/* though it should be already stopped: */
+-		stop_autoscan(device);
++		peer_ident = strrchr(persistents[i], '_') + 1;
+ 
+-		if (!handle_wps_completion(interface, network, device, wifi))
+-			break;
++		if (!strcmp(peer_ident, identifier))
++			continue;
+ 
+-		connman_network_set_connected(network, true);
++		for (list = connected_p2pList; list != NULL; list = list->next)
++		{
++			struct connman_peer *peer = list->data;
++			if (peer == NULL)
++				continue;
+ 
+-		wifi->disconnect_code = 0;
+-		wifi->assoc_code = 0;
+-		wifi->load_shaping_retries = 0;
+-		break;
++			if (connman_peer_get_state(peer) == CONNMAN_PEER_STATE_READY)
++				connected_identifier = connman_peer_get_identifier(peer);
+ 
+-	case G_SUPPLICANT_STATE_DISCONNECTED:
+-		/*
+-		 * If we're in one of the idle modes, we have
+-		 * not started association yet and thus setting
+-		 * those ones to FALSE could cancel an association
+-		 * in progress.
+-		 */
+-		wps = connman_network_get_bool(network, "WiFi.UseWPS");
+-		if (wps)
+-			if (is_idle_wps(interface, wifi))
++			if (connected_identifier && !strcmp(peer_ident, connected_identifier))
++			{
++				same = 1;
+ 				break;
++			}
++		}
++
++		if (same)
++		{
++			same = 0;
++			continue;
++		}
++
++		GKeyFile *keyfile = NULL;
++		keyfile =  __connman_storage_open_service(persistents[i]);
++		guint64 last_connected = 0;
++		last_connected = g_key_file_get_uint64(keyfile, P2P_PERSISTENT_INFO, "ConnectedTime", NULL);
++
++		if (last_connected == 0){
++			struct timeval now;
++			unsigned long current_time = 0;
++			if (!gettimeofday(&now, NULL))
++				current_time = now.tv_sec;
++
++			g_key_file_set_uint64(keyfile, P2P_PERSISTENT_INFO, "ConnectedTime", current_time);
++
++			g_key_file_free(keyfile);
++			continue;
++		}
++
++		if (oldest_time == 0 || oldest_time > last_connected)
++		{
++			oldest_time = last_connected;
++			if (oldest_identifier != NULL)
++			{
++				g_free(oldest_identifier);
++				oldest_identifier = NULL;
++			}
++			oldest_identifier = g_strdup(peer_ident);
++		}
++
++		g_key_file_free(keyfile);
++	}
++
++	if (persistents != NULL)
++		g_strfreev(persistents);
++
++	return oldest_identifier;
++}
++static void p2p_persistent_info_remove_oldest(const char *identifier, struct wifi_data *wifi)
++{
++	char *oldest_identifier = NULL;
++	GList *connected_p2p_list = NULL;
++	char persistent_info_name[28] = "p2p_persistent_";
++
++	connected_p2p_list = __connman_service_connected_peer_list(wifi);
++
++	oldest_identifier = p2p_persistent_info_find_oldest(identifier, connected_p2p_list, wifi);
+ 
+-		if (is_idle(wifi))
+-			break;
++	if (oldest_identifier == NULL)
++		return;
+ 
+-		if (handle_assoc_status_code(interface, wifi))
+-			break;
++	strncat(persistent_info_name, oldest_identifier, strlen(oldest_identifier));
+ 
+-		/* If previous state was 4way-handshake, then
+-		 * it's either: psk was incorrect and thus we retry
+-		 * or if we reach the maximum retries we declare the
+-		 * psk as wrong */
+-		if (handle_4way_handshake_failure(interface,
+-						network, wifi))
+-			break;
++	g_hash_table_remove(wifi->persistent_peer_ssid, oldest_identifier);
++	__connman_storage_remove_service(persistent_info_name);
+ 
+-		/* See table 8-36 Reason codes in IEEE Std 802.11 */
+-		switch (wifi->disconnect_code) {
+-		case 6: /* Class 2 frame received from nonauthenticated STA */
+-			connman_network_set_error(network,
+-						CONNMAN_NETWORK_ERROR_BLOCKED);
+-			break;
++	g_free(oldest_identifier);
++	g_slist_free(connected_p2p_list);
++}
++static void p2p_persistent_info_save(const char *identifier, GSupplicantP2PPersistentGroup *persistent_group)
++{
++	char persistent_info_name[28] = "p2p_persistent_";
++	strncat(persistent_info_name, identifier, strlen(identifier));
++	int count = 0;
+ 
+-		default:
+-			break;
+-		}
++	if(persistent_group == NULL) {
++		return;
++	} else {
++		GKeyFile *keyfile;
++		char * mac_address=NULL;
+ 
+-		if (network != wifi->pending_network) {
+-			connman_network_set_connected(network, false);
+-			connman_network_set_associating(network, false);
+-		}
+-		wifi->disconnecting = false;
++		if(persistent_group->psk == NULL)
++			return;
+ 
+-		start_autoscan(device);
++		keyfile = __connman_storage_open_service(persistent_info_name);
++		if (keyfile == NULL)
++			return;
+ 
+-		break;
++		g_key_file_set_string(keyfile, P2P_PERSISTENT_INFO, "SSID", persistent_group->ssid);
++		g_key_file_set_string(keyfile, P2P_PERSISTENT_INFO, "BSSID", persistent_group->bssid);
++		g_key_file_set_string(keyfile, P2P_PERSISTENT_INFO, "PSK", persistent_group->psk);
+ 
+-	case G_SUPPLICANT_STATE_INACTIVE:
+-		connman_network_set_associating(network, false);
+-		start_autoscan(device);
++		struct wifi_data *wifi = g_supplicant_interface_get_data(persistent_group->interface);
++		if (wifi) {
++			mac_address = __connman_util_insert_colon_to_mac_addr(connman_device_get_ident(wifi->device));
++			if (mac_address)
++				g_key_file_set_string(keyfile, P2P_PERSISTENT_INFO, "MAC", mac_address);
++		}
+ 
+-		break;
++		if(persistent_group->go == TRUE)
++			g_key_file_set_string(keyfile, P2P_PERSISTENT_INFO, "Role", "GO");
++		else
++			g_key_file_set_string(keyfile, P2P_PERSISTENT_INFO, "Role", "Client");
+ 
+-	case G_SUPPLICANT_STATE_UNKNOWN:
+-	case G_SUPPLICANT_STATE_DISABLED:
+-	case G_SUPPLICANT_STATE_ASSOCIATED:
+-	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
+-		break;
+-	}
++		struct timeval now;
++		unsigned long connected_time = 0;
++		if (!gettimeofday(&now, NULL))
++			connected_time = now.tv_sec;
+ 
+-	old_connected = wifi->connected;
+-	wifi->state = state;
++		persistent_group->connected_time = connected_time;
++		g_key_file_set_uint64(keyfile, P2P_PERSISTENT_INFO, "ConnectedTime", persistent_group->connected_time);
+ 
+-	/* Saving wpa_s state policy:
+-	 * If connected and if the state changes are roaming related:
+-	 * --> We stay connected
+-	 * If completed
+-	 * --> We are connected
+-	 * All other case:
+-	 * --> We are not connected
+-	 * */
+-	switch (state) {
+-	case G_SUPPLICANT_STATE_AUTHENTICATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATING:
+-	case G_SUPPLICANT_STATE_ASSOCIATED:
+-	case G_SUPPLICANT_STATE_4WAY_HANDSHAKE:
+-	case G_SUPPLICANT_STATE_GROUP_HANDSHAKE:
+-		if (wifi->connected)
+-			connman_warn("Probably roaming right now!"
+-						" Staying connected...");
+-		break;
+-	case G_SUPPLICANT_STATE_SCANNING:
+-		wifi->connected = false;
++		__connman_storage_save_service(keyfile, persistent_info_name);
+ 
+-		if (old_connected)
+-			start_autoscan(device);
+-		break;
+-	case G_SUPPLICANT_STATE_COMPLETED:
+-		wifi->connected = true;
+-		break;
+-	default:
+-		wifi->connected = false;
+-		break;
+-	}
++		g_free(mac_address);
++		count = __connman_storage_get_p2p_persistents_count();
++		if (wifi && count > P2P_PERSISTENT_MAX_COUNT)
++			p2p_persistent_info_remove_oldest(identifier, wifi);
+ 
+-	DBG("DONE");
++		g_key_file_free(keyfile);
++	}
+ }
+-
+-static void interface_removed(GSupplicantInterface *interface)
++static void p2p_go_neg_failed(GSupplicantInterface *interface, struct connman_peer *peer, int status)
+ {
+-	const char *ifname = g_supplicant_interface_get_ifname(interface);
+ 	struct wifi_data *wifi;
+-
+-	DBG("ifname %s", ifname);
++	const char *identifier, *path;
+ 
+ 	wifi = g_supplicant_interface_get_data(interface);
++	identifier = connman_peer_get_identifier(peer);
+ 
+-	if (wifi)
+-		wifi->interface = NULL;
++	DBG("identifier %s", identifier);
+ 
+-	if (wifi && wifi->tethering)
+-		return;
++	p2p_peers_refresh(wifi);
+ 
+-	if (!wifi || !wifi->device) {
+-		DBG("wifi interface already removed");
++	// TODO: will consider with other WFDS changes
++//	wfds_on_go_neg_failed(connman_network, status);
++
++	path = __connman_peer_get_path(peer);
++
++	if(!path)
+ 		return;
+-	}
+ 
+-	connman_device_set_powered(wifi->device, false);
++	connman_dbus_property_changed_basic(path, CONNMAN_PEER_INTERFACE,
++					"P2PGONegFailed", DBUS_TYPE_INT32, &status);
+ 
+-	check_p2p_technology();
+ }
+ 
+-static void set_device_type(const char *type, char dev_type[17])
++static void peer_dhcp_address_update()
+ {
+-	const char *oui = "0050F204";
+-	const char *category = "0001";
+-	const char *sub_category = "0000";
++	struct connman_group *group;
+ 
+-	if (!g_strcmp0(type, "handset")) {
+-		category = "000A";
+-		sub_category = "0005";
+-	} else if (!g_strcmp0(type, "vm") || !g_strcmp0(type, "container"))
+-		sub_category = "0001";
+-	else if (!g_strcmp0(type, "server"))
+-		sub_category = "0002";
+-	else if (!g_strcmp0(type, "laptop"))
+-		sub_category = "0005";
+-	else if (!g_strcmp0(type, "desktop"))
+-		sub_category = "0006";
+-	else if (!g_strcmp0(type, "tablet"))
+-		sub_category = "0009";
+-	else if (!g_strcmp0(type, "watch"))
+-		category = "00FF";
++	group = __connman_group_lookup_from_ident(p2p_go_identifier);
++	if (group == NULL)
++		return;
+ 
+-	snprintf(dev_type, 17, "%s%s%s", category, oui, sub_category);
++	__connman_group_client_dhcp_ip_assigned(group);
+ }
+-
+-static void p2p_support(GSupplicantInterface *interface)
++static void peer_changed(GSupplicantPeer *peer, GSupplicantPeerState state)
+ {
+-	char dev_type[17] = {};
+-	const char *hostname;
++	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	enum connman_peer_state p_state = CONNMAN_PEER_STATE_UNKNOWN;
++	struct connman_peer *connman_peer;
++	struct connman_group *connman_group;
++	const char *identifier;
+ 
+-	DBG("");
++	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+-	if (!interface)
++	DBG("ident: %s", identifier);
++
++	if (!wifi)
+ 		return;
+ 
+-	if (!g_supplicant_interface_has_p2p(interface))
++	connman_peer = connman_peer_get(wifi->device, identifier);
++	if (!connman_peer)
+ 		return;
+ 
+-	if (connman_technology_driver_register(&p2p_tech_driver) < 0) {
+-		DBG("Could not register P2P technology driver");
++	switch (state) {
++	case G_SUPPLICANT_PEER_SERVICES_CHANGED:
++		apply_peer_services(peer, connman_peer);
++		connman_peer_services_changed(connman_peer);
+ 		return;
+-	}
++	case G_SUPPLICANT_PEER_GROUP_CHANGED:
++		if (!g_supplicant_peer_is_in_a_group(peer))
++			p_state = CONNMAN_PEER_STATE_IDLE;
++		else
++			p_state = CONNMAN_PEER_STATE_CONFIGURATION;
++		break;
++	case G_SUPPLICANT_PEER_GROUP_STARTED:
++		break;
++	case G_SUPPLICANT_PEER_GROUP_FINISHED:
++		p_state = CONNMAN_PEER_STATE_IDLE;
++		break;
++	case G_SUPPLICANT_PEER_GROUP_JOINED:
++		connman_peer_set_iface_address(connman_peer,
++				g_supplicant_peer_get_iface_address(peer));
+ 
+-	hostname = connman_utsname_get_hostname();
+-	if (!hostname)
+-		hostname = "ConnMan";
++		if (p2p_go_identifier) {
++			GSupplicantP2PPersistentGroup *persistent_group;
++			GSupplicantGroup *group;
++			struct connman_network *network;
++			char *ipaddress = g_supplicant_peer_get_ip_address(peer);
+ 
+-	set_device_type(connman_machine_get_type(), dev_type);
+-	g_supplicant_interface_set_p2p_device_config(interface,
+-							hostname, dev_type);
+-	connman_peer_driver_register(&peer_driver);
+-}
++			const char *identifier = connman_peer_get_identifier(connman_peer);
+ 
+-static void scan_started(GSupplicantInterface *interface)
+-{
+-	DBG("");
+-}
++			network = connman_device_get_network(wifi->device, identifier);
+ 
+-static void scan_finished(GSupplicantInterface *interface)
+-{
+-	DBG("");
+-}
++			connman_peer_set_state(connman_peer, CONNMAN_PEER_STATE_ASSOCIATION);
++			connman_peer_set_as_go(connman_peer, false);
++			connman_group = __connman_group_lookup_from_ident(p2p_go_identifier);
++			group = g_supplicant_get_group(__connman_group_get_group_owner(connman_group));
+ 
+-static void ap_create_fail(GSupplicantInterface *interface)
+-{
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+-	int ret;
++			if (connman_group->autonomous)
++				__connman_peer_set_autonomous_group(connman_peer, true);
+ 
+-	if ((wifi->tethering) && (wifi->tethering_param)) {
+-		DBG("%s create AP fail \n",
+-				g_supplicant_interface_get_ifname(wifi->interface));
++			if (group) {
++				persistent_group = g_supplicant_interface_get_p2p_persistent_group(iface, group);
++				if(persistent_group != NULL) {
++					persistent_group->go = TRUE;
++					p2p_persistent_info_save(identifier, persistent_group);
++				}
++			}
+ 
+-		connman_inet_remove_from_bridge(wifi->index, wifi->bridge);
+-		wifi->ap_supported = WIFI_AP_NOT_SUPPORTED;
+-		wifi->tethering = false;
++			if (ipaddress != NULL){
++				connman_group->is_static_ip = true;
++				connman_group->peer_ip = g_strdup(ipaddress);
++				//p_state = CONNMAN_PEER_STATE_CONFIGURATION;
+ 
+-		ret = tech_set_tethering(wifi->tethering_param->technology,
+-				wifi->bridge, true);
++				__connman_peer_set_static_ip(connman_peer, ipaddress);
++			}
++			p_state = CONNMAN_PEER_STATE_CONFIGURATION;
++//			if (network)
++//				wfds_on_p2p_peer_joined(network, group);
+ 
+-		if ((ret == -EOPNOTSUPP) && (wifi_technology)) {
+-			connman_technology_tethering_notify(wifi_technology,false);
++//			if (network && connman_group->is_static_ip)
++//				wfds_on_p2p_group_peer_static_ip_added(network, connman_group->peer_ip);
++
++			__connman_group_peer_joined(connman_group, identifier,
++					g_supplicant_peer_get_iface_address(peer), __connman_peer_get_path(connman_peer));
++		} else {
++			connman_peer_set_state(connman_peer, CONNMAN_PEER_STATE_ASSOCIATION);
++			connman_peer_set_as_go(connman_peer, true);
++
++			p_state = CONNMAN_PEER_STATE_CONFIGURATION;
++		}
++		break;
++	case G_SUPPLICANT_PEER_GROUP_DISCONNECTED:
++		if (p2p_go_identifier) {
++			connman_group = __connman_group_lookup_from_ident(p2p_go_identifier);
++			if (__connman_group_peer_disconnected(connman_group, identifier)) {
++				peer_cancel_timeout(wifi);
++				wifi->p2p_device = false;
++				__connman_peer_set_static_ip(connman_peer, NULL);
++			}
+ 		}
++		p_state = CONNMAN_PEER_STATE_IDLE;
++		break;
++	case G_SUPPLICANT_PEER_GROUP_FAILED:
++		if (g_supplicant_peer_has_requested_connection(peer))
++			p_state = CONNMAN_PEER_STATE_IDLE;
++		else
++			p_state = CONNMAN_PEER_STATE_FAILURE;
+ 
+-		g_free(wifi->tethering_param->ssid);
+-		g_free(wifi->tethering_param);
+-		wifi->tethering_param = NULL;
++		p2p_go_neg_failed(iface, connman_peer,  g_supplicant_peer_get_failure_status(peer));
++		break;
+ 	}
+-}
+ 
+-static unsigned char calculate_strength(GSupplicantNetwork *supplicant_network)
+-{
+-	unsigned char strength;
++	if (p_state == CONNMAN_PEER_STATE_CONFIGURATION ||
++					p_state == CONNMAN_PEER_STATE_FAILURE) {
++		if (wifi->p2p_connecting
++				&& connman_peer == wifi->pending_peer)
++			peer_cancel_timeout(wifi);
++		else
++			p_state = CONNMAN_PEER_STATE_UNKNOWN;
++	}
+ 
+-	strength = 120 + g_supplicant_network_get_signal(supplicant_network);
+-	if (strength > 100)
+-		strength = 100;
++	if (p_state == CONNMAN_PEER_STATE_UNKNOWN)
++		return;
+ 
+-	return strength;
++	if (p_state == CONNMAN_PEER_STATE_CONFIGURATION) {
++		GSupplicantInterface *g_iface;
++		struct wifi_data *g_wifi;
++		bool is_client = false;
++
++		g_iface = g_supplicant_peer_get_group_interface(peer);
++		if (!g_iface)
++			return;
++
++		g_wifi = g_supplicant_interface_get_data(g_iface);
++		if (!g_wifi)
++			return;
++
++		is_client = g_supplicant_peer_is_client(peer);
++		connman_peer_set_as_master(connman_peer, !is_client);
++
++		if (!is_client)
++			connman_peer_dhcpclient_cb(connman_peer, peer_dhcp_address_update);
++		else
++			connman_peer_dhcpclient_cb(connman_peer, NULL);
++
++		connman_peer_set_sub_device(connman_peer, g_wifi->device);
++
++		/*
++		 * If wpa_supplicant didn't create a dedicated p2p-group
++		 * interface then mark this interface as p2p_device to avoid
++		 * scan and auto-scan are launched on it while P2P is connected.
++		 */
++		if (!g_list_find(p2p_iface_list, g_wifi))
++			wifi->p2p_device = true;
++	}
++
++	connman_peer_set_state(connman_peer, p_state);
+ }
+ 
+-static void network_added(GSupplicantNetwork *supplicant_network)
++static void peer_request(GSupplicantPeer *peer, int dev_passwd_id)
+ {
+-	struct connman_network *network;
+-	GSupplicantInterface *interface;
+-	struct wifi_data *wifi;
+-	struct wifi_network *network_data;
+-	const char *name, *identifier, *security, *group, *mode;
+-	const unsigned char *ssid;
+-	unsigned int ssid_len;
+-	bool wps;
+-	bool wps_pbc;
+-	bool wps_ready;
+-	bool wps_advertizing;
+-
+-	mode = g_supplicant_network_get_mode(supplicant_network);
+-	identifier = g_supplicant_network_get_identifier(supplicant_network);
+-
+-	DBG("%s", identifier);
++	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	struct connman_network *connman_network;
++	struct connman_peer *connman_peer;
++	const char *identifier, *name, *path;
+ 
+-	if (!g_strcmp0(mode, "adhoc"))
+-		return;
++	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+-	interface = g_supplicant_network_get_interface(supplicant_network);
+-	wifi = g_supplicant_interface_get_data(interface);
+-	name = g_supplicant_network_get_name(supplicant_network);
+-	security = g_supplicant_network_get_security(supplicant_network);
+-	group = g_supplicant_network_get_identifier(supplicant_network);
+-	wps = g_supplicant_network_get_wps(supplicant_network);
+-	wps_pbc = g_supplicant_network_is_wps_pbc(supplicant_network);
+-	wps_ready = g_supplicant_network_is_wps_active(supplicant_network);
+-	wps_advertizing = g_supplicant_network_is_wps_advertizing(
+-							supplicant_network);
++	DBG("ident: %s", identifier);
+ 
+-	if (!wifi)
++	connman_peer = connman_peer_get(wifi->device, identifier);
++	if (!connman_peer)
+ 		return;
+ 
+-	ssid = g_supplicant_network_get_ssid(supplicant_network, &ssid_len);
+-
+-	network = connman_device_get_network(wifi->device, identifier);
++	name = g_supplicant_peer_get_name(peer);
++	path = g_supplicant_peer_get_path(peer);
++      connman_network = connman_device_get_network(wifi->device, identifier);
+ 
+-	if (!network) {
+-		network = connman_network_create(identifier,
+-						CONNMAN_NETWORK_TYPE_WIFI);
+-		if (!network)
++      if (connman_network == NULL) {
++		DBG("creating new network");
++		connman_network = connman_network_create(identifier, CONNMAN_NETWORK_TYPE_WIFI);
++		if (connman_network == NULL)
+ 			return;
+ 
+-		connman_network_set_index(network, wifi->index);
++		connman_network_set_index(connman_network, wifi->index);
+ 
+-		if (connman_device_add_network(wifi->device, network) < 0) {
+-			connman_network_unref(network);
++             connman_network_set_name(connman_network, name);
++		connman_network_set_string(connman_network, "Path", path);
++
++	      if (connman_device_add_network(wifi->device, connman_network) < 0) {
++			connman_network_unref(connman_network);
+ 			return;
+ 		}
+ 
+-		wifi->networks = g_slist_prepend(wifi->networks, network);
++		wifi->networks = g_slist_prepend(wifi->networks, connman_network);
++	}  else	{
++		DBG("network already exists, just update it");
+ 
+-		network_data = g_new0(struct wifi_network, 1);
+-		connman_network_set_data(network, network_data);
+-	}
++	      connman_network_set_name(connman_network, name);
+ 
+-	network_data = connman_network_get_data(network);
+-	network_data->keymgmt =
+-		g_supplicant_network_get_keymgmt(supplicant_network);
++		__connman_service_update_from_network(connman_network);
++	}
+ 
+-	if (name && name[0] != '\0')
+-		connman_network_set_name(network, name);
++//	wfds_on_go_neg_requested(connman_network, dev_passwd_id);
+ 
+-	connman_network_set_blob(network, "WiFi.SSID",
+-						ssid, ssid_len);
+-	connman_network_set_string(network, "WiFi.Security", security);
+-	connman_network_set_strength(network,
+-				calculate_strength(supplicant_network));
+-	connman_network_set_bool(network, "WiFi.WPS", wps);
+-	connman_network_set_bool(network, "WiFi.WPSAdvertising",
+-				wps_advertizing);
++	connman_peer_request_connection(connman_peer, dev_passwd_id);
++}
+ 
+-	if (wps) {
+-		/* Is AP advertizing for WPS association?
+-		 * If so, we decide to use WPS by default */
+-		if (wps_ready && wps_pbc &&
+-						wps_advertizing)
+-			connman_network_set_bool(network, "WiFi.UseWPS", true);
+-	}
++static void debug(const char *str)
++{
++	if (getenv("CONNMAN_SUPPLICANT_DEBUG"))
++		connman_debug("%s", str);
++}
+ 
+-	connman_network_set_frequency(network,
+-			g_supplicant_network_get_frequency(supplicant_network));
++static void disconnect_reasoncode(GSupplicantInterface *interface,
++				int reasoncode)
++{
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 
+-	connman_network_set_available(network, true);
+-	connman_network_set_string(network, "WiFi.Mode", mode);
++	if (wifi != NULL) {
++		wifi->disconnect_code = reasoncode;
++	}
++}
+ 
+-	if (ssid)
+-		connman_network_set_group(network, group);
++static void assoc_status_code(GSupplicantInterface *interface, int status_code)
++{
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 
+-	if (wifi->hidden && ssid) {
+-		if (!g_strcmp0(wifi->hidden->security, security) &&
+-				wifi->hidden->ssid_len == ssid_len &&
+-				!memcmp(wifi->hidden->ssid, ssid, ssid_len)) {
+-			connman_network_connect_hidden(network,
+-					wifi->hidden->identity,
+-					wifi->hidden->passphrase,
+-					wifi->hidden->user_data);
+-			wifi->hidden->user_data = NULL;
+-			hidden_free(wifi->hidden);
+-			wifi->hidden = NULL;
+-		}
++	if (wifi != NULL) {
++		wifi->assoc_code = status_code;
+ 	}
+ }
+ 
+-static void network_removed(GSupplicantNetwork *network)
++static void p2p_group_started(GSupplicantGroup *group)
+ {
+-	GSupplicantInterface *interface;
+ 	struct wifi_data *wifi;
+-	const char *name, *identifier;
+-	struct connman_network *connman_network;
++	GSList *item;
++	GSupplicantP2PPersistentGroup *persistent_group;
++	struct connman_group *connman_group = NULL;
++	struct connman_peer *connman_peer_go = NULL;
++	const char* go_path = NULL;
+ 
+-	interface = g_supplicant_network_get_interface(network);
+-	wifi = g_supplicant_interface_get_data(interface);
+-	identifier = g_supplicant_network_get_identifier(network);
+-	name = g_supplicant_network_get_name(network);
++	GSupplicantInterface *iface = g_supplicant_group_get_orig_interface(group);
+ 
+-	DBG("name %s", name);
++	wifi = g_supplicant_interface_get_data(iface);
+ 
+ 	if (!wifi)
+ 		return;
+ 
+-	connman_network = connman_device_get_network(wifi->device, identifier);
+-	if (!connman_network)
+-		return;
++	const char* bssid_no_colon = g_supplicant_group_get_bssid_no_colon(group);
++	const char *ssid = g_supplicant_group_get_ssid(group);
++	const char *passphrase = g_supplicant_group_get_passphrase(group);
+ 
+-	wifi->networks = g_slist_remove(wifi->networks, connman_network);
++	struct connman_peer *peer = connman_peer_get(wifi->device, bssid_no_colon);
++	if (peer)
++		go_path = __connman_peer_get_path(peer);
++	else
++		go_path = g_supplicant_group_get_object_path(group);
+ 
+-	g_free(connman_network_get_data(connman_network));
+-	connman_device_remove_network(wifi->device, connman_network);
+-	connman_network_unref(connman_network);
+-}
++	/* persistent check */
++	item = wifi->persistent_groups;
++	while(item != NULL) {
++		persistent_group = item->data;
+ 
+-static void network_changed(GSupplicantNetwork *network, const char *property)
+-{
+-	GSupplicantInterface *interface;
+-	struct wifi_data *wifi;
+-	const char *name, *identifier;
+-	struct connman_network *connman_network;
+-	bool update_needed;
++		if (persistent_group->ssid == NULL || persistent_group->bssid_no_colon == NULL ||  bssid_no_colon == NULL) {
++			item = g_slist_next(item);
++			continue;
++		}
+ 
+-	interface = g_supplicant_network_get_interface(network);
+-	wifi = g_supplicant_interface_get_data(interface);
+-	identifier = g_supplicant_network_get_identifier(network);
+-	name = g_supplicant_network_get_name(network);
++		if(g_str_equal(persistent_group->bssid_no_colon, bssid_no_colon)){
++			if (!g_str_equal(persistent_group->ssid, ssid) || !g_str_equal(persistent_group->psk, passphrase)){
++				if (persistent_group->ssid)
++					g_free(persistent_group->ssid);
++				persistent_group->ssid = g_strdup(ssid);
+ 
+-	DBG("name %s", name);
++				if (passphrase && strcmp(passphrase, "") && persistent_group->psk) {
++					g_free(persistent_group->psk);
++					persistent_group->psk = g_strdup(passphrase);
++				}
++			}
++			g_supplicant_interface_set_p2p_persistent_group(iface, group, persistent_group);
++			break;
++		}
+ 
+-	if (!wifi)
+-		return;
++		item = g_slist_next(item);
++	}
++	bool is_group_owner = false;
++	if (g_supplicant_group_get_role(group) == G_SUPPLICANT_GROUP_ROLE_GO) {
++		is_group_owner = true;
+ 
+-	connman_network = connman_device_get_network(wifi->device, identifier);
+-	if (!connman_network)
+-		return;
++		__connman_p2p_go_set_bridge(p2p_group_ifname);
+ 
+-	if (g_str_equal(property, "WPSCapabilities")) {
+-		bool wps;
+-		bool wps_pbc;
+-		bool wps_ready;
+-		bool wps_advertizing;
++		//If autonomous group then only start the DHCP server
++		if (create_group_flag)
++			__connman_p2p_go_set_enabled();
++	}
+ 
+-		wps = g_supplicant_network_get_wps(network);
+-		wps_pbc = g_supplicant_network_is_wps_pbc(network);
+-		wps_ready = g_supplicant_network_is_wps_active(network);
+-		wps_advertizing =
+-			g_supplicant_network_is_wps_advertizing(network);
++	int freq = g_supplicant_group_get_frequency(group);
++	bool persistent = g_supplicant_group_get_persistent(group);
+ 
+-		connman_network_set_bool(connman_network, "WiFi.WPS", wps);
+-		connman_network_set_bool(connman_network,
+-				"WiFi.WPSAdvertising", wps_advertizing);
++	connman_group = __connman_group_create(iface, p2p_group_ifname, ssid, passphrase,
++					is_group_owner, persistent, go_path, create_group_flag, freq);
+ 
+-		if (wps) {
+-			/*
+-			 * Is AP advertizing for WPS association?
+-			 * If so, we decide to use WPS by default
+-			 */
+-			if (wps_ready && wps_pbc && wps_advertizing)
+-				connman_network_set_bool(connman_network,
+-							"WiFi.UseWPS", true);
++	const char *connman_group_path = __connman_group_get_path(connman_group);
++
++	if (is_group_owner) {
++		p2p_go_identifier = g_strdup(__connman_group_get_identifier(connman_group));
++	} else {
++		persistent_group = g_supplicant_interface_get_p2p_persistent_group(iface, group);
++		if(persistent_group != NULL) {
++			persistent_group->go = FALSE;
++			p2p_persistent_info_save(persistent_group->bssid_no_colon, persistent_group);
++		}
++		char *ip_addr = g_supplicant_group_get_ip_addr(group);
++		char *ip_mask = g_supplicant_group_get_ip_mask(group);
++		char *go_ip_addr = g_supplicant_group_get_go_ip_addr(group);
++
++		if (ip_addr) {
++			__connman_peer_set_static_ip(peer, go_ip_addr);
++			if (connman_peer_set_ipaddress(peer, ip_addr, ip_mask, go_ip_addr) < 0)
++				connman_warn("Setting static IP for Peer failed");
+ 		}
+ 
+-		update_needed = true;
+-	} else if (g_str_equal(property, "Signal")) {
+-		connman_network_set_strength(connman_network,
+-					calculate_strength(network));
+-		update_needed = true;
+-	} else
+-		update_needed = false;
++		GSupplicantPeer *supplicant_peer = g_supplicant_interface_peer_lookup(iface, bssid_no_colon);
++		if (supplicant_peer) {
++			peer_changed(supplicant_peer, G_SUPPLICANT_PEER_GROUP_JOINED);
++		}
++	}
+ 
+-	if (update_needed)
+-		connman_network_update(connman_network);
++	if (is_group_owner && create_group_flag) {
++		g_dbus_send_reply(connection, group_msg,
++						DBUS_TYPE_OBJECT_PATH, &connman_group_path,
++						DBUS_TYPE_INVALID);
++
++		create_group_flag = FALSE;
++		dbus_message_unref(group_msg);
++	}
+ }
+ 
+-static void network_associated(GSupplicantNetwork *network)
++static void p2p_find_group_stop(struct wifi_data *wifi)
+ {
+-	GSupplicantInterface *interface;
++	if (wifi) {
++		wifi->p2p_find_timeout = 0;
++		g_supplicant_interface_p2p_stop_find(wifi->interface);
++	}
++}
++
++static void p2p_group_finished(GSupplicantInterface *interface)
++{
++	GList *list;
+ 	struct wifi_data *wifi;
+-	struct connman_network *connman_network;
+-	const char *identifier;
++	GSupplicantInterface *not_group_interface;
+ 
+ 	DBG("");
+ 
+-	interface = g_supplicant_network_get_interface(network);
+-	if (!interface)
+-		return;
+-
+-	wifi = g_supplicant_interface_get_data(interface);
+-	if (!wifi)
+-		return;
+-
+-	/* P2P networks must not be treated as WiFi networks */
+-	if (wifi->p2p_connecting || wifi->p2p_device)
+-		return;
++	if (p2p_go_identifier) {
++		struct connman_group *connman_group = __connman_group_lookup_from_ident(p2p_go_identifier);
++		if (connman_group->autonomous)
++			__connman_p2p_go_set_disabled();
+ 
+-	identifier = g_supplicant_network_get_identifier(network);
++		g_free(p2p_go_identifier);
++		p2p_go_identifier = NULL;
++	}
+ 
+-	connman_network = connman_device_get_network(wifi->device, identifier);
+-	if (!connman_network)
+-		return;
++	__connman_group_remove(interface);
+ 
+-	if (wifi->network) {
+-		if (wifi->network == connman_network)
+-			return;
++	for (list = iface_list; list; list = list->next) {
++		wifi = list->data;
++		not_group_interface = wifi->interface;
+ 
+-		/*
+-		 * This should never happen, we got associated with
+-		 * a network different than the one we were expecting.
+-		 */
+-		DBG("Associated to %p while expecting %p",
+-					connman_network, wifi->network);
++		if (!not_group_interface ||
++			!g_supplicant_interface_has_p2p(wifi->interface))
++			continue;
+ 
+-		connman_network_set_associating(wifi->network, false);
++		p2p_find_group_stop(wifi);
++		if (wifi->p2p_listen_suppressed == true ||
++				connman_technology_get_p2p_listen(p2p_technology)) {
++			leave_p2p_listen_on_iface(wifi);
++			p2p_peers_refresh(wifi);
++			if (wifi->p2p_listen_suppressed == true)
++				wifi->p2p_listen_suppressed = false;
++		}
+ 	}
+ 
+-	DBG("Reconnecting to previous network %p from wpa_s", connman_network);
+-
+-	wifi->network = connman_network_ref(connman_network);
+-	wifi->retries = 0;
++	if (p2p_group_ifname) {
++		g_free(p2p_group_ifname);
++		p2p_group_ifname = NULL;
++	}
++}
++static gboolean p2p_pbc_requested(gpointer argv)
++{
++	pbc_requested_ref = -1;
+ 
+-	/*
+-	 * Interface state changes callback (interface_state) is always
+-	 * called before network_associated callback thus we need to call
+-	 * interface_state again in order to process the new state now that
+-	 * we have the network properly set.
+-	 */
+-	interface_state(interface);
++	return FALSE;
+ }
+ 
+-static void sta_authorized(GSupplicantInterface *interface,
+-					const char *addr)
++static void p2p_invitation_result(GSupplicantInterface *interface, int status)
+ {
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
++	struct wifi_data *wifi;
+ 
+-	DBG("wifi %p station %s authorized", wifi, addr);
++	wifi = g_supplicant_interface_get_data(interface);
+ 
+-	if (!wifi || !wifi->tethering)
++	if (!wifi)
+ 		return;
+ 
+-	__connman_tethering_client_register(addr);
++	DBG("status %i", status);
++
++	__connman_technology_p2p_invitation_result(p2p_technology, status);
+ }
+ 
+-static void sta_deauthorized(GSupplicantInterface *interface,
+-					const char *addr)
++static void p2p_invitation_received(GSupplicantInterface *interface,
++				GSupplicantPeer *peer, const char *go_dev_addr, bool persistent)
+ {
+ 	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
++	struct connman_peer *connman_peer;
++	const char *identifier, *path;
++	const char *go_dev_addr_colon;
+ 
+-	DBG("wifi %p station %s deauthorized", wifi, addr);
++	if (!wifi || !wifi->device)
++		return;
+ 
+-	if (!wifi || !wifi->tethering)
++	identifier = g_supplicant_peer_get_identifier(peer);
++
++	DBG("ident: %s", identifier);
++
++	connman_peer = connman_peer_get(wifi->device, identifier);
++	if (!connman_peer)
+ 		return;
+ 
+-	__connman_tethering_client_unregister(addr);
+-}
++	go_dev_addr_colon = __connman_util_insert_colon_to_mac_addr(go_dev_addr);
++	path = __connman_peer_get_path(connman_peer);
+ 
+-static void apply_peer_services(GSupplicantPeer *peer,
+-				struct connman_peer *connman_peer)
+-{
+-	const unsigned char *data;
+-	int length;
++	if (!path) {
++		g_free(go_dev_addr_colon);
++		return;
++	}
+ 
+-	DBG("");
++	if (!persistent) {
++		connman_peer_set_state(connman_peer, CONNMAN_PEER_STATE_IDLE);
++
++		/* Invitation received from GO */
++		if (g_str_equal(identifier, go_dev_addr)) {
++			wifi->invited_path = __connman_peer_get_path(connman_peer);
++		/* Sometimes there is only src address in InvitationReceived signal without GO device address */
++		} else if (g_str_equal(go_dev_addr, "000000000000")) {
++			wifi->invited_path = __connman_peer_get_path(connman_peer);
++			g_free(go_dev_addr_colon);
++			go_dev_addr_colon = __connman_util_insert_colon_to_mac_addr(identifier);
++		} else {
++			struct connman_network *network_go = connman_device_get_network(wifi->device, go_dev_addr);
+ 
+-	connman_peer_reset_services(connman_peer);
++			if (network_go) {
++				struct connman_service *service_go;
+ 
+-	data = g_supplicant_peer_get_widi_ies(peer, &length);
+-	if (data) {
+-		connman_peer_add_service(connman_peer,
+-			CONNMAN_PEER_SERVICE_WIFI_DISPLAY, data, length);
++				wifi->invited_path = connman_network_get_string(network_go, "Path");
++			}
++		}
++
++		connman_peer_invitation_request(path, "P2PInvitationReceived", go_dev_addr_colon);
++
++	} else {
++		p2p_find_stop(wifi->device);
++		if (connman_technology_get_p2p_listen(p2p_technology) == true &&
++			connman_peer_get_state(connman_peer) == CONNMAN_PEER_STATE_READY) {//already changed to listen off
++			leave_p2p_listen_on_iface(wifi);
++			connman_technology_set_p2p_listen(p2p_technology, false);
++		}
++
++		connman_peer_invitation_request(path, "P2PPersistentReceived", go_dev_addr_colon);
+ 	}
+ }
+ 
+-static void peer_found(GSupplicantPeer *peer)
++static void p2p_prov_disc_requested_pbc(GSupplicantInterface *interface,
++					GSupplicantPeer *peer)
+ {
+-	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 	struct connman_peer *connman_peer;
+-	const char *identifier, *name;
+-	int ret;
++	const char *identifier, *path;
++	const char *sig = "pbc";
++
++	if (!wifi || !wifi->device)
++		return;
+ 
+ 	identifier = g_supplicant_peer_get_identifier(peer);
+-	name = g_supplicant_peer_get_name(peer);
+ 
+ 	DBG("ident: %s", identifier);
+ 
++	/** Throttle pbc requested messages */
++	if (pbc_requested_ref != -1) {
++		g_source_remove(pbc_requested_ref);
++		pbc_requested_ref = g_timeout_add_seconds(2, p2p_pbc_requested, NULL);
++		return;
++	}
++
+ 	connman_peer = connman_peer_get(wifi->device, identifier);
+-	if (connman_peer)
++	if (!connman_peer)
+ 		return;
++	if (connman_peer_get_state(connman_peer) != CONNMAN_PEER_STATE_ASSOCIATION)
++	{
++	connman_peer_set_state(connman_peer, CONNMAN_PEER_STATE_IDLE);
++	connman_peer_set_as_master(connman_peer, false);
++	}
++	path = __connman_peer_get_path(connman_peer);
+ 
+-	connman_peer = connman_peer_create(identifier);
+-	connman_peer_set_name(connman_peer, name);
+-	connman_peer_set_device(connman_peer, wifi->device);
+-	apply_peer_services(peer, connman_peer);
++	if (path && p2p_go_identifier) {
++		connman_dbus_property_changed_basic(path,
++					CONNMAN_PEER_INTERFACE,
++					"P2PProvDiscRequestedPBC",
++					DBUS_TYPE_STRING, &sig);
+ 
+-	ret = connman_peer_register(connman_peer);
+-	if (ret < 0 && ret != -EALREADY)
+-		connman_peer_unref(connman_peer);
+-	else
+-		wifi->peers = g_slist_prepend(wifi->peers, connman_peer);
++		pbc_requested_ref = g_timeout_add_seconds(2, p2p_pbc_requested, NULL);
++	}
+ }
+ 
+-static void peer_lost(GSupplicantPeer *peer)
++static void p2p_prov_disc_requested_enter_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer)
+ {
+-	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 	struct connman_peer *connman_peer;
+-	const char *identifier;
++	struct connman_network *connman_network;
++	const char *identifier, *path;
++	const char *sig = "keypad";
+ 
+-	if (!wifi)
++	if (!wifi || !wifi->device)
+ 		return;
+ 
+ 	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+ 	DBG("ident: %s", identifier);
+ 
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
++		return;
++
++//	wfds_on_p2p_pin_requested(connman_network, NULL);
++
+ 	connman_peer = connman_peer_get(wifi->device, identifier);
+-	if (connman_peer) {
+-		if (wifi->p2p_connecting &&
+-				wifi->pending_peer == connman_peer) {
+-			peer_connect_timeout(wifi);
+-		}
+-		connman_peer_unregister(connman_peer);
+-		connman_peer_unref(connman_peer);
++	if (!connman_peer)
++		return;
++
++	connman_peer_set_state(connman_peer, CONNMAN_PEER_STATE_IDLE);
++	connman_peer_set_as_master(connman_peer, false);
++
++	path = __connman_peer_get_path(connman_peer);
++
++	if (p2p_go_identifier) {
++		connman_dbus_property_changed_basic(path,
++					CONNMAN_PEER_INTERFACE,
++					"P2PProvDiscRequestedEnterPin",
++					DBUS_TYPE_STRING, &sig);
+ 	}
++}
+ 
+-	wifi->peers = g_slist_remove(wifi->peers, connman_peer);
++static gboolean p2p_pin_requested(gpointer argv)
++{
++	pin_requested_ref = -1;
++
++	return FALSE;
+ }
+ 
+-static void peer_changed(GSupplicantPeer *peer, GSupplicantPeerState state)
++static void p2p_prov_disc_requested_display_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, const char *pin)
+ {
+-	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
+-	enum connman_peer_state p_state = CONNMAN_PEER_STATE_UNKNOWN;
++	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
+ 	struct connman_peer *connman_peer;
+-	const char *identifier;
++	struct connman_network *connman_network;
++	const char *identifier, *path;
++	const char *sig = "keypad";
++
++	if (!wifi || !wifi->device)
++		return;
+ 
+ 	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+ 	DBG("ident: %s", identifier);
+ 
+-	if (!wifi)
++	/** Throttle pin requested messages */
++	if (pin_requested_ref != -1) {
++		g_source_remove(pin_requested_ref);
++		pin_requested_ref = g_timeout_add_seconds(2, p2p_pin_requested, NULL);
++		return;
++	}
++
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
+ 		return;
+ 
+ 	connman_peer = connman_peer_get(wifi->device, identifier);
+ 	if (!connman_peer)
+ 		return;
+ 
+-	switch (state) {
+-	case G_SUPPLICANT_PEER_SERVICES_CHANGED:
+-		apply_peer_services(peer, connman_peer);
+-		connman_peer_services_changed(connman_peer);
+-		return;
+-	case G_SUPPLICANT_PEER_GROUP_CHANGED:
+-		if (!g_supplicant_peer_is_in_a_group(peer))
+-			p_state = CONNMAN_PEER_STATE_IDLE;
+-		else
+-			p_state = CONNMAN_PEER_STATE_CONFIGURATION;
+-		break;
+-	case G_SUPPLICANT_PEER_GROUP_STARTED:
+-		break;
+-	case G_SUPPLICANT_PEER_GROUP_FINISHED:
+-		p_state = CONNMAN_PEER_STATE_IDLE;
+-		break;
+-	case G_SUPPLICANT_PEER_GROUP_JOINED:
+-		connman_peer_set_iface_address(connman_peer,
+-				g_supplicant_peer_get_iface_address(peer));
+-		break;
+-	case G_SUPPLICANT_PEER_GROUP_DISCONNECTED:
+-		p_state = CONNMAN_PEER_STATE_IDLE;
+-		break;
+-	case G_SUPPLICANT_PEER_GROUP_FAILED:
+-		if (g_supplicant_peer_has_requested_connection(peer))
+-			p_state = CONNMAN_PEER_STATE_IDLE;
+-		else
+-			p_state = CONNMAN_PEER_STATE_FAILURE;
+-		break;
+-	}
++	connman_peer_set_state(connman_peer, CONNMAN_PEER_STATE_IDLE);
++	connman_peer_set_as_master(connman_peer, false);
++	path = __connman_peer_get_path(connman_peer);
+ 
+-	if (p_state == CONNMAN_PEER_STATE_CONFIGURATION ||
+-					p_state == CONNMAN_PEER_STATE_FAILURE) {
+-		if (wifi->p2p_connecting
+-				&& connman_peer == wifi->pending_peer)
+-			peer_cancel_timeout(wifi);
+-		else
+-			p_state = CONNMAN_PEER_STATE_UNKNOWN;
+-	}
++	wifi->generated_pin = pin;
++	wifi->pin_requested_path = connman_network_get_string(connman_network, "Path");
+ 
+-	if (p_state == CONNMAN_PEER_STATE_UNKNOWN)
+-		return;
++//	wfds_on_p2p_pin_requested(connman_network, pin);
+ 
+-	if (p_state == CONNMAN_PEER_STATE_CONFIGURATION) {
+-		GSupplicantInterface *g_iface;
+-		struct wifi_data *g_wifi;
++	if (p2p_go_identifier || __connman_group_exist() == FALSE) {
++		connman_dbus_property_changed_basic(path,
++					CONNMAN_PEER_INTERFACE,
++					"P2PProvDiscRequestedDisplayPin",
++					DBUS_TYPE_STRING, &pin);
+ 
+-		g_iface = g_supplicant_peer_get_group_interface(peer);
+-		if (!g_iface)
+-			return;
++		pin_requested_ref = g_timeout_add_seconds(2, p2p_pin_requested, NULL);
++	}
++}
+ 
+-		g_wifi = g_supplicant_interface_get_data(g_iface);
+-		if (!g_wifi)
+-			return;
++static void p2p_prov_disc_response_enter_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer)
++{
++	struct wifi_data *wifi;
++	const char *identifier;
++	struct connman_network *connman_network;
+ 
+-		connman_peer_set_as_master(connman_peer,
+-					!g_supplicant_peer_is_client(peer));
+-		connman_peer_set_sub_device(connman_peer, g_wifi->device);
++	wifi = g_supplicant_interface_get_data(interface);
++	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+-		/*
+-		 * If wpa_supplicant didn't create a dedicated p2p-group
+-		 * interface then mark this interface as p2p_device to avoid
+-		 * scan and auto-scan are launched on it while P2P is connected.
+-		 */
+-		if (!g_list_find(p2p_iface_list, g_wifi))
+-			wifi->p2p_device = true;
+-	}
++	DBG("identifier %s", identifier);
+ 
+-	connman_peer_set_state(connman_peer, p_state);
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
++		return;
++
++//	wfds_on_p2p_pin_response(connman_network, NULL);
+ }
+ 
+-static void peer_request(GSupplicantPeer *peer)
++static void p2p_prov_disc_response_display_pin(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, const char *pin)
+ {
+-	GSupplicantInterface *iface = g_supplicant_peer_get_interface(peer);
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(iface);
+-	struct connman_peer *connman_peer;
++	struct wifi_data *wifi;
+ 	const char *identifier;
++	struct connman_network *connman_network;
+ 
++	wifi = g_supplicant_interface_get_data(interface);
+ 	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+-	DBG("ident: %s", identifier);
++	DBG("identifier %s", identifier);
+ 
+-	connman_peer = connman_peer_get(wifi->device, identifier);
+-	if (!connman_peer)
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
+ 		return;
+ 
+-	connman_peer_request_connection(connman_peer);
++//	wfds_on_p2p_pin_response(connman_network, pin);
+ }
+ 
+-static void debug(const char *str)
++static void p2p_prov_disc_fail(GSupplicantInterface *interface,
++					GSupplicantPeer *peer, int status)
+ {
+-	if (getenv("CONNMAN_SUPPLICANT_DEBUG"))
+-		connman_debug("%s", str);
+-}
++	struct wifi_data *wifi;
++	const char *identifier;
++	struct connman_network *connman_network;
+ 
+-static void disconnect_reasoncode(GSupplicantInterface *interface,
+-				int reasoncode)
+-{
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
++	wifi = g_supplicant_interface_get_data(interface);
++	identifier = g_supplicant_peer_get_identifier(peer);
+ 
+-	if (wifi != NULL) {
+-		wifi->disconnect_code = reasoncode;
+-	}
+-}
++	DBG("identifier %s", identifier);
+ 
+-static void assoc_status_code(GSupplicantInterface *interface, int status_code)
+-{
+-	struct wifi_data *wifi = g_supplicant_interface_get_data(interface);
++	connman_network = connman_device_get_network(wifi->device, identifier);
++	if (!connman_network)
++		return;
+ 
+-	if (wifi != NULL) {
+-		wifi->assoc_code = status_code;
+-	}
++//	wfds_on_p2p_prov_failed(connman_network, status);
+ }
+ 
+ static const GSupplicantCallbacks callbacks = {
+@@ -3302,6 +5946,7 @@ static const GSupplicantCallbacks callbacks = {
+ 	.interface_state	= interface_state,
+ 	.interface_removed	= interface_removed,
+ 	.p2p_support		= p2p_support,
++	.p2p_device_config_loaded = p2p_device_config_loaded,
+ 	.scan_started		= scan_started,
+ 	.scan_finished		= scan_finished,
+ 	.ap_create_fail		= ap_create_fail,
+@@ -3309,15 +5954,35 @@ static const GSupplicantCallbacks callbacks = {
+ 	.network_removed	= network_removed,
+ 	.network_changed	= network_changed,
+ 	.network_associated	= network_associated,
++	.station_added          = station_added,
++	.station_removed        = station_removed,
+ 	.sta_authorized		= sta_authorized,
+ 	.sta_deauthorized	= sta_deauthorized,
+ 	.peer_found		= peer_found,
+ 	.peer_lost		= peer_lost,
+ 	.peer_changed		= peer_changed,
+ 	.peer_request		= peer_request,
++	.p2p_sd_response = p2p_sd_response,
++	.p2p_sd_asp_response = p2p_sd_asp_response,
++	.wps_state		= wps_state,
+ 	.debug			= debug,
+ 	.disconnect_reasoncode  = disconnect_reasoncode,
+ 	.assoc_status_code      = assoc_status_code,
++	.p2p_group_started		= p2p_group_started,
++	.p2p_group_finished		= p2p_group_finished,
++	.p2ps_prov_start = p2ps_prov_start,
++	.p2ps_prov_done = p2ps_prov_done,
++	.p2p_persistent_group_added = p2p_persistent_group_added,
++	.p2p_persistent_group_removed = p2p_persistent_group_removed,
++	.p2p_prov_disc_requested_pbc = p2p_prov_disc_requested_pbc,
++	.p2p_prov_disc_requested_enter_pin = p2p_prov_disc_requested_enter_pin,
++	.p2p_prov_disc_requested_display_pin = p2p_prov_disc_requested_display_pin,
++	.p2p_prov_disc_response_enter_pin = p2p_prov_disc_response_enter_pin,
++	.p2p_prov_disc_response_display_pin = p2p_prov_disc_response_display_pin,
++	.p2p_prov_disc_fail = p2p_prov_disc_fail,
++
++	.p2p_invitation_result = p2p_invitation_result,
++	.p2p_invitation_received = p2p_invitation_received,
+ };
+ 
+ 
+@@ -3333,10 +5998,10 @@ static void tech_remove(struct connman_technology *technology)
+ 	wifi_technology = NULL;
+ }
+ 
+-static GSupplicantSSID *ssid_ap_init(const struct connman_technology *technology)
++static GSupplicantSSID *ssid_ap_init(const char *ssid, const char *passphrase)
+ {
++    struct connman_technology *technology;
+ 	GSupplicantSSID *ap;
+-	const char *ssid, *passphrase;
+ 	int freq;
+ 	bool ret;
+ 
+@@ -3461,13 +6126,14 @@ static void sta_remove_callback(int result,
+ 
+ 	info->wifi->interface = NULL;
+ 
+-	g_supplicant_interface_create(info->ifname, driver, info->wifi->bridge,
++	g_supplicant_interface_create(info->ifname, driver, info->wifi->bridge, NULL,
+ 						ap_create_callback,
+ 							info);
+ }
+ 
+ static int enable_wifi_tethering(struct connman_technology *technology,
+-				const char *bridge, bool available)
++				const char *bridge, const char *identifier,
++				const char *passphrase, bool available)
+ {
+ 	GList *list;
+ 	GSupplicantInterface *interface;
+@@ -3520,14 +6186,14 @@ static int enable_wifi_tethering(struct connman_technology *technology,
+ 		info->wifi = wifi;
+ 		info->technology = technology;
+ 		info->wifi->bridge = bridge;
+-		info->ssid = ssid_ap_init(technology);
++		info->ssid = ssid_ap_init(identifier, passphrase);
+ 		if (!info->ssid)
+ 			goto failed;
+ 
+ 		info->ifname = g_strdup(ifname);
+ 
+ 		wifi->tethering_param->technology = technology;
+-		wifi->tethering_param->ssid = ssid_ap_init(technology);
++		wifi->tethering_param->ssid = ssid_ap_init(identifier, passphrase);
+ 		if (!wifi->tethering_param->ssid)
+ 			goto failed;
+ 
+@@ -3569,6 +6235,7 @@ static int enable_wifi_tethering(struct connman_technology *technology,
+ }
+ 
+ static int tech_set_tethering(struct connman_technology *technology,
++				const char *identifier, const char *passphrase,
+ 				const char *bridge, bool enabled)
+ {
+ 	GList *list;
+@@ -3596,11 +6263,13 @@ static int tech_set_tethering(struct connman_technology *technology,
+ 	}
+ 
+ 	DBG("trying tethering for available devices");
+-	err = enable_wifi_tethering(technology, bridge, true);
++	err = enable_wifi_tethering(technology, bridge, identifier, passphrase,
++				true);
+ 
+ 	if (err < 0) {
+ 		DBG("trying tethering for any device");
+-		err = enable_wifi_tethering(technology, bridge, false);
++		err = enable_wifi_tethering(technology, bridge, identifier,
++					passphrase, false);
+ 	}
+ 
+ 	return err;
+@@ -3624,6 +6293,21 @@ static int tech_set_regdom(struct connman_technology *technology, const char *al
+ 	return g_supplicant_set_country(alpha2, regdom_callback, NULL);
+ }
+ 
++static void tech_add_interface(struct connman_technology *technology,
++			int index, const char *name, const char *ident)
++{
++	DBG("index %d name %s ident %s", index, name, ident);
++
++	if(p2p_group_if_prefix && g_str_has_prefix(name, p2p_group_if_prefix)) {
++		if (p2p_group_ifname) {
++			g_free(p2p_group_ifname);
++			p2p_group_ifname = NULL;
++		}
++		p2p_group_ifname = g_strdup(name);
++		p2p_group_ifindex = index;
++	}
++}
++
+ static struct connman_technology_driver tech_driver = {
+ 	.name		= "wifi",
+ 	.type		= CONNMAN_SERVICE_TYPE_WIFI,
+@@ -3631,6 +6315,7 @@ static struct connman_technology_driver tech_driver = {
+ 	.remove		= tech_remove,
+ 	.set_tethering	= tech_set_tethering,
+ 	.set_regdom	= tech_set_regdom,
++	.add_interface = tech_add_interface,
+ };
+ 
+ static int wifi_init(void)
+@@ -3657,6 +6342,72 @@ static int wifi_init(void)
+ 	return 0;
+ }
+ 
++
++
++
++static enum connman_peer_wps_method p2psconnect_mode_to_wpa_method(int mode){
++
++ /*
++  always be in sync with p2p_connect_mode
++		typedef enum _p2p_connect_mode {
++			P2P_CONNECT_DISPLAY = 1,
++			P2P_CONNECT_KEYPAD = 5,
++			P2P_CONNECT_P2PS = 8
++		} p2p_connect_mode;
++
++ */
++   enum  connman_peer_wps_method wps_method=CONNMAN_PEER_WPS_UNKNOWN;
++
++	switch(mode){
++       case 1:
++                wps_method=CONNMAN_PEER_WPS_DISPLAY;
++		break;
++	case 5:
++                 wps_method=CONNMAN_PEER_WPS_KEYBOARD;
++		break;
++	case 8:
++                 wps_method=CONNMAN_PEER_WPS_P2PS;
++		break;
++
++	}
++	return wps_method;
++
++}
++
++
++
++/** WFDS calls into wifi.c */
++int wfds_p2p_wifi_connect(struct connman_network* network, int mode, const char* pin, gboolean persistent)
++{
++	struct connman_peer *connman_peer;
++	connman_peer = connman_peer_get(connman_network_get_device(network), connman_network_get_identifier(network));
++
++	return  peer_connect(connman_peer, p2psconnect_mode_to_wpa_method(mode), pin);
++
++}
++
++int wfds_p2p_wifi_disconnect(struct connman_network* network, GSupplicantP2PGroup* group)
++{
++	g_supplicant_interface_p2p_group_disconnect(group->group_interface, NULL, NULL);
++
++	return 0;
++}
++
++int wfds_p2p_wifi_extended_listen(gboolean enabled)
++{
++	if (enabled)
++	{
++		tech_set_p2p_listen_params(wifi_technology, 450, 500);
++	}
++
++	int err = tech_set_p2p_listen(wifi_technology, enabled);
++
++	if (err == -EINPROGRESS)
++		err = 0;
++
++	return err;
++}
++
+ static void wifi_exit(void)
+ {
+ 	DBG();
+diff --git a/src/connman.h b/src/connman.h
+index 68176086..2d010c1c 100644
+--- a/src/connman.h
++++ b/src/connman.h
+@@ -138,6 +138,8 @@ void __connman_log_enable(struct connman_debug_desc *start,
+ 
+ #include <connman/backtrace.h>
+ 
++#include <connman/option.h>
++
+ #include <connman/setting.h>
+ 
+ #include <connman/plugin.h>
+@@ -272,12 +274,14 @@ void __connman_storage_delete_global(void);
+ GKeyFile *__connman_storage_load_config(const char *ident);
+ GKeyFile *__connman_storage_load_provider_config(const char *ident);
+ 
++GKeyFile *__connman_storage_open_service(const char *ident);
+ int __connman_storage_save_service(GKeyFile *keyfile, const char *ident);
+ GKeyFile *__connman_storage_load_provider(const char *identifier);
+ void __connman_storage_save_provider(GKeyFile *keyfile, const char *identifier);
+ bool __connman_storage_remove_provider(const char *identifier);
+ char **__connman_storage_get_providers(void);
+ bool __connman_storage_remove_service(const char *service_id);
++gchar **__connman_storage_get_p2p_persistents(void);
+ 
+ int __connman_detect_init(void);
+ void __connman_detect_cleanup(void);
+@@ -559,6 +563,8 @@ void __connman_technology_remove_interface(enum connman_service_type type,
+ 				int index, const char *ident);
+ void __connman_technology_notify_regdom_by_device(struct connman_device *device,
+ 						int result, const char *alpha2);
++int __connman_technology_set_p2p_go(DBusMessage *msg, const char *ident,
++				const char *passphrase);
+ 
+ #include <connman/device.h>
+ 
+@@ -571,6 +577,7 @@ enum connman_service_type __connman_device_get_service_type(struct connman_devic
+ struct connman_device *__connman_device_find_device(enum connman_service_type type);
+ int __connman_device_request_scan(enum connman_service_type type);
+ int __connman_device_request_scan_full(enum connman_service_type type);
++int __connman_device_request_cancel_p2p(enum connman_service_type type);
+ int __connman_device_request_hidden_scan(struct connman_device *device,
+ 				const char *ssid, unsigned int ssid_len,
+ 				const char *identity, const char *passphrase,
+@@ -638,13 +645,25 @@ bool __connman_config_address_provisioned(const char *address,
+ 
+ #include <connman/tethering.h>
+ 
++struct connman_station_info {
++	bool is_connected;
++	char *path;
++	char *type;
++	char ip[64];
++	char mac[32];
++	char hostname[64];
++};
++
+ int __connman_tethering_init(void);
+ void __connman_tethering_cleanup(void);
+ 
+ const char *__connman_tethering_get_bridge(void);
++int __connman_tethering_sta_count();
++GHashTable *__connman_tethering_get_sta_hash();
+ int __connman_tethering_set_enabled(void);
+ void __connman_tethering_set_disabled(void);
+ void __connman_tethering_list_clients(DBusMessageIter *array);
++int __connman_tethering_set_enabled_with_ip(const char *ip);
+ 
+ int __connman_private_network_request(DBusMessage *msg, const char *owner);
+ int __connman_private_network_release(const char *path);
+@@ -688,6 +707,7 @@ int __connman_service_compare(const struct connman_service *a,
+ 					const struct connman_service *b);
+ 
+ struct connman_service *__connman_service_lookup_from_index(int index);
++struct connman_service *__connman_service_lookup_from_ident(const char *identifier);
+ struct connman_service *__connman_service_create_from_network(struct connman_network *network);
+ struct connman_service *__connman_service_create_from_provider(struct connman_provider *provider);
+ bool __connman_service_index_is_default(int index);
+@@ -842,7 +862,9 @@ void __connman_peer_cleanup(void);
+ 
+ void __connman_peer_list_struct(DBusMessageIter *array);
+ const char *__connman_peer_get_path(struct connman_peer *peer);
+-void __connman_peer_disconnect_all(void);
++void __connman_peer_set_static_ip(struct connman_peer *peer, char* static_ip);
++void __connman_peer_set_autonomous_group(struct connman_peer *peer, bool autonomous_group);
++bool __connman_peer_get_connected_exists(void);
+ 
+ int __connman_peer_service_init(void);
+ void __connman_peer_service_cleanup(void);
+@@ -996,6 +1018,15 @@ typedef void (*ippool_collision_cb_t) (struct connman_ippool *pool,
+ int __connman_ippool_init(void);
+ void __connman_ippool_cleanup(void);
+ 
++#define __connman_ippool_ref(ipconfig) \
++	__connman_ippool_ref_debug(ipconfig, __FILE__, __LINE__, __func__)
++#define __connman_ippool_unref(ipconfig) \
++	__connman_ippool_unref_debug(ipconfig, __FILE__, __LINE__, __func__)
++
++struct connman_ippool *__connman_ippool_ref_debug(struct connman_ippool *pool,
++			const char *file, int line, const char *caller);
++void __connman_ippool_unref_debug(struct connman_ippool *pool,
++			const char *file, int line, const char *caller);
+ void __connman_ippool_free(struct connman_ippool *pool);
+ 
+ struct connman_ippool *__connman_ippool_create(int index,
+@@ -1004,6 +1035,13 @@ struct connman_ippool *__connman_ippool_create(int index,
+ 					ippool_collision_cb_t collision_cb,
+ 					void *user_data);
+ 
++struct connman_ippool *__connman_ippool_create_with_block(int index,
++					unsigned int start,
++					unsigned int range,
++					uint32_t block,
++					ippool_collision_cb_t collision_cb,
++					void *user_data);
++
+ const char *__connman_ippool_get_gateway(struct connman_ippool *pool);
+ const char *__connman_ippool_get_broadcast(struct connman_ippool *pool);
+ const char *__connman_ippool_get_subnet_mask(struct connman_ippool *pool);
+@@ -1090,3 +1128,6 @@ int __connman_util_get_random(uint64_t *val);
+ unsigned int __connman_util_random_delay_ms(unsigned int secs);
+ int __connman_util_init(void);
+ void __connman_util_cleanup(void);
++char *__connman_util_insert_colon_to_mac_addr(const char *mac_addr);
++char *__connman_util_mac_binary_to_string_no_colon(const unsigned char binmac[6]);
++const char * g_supplicant_peer_identifier_from_intf_address(const char* pintf_addr);
+diff --git a/src/device.c b/src/device.c
+index 264c5e2d..6d4feaad 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -68,6 +68,11 @@ struct connman_device {
+ 	char *last_network;
+ 	struct connman_network *network;
+ 	GHashTable *networks;
++
++	unsigned int wifi_rssi;
++	unsigned int wifi_link_speed;
++	unsigned int wifi_frequency;
++	unsigned int wifi_noise;
+ };
+ 
+ static void clear_pending_trigger(struct connman_device *device)
+@@ -558,6 +563,14 @@ void connman_device_set_interface(struct connman_device *device,
+ 	}
+ }
+ 
++const char *connman_device_get_interface(struct connman_device *device)
++{
++	if (!device)
++		return NULL;
++
++	return device->interface;
++}
++
+ /**
+  * connman_device_set_ident:
+  * @device: device structure
+@@ -826,6 +839,25 @@ int connman_device_set_string(struct connman_device *device,
+ 	return 0;
+ }
+ 
++int connman_device_set_integer(struct connman_device *device,
++                                       const char *key, int value)
++{
++	DBG("device %p key %s value %d", device, key, value);
++
++	if (g_strcmp0(key, "WiFi.RSSI") == 0)
++		device->wifi_rssi = value;
++	else if (g_strcmp0(key, "WiFi.LinkSpeed") == 0)
++		device->wifi_link_speed = value;
++	else if (g_strcmp0(key, "WiFi.Frequency") == 0)
++		device->wifi_frequency = value;
++	else if (g_strcmp0(key, "WiFi.Noise") == 0)
++		device->wifi_noise = value;
++	else
++		return -EINVAL;
++
++	return 0;
++}
++
+ /**
+  * connman_device_get_string:
+  * @device: device structure
+@@ -852,6 +884,23 @@ const char *connman_device_get_string(struct connman_device *device,
+ 	return NULL;
+ }
+ 
++int connman_device_get_integer(struct connman_device *device,
++                                       const char *key)
++{
++	DBG("device %p key %s", device, key);
++
++	if (g_strcmp0(key, "WiFi.RSSI") == 0)
++		return device->wifi_rssi;
++	else if (g_strcmp0(key, "WiFi.LinkSpeed") == 0)
++		return device->wifi_link_speed;
++	else if (g_strcmp0(key, "WiFi.Frequency") == 0)
++		return device->wifi_frequency;
++	else if (g_strcmp0(key, "WiFi.Noise") == 0)
++		return device->wifi_noise;
++
++	return 0;
++}
++
+ /**
+  * connman_device_add_network:
+  * @device: device structure
+@@ -1183,6 +1232,77 @@ void __connman_device_stop_scan(enum connman_service_type type)
+ 	}
+ }
+ 
++static int device_cancel_p2p(struct connman_device *device)
++{
++	if (!device->driver || !device->driver->cancel_p2p)
++		return -EOPNOTSUPP;
++
++	if (!device->powered)
++		return -ENOLINK;
++
++	return device->driver->cancel_p2p(device);
++}
++int __connman_device_request_cancel_p2p(enum connman_service_type type)
++{
++	int last_err = -ENOSYS;
++	GSList *list;
++	int err;
++
++	switch (type) {
++	case CONNMAN_SERVICE_TYPE_UNKNOWN:
++	case CONNMAN_SERVICE_TYPE_SYSTEM:
++	case CONNMAN_SERVICE_TYPE_ETHERNET:
++	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++	case CONNMAN_SERVICE_TYPE_CELLULAR:
++	case CONNMAN_SERVICE_TYPE_GPS:
++	case CONNMAN_SERVICE_TYPE_VPN:
++	case CONNMAN_SERVICE_TYPE_GADGET:
++		return -EOPNOTSUPP;
++	case CONNMAN_SERVICE_TYPE_WIFI:
++	case CONNMAN_SERVICE_TYPE_P2P:
++		break;
++	}
++
++	for (list = device_list; list; list = list->next) {
++		struct connman_device *device = list->data;
++		enum connman_service_type service_type =
++			__connman_device_get_service_type(device);
++
++		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN) {
++			if (type == CONNMAN_SERVICE_TYPE_P2P) {
++				if (service_type != CONNMAN_SERVICE_TYPE_WIFI)
++					continue;
++			} else if (service_type != type)
++				continue;
++		}
++
++		if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++				g_strcmp0(connman_device_get_string(device, "Interface"),
++					connman_option_get_string("P2PDevice")) != 0)
++			continue;
++
++		err = device_cancel_p2p(device);
++		if (err == 0) {
++			return 0;
++		} else {
++			last_err = err;
++			DBG("device %p err %d", device, err);
++		}
++	}
++
++	return last_err;
++}
++int connman_device_request_signal_info(struct connman_device *device,
++                                       connman_device_request_signal_info_cb cb, void *user_data)
++{
++	if (device->type != CONNMAN_DEVICE_TYPE_WIFI)
++		return -EOPNOTSUPP;
++
++	if (!device->driver || !device->driver->get_signal_info)
++		return -EOPNOTSUPP;
++
++	return device->driver->get_signal_info(device, cb, user_data);
++}
+ static char *index2ident(int index, const char *prefix)
+ {
+ 	struct ifreq ifr;
+diff --git a/src/group.c b/src/group.c
+new file mode 100644
+index 00000000..e55358b3
+--- /dev/null
++++ b/src/group.c
+@@ -0,0 +1,798 @@
++/*
++ *
++ *  Connection Manager
++ *
++ *  Copyright (C) 2013-2019 LG Electronics, Inc.
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License version 2 as
++ *  published by the Free Software Foundation.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#ifdef HAVE_CONFIG_H
++#include <config.h>
++#endif
++
++#include <errno.h>
++#include <stdio.h>
++#include <string.h>
++#include <netdb.h>
++#include <gdbus.h>
++#include <ctype.h>
++
++#include <connman/storage.h>
++#include <connman/setting.h>
++#include <connman/agent.h>
++#include "include/group.h"
++#include <gsupplicant/gsupplicant.h>
++
++#include "connman.h"
++
++static DBusConnection *connection = NULL;
++static GList *group_list = NULL;
++static GHashTable *group_hash = NULL;
++
++struct peer_cb_data {
++	DBusMessageIter *iter;
++	struct connman_group *group;
++};
++
++static struct connman_group *group_get(const char *identifier)
++{
++	struct connman_group *group;
++
++	group = g_hash_table_lookup(group_hash, identifier);
++	if (group) {
++		return group;
++	}
++
++	group = g_try_new0(struct connman_group, 1);
++	if (!group)
++		return NULL;
++
++	DBG("group %p", group);
++
++	group->identifier = g_strdup(identifier);
++	group->peer_hash = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
++	group->peer_intf = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
++
++	group_list = g_list_prepend(group_list, group);
++
++	g_hash_table_insert(group_hash, group->identifier, group);
++
++	return group;
++}
++
++static int set_tethering(struct connman_group *group,
++		bool enabled)
++{
++	group->tethering = enabled;
++	dbus_bool_t val = enabled;
++
++	connman_dbus_property_changed_basic(group->path,
++			CONNMAN_GROUP_INTERFACE, "Tethering",
++			DBUS_TYPE_BOOLEAN,
++			&val);
++
++	if (enabled == TRUE) {
++		__connman_p2p_go_tethering_set_enabled();
++	} else {
++		__connman_p2p_go_tethering_set_disabled();
++	}
++
++	return 0;
++}
++
++static DBusMessage *set_property(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	struct connman_group *group = user_data;
++	DBusMessageIter iter, value;
++	const char *name;
++	int type;
++
++	DBG("group %p", group);
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &name);
++	dbus_message_iter_next(&iter);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_VARIANT)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_recurse(&iter, &value);
++
++	type = dbus_message_iter_get_arg_type(&value);
++
++	if (g_str_equal(name, "Tethering") == TRUE) {
++		int err;
++		bool tethering;
++
++		if (type != DBUS_TYPE_BOOLEAN)
++			return __connman_error_invalid_arguments(msg);
++
++		dbus_message_iter_get_basic(&value, &tethering);
++
++		if (group->tethering == tethering) {
++			if (tethering == FALSE)
++				return __connman_error_already_disabled(msg);
++			else
++				return __connman_error_already_enabled(msg);
++		}
++
++		err = set_tethering(group, tethering);
++		if (err < 0)
++			return __connman_error_failed(msg, -err);
++	}
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static void append_properties(DBusMessageIter *dict, struct connman_group *group)
++{
++	dbus_bool_t val;
++	struct connman_peer *connman_peer = NULL;
++
++	if(group->name)
++		connman_dbus_dict_append_basic(dict, "Name", DBUS_TYPE_STRING, &group->name);
++
++	val = group->is_group_owner;
++	connman_dbus_dict_append_basic(dict, "Owner", DBUS_TYPE_BOOLEAN, &val);
++
++	if (group->is_group_owner)
++		connman_dbus_dict_append_basic(dict, "Passphrase", DBUS_TYPE_STRING, &group->passphrase);
++	else if (group->group_owner)
++		connman_dbus_dict_append_basic(dict, "OwnerPath", DBUS_TYPE_OBJECT_PATH, &group->group_owner);
++
++	val = group->is_persistent;
++	connman_dbus_dict_append_basic(dict, "Persistent", DBUS_TYPE_BOOLEAN, &val);
++
++	val = group->tethering;
++	connman_dbus_dict_append_basic(dict, "Tethering", DBUS_TYPE_BOOLEAN, &val);
++
++	connman_dbus_dict_append_basic(dict, "Freq", DBUS_TYPE_UINT32, &group->freq);
++
++	if(group->is_group_owner)
++		__connman_dhcpserver_append_gateway(dict);
++	/*else {
++		connman_peer = connman_peer_get_by_path(group->group_owner);
++		if (connman_peer) {
++			connman_peer_get_local_address(dict, connman_peer);
++		}
++	}*/
++}
++
++static DBusMessage *get_properties(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	struct connman_group *group = user_data;
++	DBusMessage *reply;
++	DBusMessageIter array, dict;
++
++	DBG("group %p", group);
++
++	reply = dbus_message_new_method_return(msg);
++	if (reply == NULL)
++		return NULL;
++
++	dbus_message_iter_init_append(reply, &array);
++
++	connman_dbus_dict_open(&array, &dict);
++	append_properties(&dict, group);
++	connman_dbus_dict_close(&array, &dict);
++
++	return reply;
++}
++
++static void group_added_signal(struct connman_group *group)
++{
++	DBusMessage *signal;
++	DBusMessageIter iter;
++	DBusMessageIter dict;
++
++	signal = dbus_message_new_signal(CONNMAN_MANAGER_PATH,
++			CONNMAN_MANAGER_INTERFACE, "GroupAdded");
++	if (!signal)
++		return;
++
++	dbus_message_iter_init_append(signal, &iter);
++	dbus_message_iter_append_basic(&iter, DBUS_TYPE_OBJECT_PATH,
++							&group->path);
++
++	connman_dbus_dict_open(&iter, &dict);
++	append_properties(&dict, group);
++	connman_dbus_dict_close(&iter, &dict);
++
++	dbus_connection_send(connection, signal, NULL);
++	dbus_message_unref(signal);
++}
++
++static void group_removed_signal(struct connman_group *group)
++{
++	g_dbus_emit_signal(connection, CONNMAN_MANAGER_PATH,
++			CONNMAN_MANAGER_INTERFACE, "GroupRemoved",
++			DBUS_TYPE_OBJECT_PATH, &group->path,
++			DBUS_TYPE_INVALID);
++}
++
++static void p2p_disconnect_callback(int result,
++					GSupplicantInterface *interface,
++							void *user_data)
++{
++	struct connman_group *group = user_data;
++
++	DBG("group %p\n", group);
++}
++
++static DBusMessage *p2p_disconnect(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	struct connman_group *group = user_data;
++	int err = 0;
++
++	DBG("group %p", group);
++
++	err = g_supplicant_interface_p2p_group_disconnect(group->interface, p2p_disconnect_callback, group);
++
++	if (err < 0) {
++		if (err != -EINPROGRESS)
++			return __connman_error_failed(msg, -err);
++	}
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static void p2p_invite_callback(int result,
++					GSupplicantInterface *interface,
++							void *user_data)
++{
++	DBG("p2p invite callback %d\n", result);
++}
++
++static DBusMessage *p2p_invite(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	struct connman_group *group = user_data;
++	DBusMessageIter iter;
++	const char *peer_path;
++	char *peer_ident;
++	GSupplicantP2PInviteParams *invite_params = NULL;
++	struct connman_service *service;
++	struct connman_network *network;
++	struct connman_peer *connman_peer;
++	GSupplicantPeer *gs_peer;
++
++	DBG("group %p", group);
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &peer_path);
++
++	connman_peer = connman_peer_get_by_path(peer_path);
++	peer_ident = connman_peer_get_identifier(connman_peer);
++
++	gs_peer = g_supplicant_interface_peer_lookup(group->orig_interface, peer_ident);
++
++	if(!gs_peer || !g_supplicant_peer_get_path(gs_peer))
++		return __connman_error_invalid_arguments(msg);
++
++	invite_params = g_try_malloc0(sizeof(GSupplicantP2PInviteParams));
++	if (!invite_params)
++		return __connman_error_invalid_arguments(msg);
++
++	invite_params->peer = g_strdup(g_supplicant_peer_get_path(gs_peer));
++
++	g_supplicant_interface_p2p_invite(group->interface, invite_params, p2p_invite_callback, NULL);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static void append_peer_struct(gpointer value, gpointer user_data)
++{
++	struct peer_cb_data *cbd = user_data;
++	const char *peer_ident = value;
++	const char *peer_path, *peer_dev_addr = NULL;
++	DBusMessageIter entry, dict;
++	struct connman_peer *connman_peer = NULL;
++
++	DBG("peer_ident %s", peer_ident);
++
++	dbus_message_iter_open_container(cbd->iter, DBUS_TYPE_STRUCT, NULL, &entry);
++
++	peer_path = g_hash_table_lookup(cbd->group->peer_hash, peer_ident);
++
++	dbus_message_iter_append_basic(&entry, DBUS_TYPE_OBJECT_PATH, &peer_path);
++
++	connman_peer = connman_peer_get_by_path(peer_path);
++	if (connman_peer) {
++		__connman_peer_get_properties_struct(&entry, connman_peer);
++	} else {
++		connman_dbus_dict_open(&entry, &dict);
++		peer_dev_addr = __connman_util_insert_colon_to_mac_addr(peer_ident);
++		connman_dbus_dict_append_basic(&dict, "DeviceAddress", DBUS_TYPE_STRING, &peer_dev_addr);
++		connman_dbus_dict_close(&entry, &dict);
++	}
++
++	dbus_message_iter_close_container(cbd->iter, &entry);
++	g_free(peer_dev_addr);
++}
++
++static void append_peer_structs(DBusMessageIter *iter, void *user_data)
++{
++	struct connman_group *group = user_data;
++	struct peer_cb_data cbd;
++
++	cbd.iter = iter;
++	cbd.group = group;
++
++	DBG("iter %p group %p", iter, group);
++
++	g_slist_foreach(group->peer_list, append_peer_struct, &cbd);
++}
++
++static void append_peer_go(DBusMessageIter *iter, void *user_data)
++{
++	struct connman_group *group = user_data;
++	const char *peer_ident, *peer_dev_addr = NULL;
++	DBusMessageIter entry, dict;
++	struct connman_peer *connman_peer;
++
++	if(!group || !g_list_find(group_list, group) || !group->group_owner)
++		return;
++
++	dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &entry);
++
++	dbus_message_iter_append_basic(&entry, DBUS_TYPE_OBJECT_PATH, &group->group_owner);
++
++	connman_peer = connman_peer_get_by_path(group->group_owner);
++	if(connman_peer) {
++		peer_ident = connman_peer_get_identifier(connman_peer);
++		__connman_peer_get_properties_struct(&entry, connman_peer);
++	} else {
++		connman_dbus_dict_open(&entry, &dict);
++		peer_ident = strrchr(group->group_owner, '_') + 1;
++		peer_dev_addr = __connman_util_insert_colon_to_mac_addr(peer_ident);
++		connman_dbus_dict_append_basic(&dict, "DeviceAddress", DBUS_TYPE_STRING, &peer_dev_addr);
++		connman_dbus_dict_close(&entry, &dict);
++	}
++
++	dbus_message_iter_close_container(iter, &entry);
++	g_free(peer_dev_addr);
++}
++
++static DBusMessage *get_peers(DBusConnection *conn, DBusMessage *msg, void *user_data)
++{
++	struct connman_group *group = user_data;
++	DBusMessage *reply;
++
++	reply = dbus_message_new_method_return(msg);
++	if (reply == NULL)
++		return NULL;
++
++	if(group->is_group_owner)
++		__connman_dbus_append_objpath_dict_array(reply,
++			append_peer_structs, group);
++	else
++		__connman_dbus_append_objpath_dict_array(reply,
++			append_peer_go, group);
++
++	return reply;
++}
++
++static const GDBusMethodTable group_methods[] = {
++	{ GDBUS_DEPRECATED_METHOD("GetProperties",
++			NULL, GDBUS_ARGS({ "properties", "a{sv}" }),
++			get_properties) },
++	{ GDBUS_METHOD("SetProperty",
++			GDBUS_ARGS({ "name", "s" }, { "value", "v" }),
++			NULL, set_property) },
++	{ GDBUS_METHOD("Disconnect",
++			NULL, NULL, p2p_disconnect) },
++	{ GDBUS_METHOD("Invite",
++			GDBUS_ARGS({ "service_path", "s" }),
++			NULL, p2p_invite) },
++	{ GDBUS_METHOD("GetPeers",
++			NULL, GDBUS_ARGS({ "peers", "a(oa{sv})" }),
++			get_peers) },
++	{},
++};
++
++static const GDBusSignalTable group_signals[] = {
++	{ GDBUS_SIGNAL("PropertyChanged",
++			GDBUS_ARGS({ "name", "s" }, { "value", "v" })) },
++	{ GDBUS_SIGNAL("PeerAdded",
++			GDBUS_ARGS({ "path", "o" })) },
++	{ GDBUS_SIGNAL("PeerRemoved",
++			GDBUS_ARGS({ "path", "o" })) },
++	{ },
++};
++
++const char* __connman_group_get_path(struct connman_group *group)
++{
++	if (group)
++		return group->path;
++
++	return NULL;
++}
++
++const char* __connman_group_get_identifier(struct connman_group *group)
++{
++	return group->identifier;
++}
++
++const char* __connman_group_get_group_owner(struct connman_group *group)
++{
++	if (group)
++		return group->group_owner;
++
++	return NULL;
++}
++
++int  __connman_group_get_list_length(struct connman_group *group)
++{
++	int length = 0;
++
++	if (group->peer_list == NULL)
++		return 0;
++
++	length = g_slist_length(group->peer_list);
++
++	return length;
++}
++
++bool __connman_group_is_autonomous(struct connman_group *group)
++{
++		return group->autonomous;
++}
++
++bool __connman_group_exist(void)
++{
++	if(!group_list || !group_list->data)
++		return false;
++
++	return true;
++}
++
++int __connman_group_accept_connection(struct connman_group *group, GSupplicantP2PWPSParams *wps_params)
++{
++	if(group == NULL)
++		return -1;
++
++	if(group->path == NULL)
++		return -1;
++
++	return g_supplicant_interface_p2p_wps_start(group->interface, wps_params, NULL, NULL);
++}
++
++void __connman_group_peer_failed(struct connman_group *group)
++{
++	g_supplicant_interface_p2p_group_disconnect(group->interface, NULL, NULL);
++}
++
++struct connman_group *__connman_group_lookup_from_ident(const char *identifier)
++{
++	return group_get(identifier);
++}
++
++static void append_dict_properties(DBusMessageIter *dict, void *user_data)
++{
++	struct connman_group *group = user_data;
++
++	append_properties(dict, group);
++}
++
++static void append_struct_group(DBusMessageIter *iter,
++		connman_dbus_append_cb_t function,
++		struct connman_group *group)
++{
++	DBusMessageIter entry, dict;
++
++	dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &entry);
++
++	dbus_message_iter_append_basic(&entry, DBUS_TYPE_OBJECT_PATH,
++							&group->path);
++
++	connman_dbus_dict_open(&entry, &dict);
++	if (function)
++		function(&dict, group);
++	connman_dbus_dict_close(&entry, &dict);
++
++	dbus_message_iter_close_container(iter, &entry);
++}
++
++static void append_struct(gpointer value, gpointer user_data)
++{
++	struct connman_group *group = value;
++	DBusMessageIter *iter = user_data;
++
++	if (!group->path)
++		return;
++
++	append_struct_group(iter, append_dict_properties, group);
++}
++
++void __connman_group_list_struct(DBusMessageIter *iter)
++{
++	g_list_foreach(group_list, append_struct, iter);
++}
++
++static int group_register(struct connman_group *group)
++{
++	DBG("group %p", group);
++
++	if (group->path != NULL)
++		return -EALREADY;
++
++	group->path = g_strdup_printf("%s/group/%s", CONNMAN_PATH,
++						group->identifier);
++
++	DBG("path %s", group->path);
++
++	g_dbus_register_interface(connection, group->path,
++								CONNMAN_GROUP_INTERFACE,
++								group_methods, group_signals,
++								NULL, group, NULL);
++
++	if (!group->autonomous)
++		__connman_p2p_set_dhcp_pool(NULL);
++	group_added_signal(group);
++
++	return 0;
++}
++
++static void interface_create_callback(int result,
++					GSupplicantInterface *interface,
++							void *user_data)
++{
++	struct connman_group *group = user_data;
++
++	DBG("result %d ifname %s", result,
++				g_supplicant_interface_get_ifname(interface));
++
++	group->interface = interface;
++}
++
++void __connman_group_client_dhcp_ip_assigned(struct connman_group *group)
++{
++	dbus_bool_t dhcp_address = TRUE;
++
++	connman_dbus_property_changed_basic(group->path,
++			CONNMAN_GROUP_INTERFACE, "DHCPAddress", DBUS_TYPE_BOOLEAN,
++			&dhcp_address);
++}
++struct connman_group* __connman_group_create(GSupplicantInterface *iface, const char *ifname, const char *ssid, const char *passphrase,
++											bool go, bool persistent, const char *go_path, bool autonomous, int freq)
++{
++	struct connman_group *group;
++	char *ident;
++	int ssid_len = strlen(ssid);
++	GString *name = g_string_sized_new(ssid_len * 2 + 1);
++	int i=0;
++	int ret=0;
++
++	DBG("ssid : %s, len : %d\n", ssid, ssid_len);
++
++	for(i=0; i<ssid_len; i++) {
++		g_string_append_printf(name, "%02x", ssid[i]);
++	}
++
++	ident = g_string_free(name, FALSE);
++
++	DBG("ident : %s\n", ident);
++
++	group = group_get(ident);
++
++	g_free(ident);
++	ident = NULL;
++	if (!group)
++		return NULL;
++
++	group->name = g_strdup(ssid);
++	group->is_group_owner = go;
++	if (go) {
++		group->passphrase = g_strdup(passphrase);
++	}
++	group->is_persistent = persistent;
++	group->group_owner = go_path;
++	group->autonomous = autonomous;
++	group->freq = freq;
++	group->is_static_ip = false;
++	group->orig_interface = iface;
++
++	DBG("go path : %s\n", go_path);
++
++	ret = group_register(group);
++
++	if (ret == 0) {
++		g_supplicant_interface_create(ifname, "nl80211", NULL, NULL, interface_create_callback, group);
++	}
++
++	return group;
++}
++
++void __connman_group_remove(GSupplicantInterface *interface)
++{
++	GList *list;
++	struct connman_group *group = NULL;
++
++	if(!group_list)
++		return;
++
++	for (list = group_list; list != NULL; list = list->next) {
++		group = list->data;
++
++		if (group->interface == interface) {
++			break;
++		}
++	}
++
++	if (group) {
++		DBG("group removed\n");
++
++		if(!connection)
++			connection = connman_dbus_get_connection();
++
++		DBG("group path : %s\n", group->path);
++		__connman_p2p_set_dhcp_pool(NULL);
++
++		if (group->path && strncmp(group->path, CONNMAN_PATH, strlen(CONNMAN_PATH)) == 0) {
++			group_removed_signal(group);
++			g_dbus_unregister_interface(connection, group->path, CONNMAN_GROUP_INTERFACE);
++		}
++		g_hash_table_remove(group_hash, group->identifier);
++		group_list = g_list_remove(group_list, group);
++
++		g_hash_table_destroy(group->peer_hash);
++		g_hash_table_destroy(group->peer_intf);
++
++		g_free(group->path);
++		g_free(group->passphrase);
++		g_free(group->peer_ip);
++		g_free(group->identifier);
++		g_free(group->name);
++		g_free(group);
++		group = NULL;
++	}
++}
++
++void __connman_group_peer_joined(struct connman_group *group, const char *_peer_ident, char *intf_addr, const char *peer_path)
++{
++	const char *not_p2p_peer = "/";
++	const char *sig = "pbc";
++
++	DBG("group: %s, peer: %s peer_path: %s \n", group->name, _peer_ident, peer_path);
++
++	//Peer list will be the owner.
++	char* peer_ident = g_strdup(_peer_ident);
++
++	if (peer_path) {
++		g_hash_table_replace(group->peer_hash, peer_ident, g_strdup(peer_path));
++		if(intf_addr != NULL && g_str_equal(peer_ident, intf_addr) == FALSE)
++			g_hash_table_replace(group->peer_intf, peer_ident, intf_addr);
++	} else {
++		g_hash_table_replace(group->peer_hash, peer_ident, g_strdup(not_p2p_peer));
++	}
++
++	group->peer_list = g_slist_prepend(group->peer_list, peer_ident);
++
++	if (peer_path) {
++		g_dbus_emit_signal(connection, group->path, CONNMAN_GROUP_INTERFACE, "PeerAdded",
++						DBUS_TYPE_OBJECT_PATH, &peer_path,
++						DBUS_TYPE_INVALID);
++		connman_dbus_property_changed_basic(peer_path, CONNMAN_PEER_INTERFACE,
++						"PeerAdded", DBUS_TYPE_STRING, &sig);
++	}
++}
++
++bool __connman_group_peer_disconnected(struct connman_group *group, char *peer_ident)
++{
++	char *peer_path = NULL;
++	GSList* item;
++
++	DBG("group %s\n", group->name);
++
++	if (group->peer_hash)
++		peer_path = g_hash_table_lookup(group->peer_hash, peer_ident);
++
++	item = g_slist_find_custom(group->peer_list, peer_ident, (GCompareFunc)g_strcmp0);
++
++	if (!item)
++	{
++		DBG("Internal error - Peer not found in list %s\n", peer_ident);
++		return false;
++	}
++
++	if (peer_path && peer_ident) {
++		g_hash_table_remove(group->peer_hash, peer_ident);
++	}
++	g_hash_table_remove(group->peer_intf, peer_ident);
++	g_free(item->data);
++	group->peer_list = g_slist_delete_link(group->peer_list, item);
++
++	if(peer_path) {
++		g_dbus_emit_signal(connection, group->path,
++						CONNMAN_GROUP_INTERFACE, "PeerRemoved",
++						DBUS_TYPE_OBJECT_PATH, &peer_path,
++						DBUS_TYPE_INVALID);
++
++		g_free(peer_path);
++	}
++
++	if(group->autonomous == false && group->peer_list == NULL)
++		if (-EINPROGRESS == g_supplicant_interface_p2p_group_disconnect(group->interface, NULL, NULL))
++			return true;
++
++	return true;
++}
++
++void __connman_group_init(void)
++{
++	connection = connman_dbus_get_connection();
++
++	if (group_hash != NULL){
++		__connman_group_cleanup();
++	}
++
++	group_hash = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
++}
++
++void __connman_group_cleanup(void)
++{
++	GList *list;
++
++	if (!group_list){
++		if (group_hash != NULL){
++			g_hash_table_destroy(group_hash);
++			group_hash = NULL;
++		}
++		return;
++	}
++
++	for (list = group_list; list != NULL; list = list->next) {
++
++		struct connman_group *group = list->data;
++
++		/*
++		 * Checking if group->path == null is added to prevent connman crash [NCVTDEFFECT-2085]).
++		 * You can check original code review in http://wall.lge.com:8110/#/c/80192/.
++		 * For network module migration from drd4tv to emo, this patch will be taken as it is.
++		 * For further investigation, PLAT-16133 is created for to find a better solution
++		 * other than checking null.
++		 */
++
++		if (group && group->path && strstr(group->path, "group") != NULL) {
++			group_removed_signal(group);
++
++			if (group->interface) {
++				g_supplicant_interface_p2p_group_disconnect(group->interface, NULL, NULL);
++				g_dbus_unregister_interface(connection, group->path, CONNMAN_GROUP_INTERFACE);
++			}
++		}
++	}
++
++	list = group_list;
++	group_list = NULL;
++	g_list_free (list);
++
++	g_hash_table_destroy(group_hash);
++	group_hash = NULL;
++}
+diff --git a/src/ippool.c b/src/ippool.c
+index f2e9b000..990bd5cc 100644
+--- a/src/ippool.c
++++ b/src/ippool.c
+@@ -42,6 +42,8 @@ struct address_info {
+ };
+ 
+ struct connman_ippool {
++	unsigned int refcount;
++
+ 	struct address_info *info;
+ 
+ 	char *gateway;
+@@ -62,6 +64,44 @@ static uint32_t block_20_bits;
+ static uint32_t block_24_bits;
+ static uint32_t subnet_mask_24;
+ 
++struct connman_ippool *
++__connman_ippool_ref_debug(struct connman_ippool *pool,
++				const char *file, int line, const char *caller)
++{
++	DBG("%p ref %d by %s:%d:%s()", pool, pool->refcount + 1,
++		file, line, caller);
++
++	__sync_fetch_and_add(&pool->refcount, 1);
++
++	return pool;
++}
++
++void __connman_ippool_unref_debug(struct connman_ippool *pool,
++				const char *file, int line, const char *caller)
++{
++	if (!pool)
++		return;
++
++	DBG("%p ref %d by %s:%d:%s()", pool, pool->refcount - 1,
++		file, line, caller);
++
++	if (__sync_fetch_and_sub(&pool->refcount, 1) != 1)
++		return;
++
++	if (pool->info) {
++		allocated_blocks = g_slist_remove(allocated_blocks, pool->info);
++		g_free(pool->info);
++	}
++
++	g_free(pool->gateway);
++	g_free(pool->broadcast);
++	g_free(pool->start_ip);
++	g_free(pool->end_ip);
++	g_free(pool->subnet_mask);
++
++	g_free(pool);
++}
++
+ void __connman_ippool_free(struct connman_ippool *pool)
+ {
+ 	if (!pool)
+@@ -326,10 +366,21 @@ struct connman_ippool *__connman_ippool_create(int index,
+ 					unsigned int range,
+ 					ippool_collision_cb_t collision_cb,
+ 					void *user_data)
++{
++	return __connman_ippool_create_with_block(index, start, range, 0, collision_cb, user_data);
++}
++
++
++struct connman_ippool *__connman_ippool_create_with_block(int index,
++					unsigned int start,
++					unsigned int range,
++					uint32_t block,
++					ippool_collision_cb_t collision_cb,
++					void *user_data)
+ {
+ 	struct connman_ippool *pool;
+ 	struct address_info *info;
+-	uint32_t block;
++	
+ 
+ 	DBG("");
+ 
+diff --git a/src/main.c b/src/main.c
+index e209cf26..2e285941 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -758,6 +758,21 @@ char *connman_setting_get_string(const char *key)
+ 	return NULL;
+ }
+ 
++const char *connman_option_get_string(const char *key)
++{
++	if (g_str_equal(key, CONF_VENDOR_CLASS_ID))
++		return connman_settings.vendor_class_id;
++
++	if (g_strcmp0(key, "wifi") == 0) {
++		if (!option_wifi)
++			return "nl80211,wext";
++		else
++			return option_wifi;
++	}
++
++	return NULL;
++}
++
+ bool connman_setting_get_bool(const char *key)
+ {
+ 	if (g_str_equal(key, CONF_BG_SCAN))
+diff --git a/src/manager.c b/src/manager.c
+index 892d3a42..e325c908 100644
+--- a/src/manager.c
++++ b/src/manager.c
+@@ -30,6 +30,7 @@
+ #include <connman/agent.h>
+ 
+ #include "connman.h"
++#include "include/group.h"
+ 
+ static bool connman_state_idle;
+ static dbus_bool_t sessionmode;
+diff --git a/src/network.c b/src/network.c
+index 1cbdf9cf..a46c763c 100644
+--- a/src/network.c
++++ b/src/network.c
+@@ -55,6 +55,11 @@
+ static GSList *network_list = NULL;
+ static GSList *driver_list = NULL;
+ 
++struct connman_bss {
++	short signal;
++	unsigned short frequency;
++	// add other properties needed later
++};
+ struct connman_network {
+ 	int refcount;
+ 	enum connman_network_type type;
+@@ -64,6 +69,7 @@ struct connman_network {
+ 	uint8_t strength;
+ 	uint16_t frequency;
+ 	char *identifier;
++	char *address;
+ 	char *name;
+ 	char *node;
+ 	char *group;
+@@ -80,6 +86,7 @@ struct connman_network {
+ 
+ 	bool connecting;
+ 	bool associating;
++	connman_bool_t p2p_network;
+ 
+ 	struct connman_device *device;
+ 
+@@ -107,6 +114,7 @@ struct connman_network {
+ 		bool wps_advertizing;
+ 		bool use_wps;
+ 		char *pin_wps;
++		GHashTable *bss;
+ 	} wifi;
+ 
+ };
+@@ -1553,6 +1561,15 @@ int connman_network_set_associating(struct connman_network *network,
+ 	return 0;
+ }
+ 
++connman_bool_t connman_network_get_p2p_network(struct connman_network *network)
++{
++	return network->p2p_network;
++}
++
++void connman_network_set_p2p_network(struct connman_network *network, connman_bool_t is_p2p_network)
++{
++	network->p2p_network = is_p2p_network;
++}
+ static void set_associate_error(struct connman_network *network)
+ {
+ 	struct connman_service *service;
+@@ -2050,6 +2067,90 @@ int connman_network_set_domain(struct connman_network *network,
+ 	return 0;
+ }
+ 
++int connman_network_set_address(struct connman_network *network,
++                                       const unsigned char *addr_octet, unsigned int size)
++{
++	char *str;
++
++	if (!addr_octet || size != 6)
++		return -EINVAL;
++
++	DBG("");
++	str = g_strdup_printf("%02X:%02X:%02X:%02X:%02X:%02X",
++						addr_octet[0], addr_octet[1], addr_octet[2],
++						addr_octet[3], addr_octet[4], addr_octet[5]);
++	if (!str)
++		return -ENOMEM;
++
++	g_free(network->address);
++	network->address = str;
++
++	return 0;
++}
++
++const char *connman_network_get_address(struct connman_network *network)
++{
++	if (!network)
++		return NULL;
++
++	return network->address;
++}
++
++int connman_network_add_bss(struct connman_network *network,
++                                                       const unsigned char *id,
++                                                       short signal,
++                                                       unsigned short frequency)
++{
++	struct connman_bss *bss;
++	char *str;
++
++	if (!id)
++		return -EINVAL;
++
++	bss = g_try_new0(struct connman_bss, 1);
++	if (!bss)
++		return -ENOMEM;
++
++	str = g_strdup_printf("%02X:%02X:%02X:%02X:%02X:%02X",
++						id[0], id[1], id[2],
++						id[3], id[4], id[5]);
++	if (!str) {
++		g_free(bss);
++		return -ENOMEM;
++	}
++
++	bss->signal = signal;
++	bss->frequency = frequency;
++
++	g_hash_table_replace(network->wifi.bss, str, bss);
++
++	return 0;
++}
++
++GHashTable *connman_network_get_bss_table(struct connman_network *network)
++{
++	if (!network)
++		return NULL;
++
++	return network->wifi.bss;
++}
++
++short connman_network_get_bss_signal(struct connman_bss *bss)
++{
++	if (!bss)
++		return 0;
++
++	return bss->signal;
++}
++
++unsigned short connman_network_get_bss_frequency(struct connman_bss *bss)
++{
++	if (!bss)
++		return 0;
++
++	return bss->frequency;
++}
++
+ /**
+  * connman_network_set_name:
+  * @network: network structure
+diff --git a/src/p2pgo.c b/src/p2pgo.c
+new file mode 100644
+index 00000000..5c0b7f79
+--- /dev/null
++++ b/src/p2pgo.c
+@@ -0,0 +1,286 @@
++/*
++ *
++ *  Connection Manager
++ *
++ *  Copyright (C) 2007-2012  Intel Corporation. All rights reserved.
++ *  Copyright (C) 2011	ProFUSION embedded systems
++ *  Copyright (C) 2013 LG Electronics, Inc.
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License version 2 as
++ *  published by the Free Software Foundation.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#ifdef HAVE_CONFIG_H
++#include <config.h>
++#endif
++
++#include <errno.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <stdio.h>
++#include <sys/ioctl.h>
++#include <net/if.h>
++#include <linux/sockios.h>
++#include <string.h>
++#include <fcntl.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
++#include <linux/if_tun.h>
++#include <linux/if_bridge.h>
++
++#include "connman.h"
++
++#include <gdhcp/gdhcp.h>
++
++#include <gdbus.h>
++
++#ifndef DBUS_TYPE_UNIX_FD
++#define DBUS_TYPE_UNIX_FD -1
++#endif
++
++#define BRIDGE_DNS		"8.8.8.8"
++#define DEFAULT_MTU		1500
++
++#define PRIVATE_NETWORK_PRIMARY_DNS		BRIDGE_DNS
++#define PRIVATE_NETWORK_SECONDARY_DNS		"8.8.4.4"
++
++#define P2P_DEFAULT_BLOCK		0xc0a83100 //192.168.49.x
++
++static GDHCPServer *tethering_dhcp_server = NULL;
++static struct connman_ippool *dhcp_ippool = NULL;
++
++static char* bridge_name;
++
++void __connman_p2p_go_set_bridge(char *bridge)
++{
++	bridge_name = g_strdup(bridge);
++}
++
++const char *__connman_p2p_go_get_bridge(void)
++{
++	return bridge_name;
++}
++
++static void dhcp_server_debug(const char *str, void *data)
++{
++	connman_info("%s: %s\n", (const char *) data, str);
++}
++
++static void dhcp_server_error(GDHCPServerError error)
++{
++	switch (error) {
++	case G_DHCP_SERVER_ERROR_NONE:
++		connman_error("OK");
++		break;
++	case G_DHCP_SERVER_ERROR_INTERFACE_UNAVAILABLE:
++		connman_error("Interface unavailable");
++		break;
++	case G_DHCP_SERVER_ERROR_INTERFACE_IN_USE:
++		connman_error("Interface in use");
++		break;
++	case G_DHCP_SERVER_ERROR_INTERFACE_DOWN:
++		connman_error("Interface down");
++		break;
++	case G_DHCP_SERVER_ERROR_NOMEM:
++		connman_error("No memory");
++		break;
++	case G_DHCP_SERVER_ERROR_INVALID_INDEX:
++		connman_error("Invalid index");
++		break;
++	case G_DHCP_SERVER_ERROR_INVALID_OPTION:
++		connman_error("Invalid option");
++		break;
++	case G_DHCP_SERVER_ERROR_IP_ADDRESS_INVALID:
++		connman_error("Invalid address");
++		break;
++	}
++}
++
++static GDHCPServer *dhcp_server_start(const char *bridge,
++				const char *router, const char* subnet,
++				const char *start_ip, const char *end_ip,
++				unsigned int lease_time, const char *dns)
++{
++	GDHCPServerError error;
++	GDHCPServer *dhcp_server;
++	int index;
++
++	DBG("");
++
++	index = connman_inet_ifindex(bridge);
++	if (index < 0)
++		return NULL;
++
++	dhcp_server = g_dhcp_server_new(G_DHCP_IPV4, index, &error);
++	if (!dhcp_server) {
++		dhcp_server_error(error);
++		return NULL;
++	}
++
++	g_dhcp_server_set_debug(dhcp_server, dhcp_server_debug, "DHCP server");
++
++	g_dhcp_server_set_lease_time(dhcp_server, lease_time);
++	g_dhcp_server_set_option(dhcp_server, G_DHCP_SUBNET, subnet);
++	g_dhcp_server_set_option(dhcp_server, G_DHCP_ROUTER, router);
++	g_dhcp_server_set_option(dhcp_server, G_DHCP_DNS_SERVER, dns);
++	g_dhcp_server_set_ip_range(dhcp_server, start_ip, end_ip);
++
++	g_dhcp_server_start(dhcp_server);
++
++	return dhcp_server;
++}
++
++static void dhcp_server_stop(GDHCPServer *server)
++{
++	if (!server)
++		return;
++
++	g_dhcp_server_unref(server);
++}
++
++int __connman_p2p_go_set_enabled(void)
++{
++	int index;
++	int err;
++	const char *gateway;
++	const char *broadcast;
++	const char *subnet_mask;
++	const char *start_ip;
++	const char *end_ip;
++	const char *dns;
++
++	index = connman_inet_ifindex(bridge_name);
++	connman_info("p2pgo.c :  index = %d",index);
++
++	dhcp_ippool = __connman_ippool_create_with_block(index, 2, 252,
++						P2P_DEFAULT_BLOCK, NULL, NULL);
++
++	if (!dhcp_ippool) {
++		connman_error("Fail to create IP pool");
++		__connman_bridge_remove(bridge_name);
++	}
++
++	gateway = __connman_ippool_get_gateway(dhcp_ippool);
++	broadcast = __connman_ippool_get_broadcast(dhcp_ippool);
++	subnet_mask = __connman_ippool_get_subnet_mask(dhcp_ippool);
++	start_ip = __connman_ippool_get_start_ip(dhcp_ippool);
++	end_ip = __connman_ippool_get_end_ip(dhcp_ippool);
++
++	err = __connman_bridge_enable(bridge_name, gateway,
++		connman_ipaddress_calc_netmask_len(subnet_mask), broadcast);
++	if (err < 0 && err != -EALREADY) {
++		__connman_ippool_unref(dhcp_ippool);
++		__connman_bridge_remove(bridge_name);
++	}
++
++	dns = gateway;
++	if (__connman_dnsproxy_add_listener(index) < 0) {
++		connman_error("Can't add listener %s to DNS proxy",
++								bridge_name);
++		dns = BRIDGE_DNS;
++	}
++
++	tethering_dhcp_server = dhcp_server_start(bridge_name,
++						gateway, subnet_mask,
++						start_ip, end_ip,
++						24 * 3600, dns);
++	if (tethering_dhcp_server == NULL) {
++		__connman_bridge_disable(bridge_name);
++		__connman_ippool_unref(dhcp_ippool);
++		__connman_bridge_remove(bridge_name);
++	}
++
++	DBG("p2p go dhcp started");
++	return 0;
++}
++
++void __connman_p2p_go_set_disabled(void)
++{
++	int index;
++
++	index = connman_inet_ifindex(bridge_name);
++	if (index < 0)
++		return;
++
++	__connman_dnsproxy_remove_listener(index);
++
++	__connman_nat_disable(bridge_name);
++
++	dhcp_server_stop(tethering_dhcp_server);
++
++	tethering_dhcp_server = NULL;
++
++	__connman_bridge_disable(bridge_name);
++
++	__connman_ippool_unref(dhcp_ippool);
++
++	__connman_bridge_remove(bridge_name);
++
++	DBG("p2p go stopped");
++}
++
++void __connman_p2p_go_tethering_set_enabled(void)
++{
++	unsigned char prefixlen;
++	const char *subnet_mask;
++	const char *start_ip;
++
++	if (!dhcp_ippool)
++		return;
++	subnet_mask = __connman_ippool_get_subnet_mask(dhcp_ippool);
++	start_ip = __connman_ippool_get_start_ip(dhcp_ippool);
++
++	prefixlen =
++		connman_ipaddress_calc_netmask_len(subnet_mask);
++	__connman_nat_enable(bridge_name, start_ip, prefixlen);
++}
++
++void __connman_p2p_go_tethering_set_disabled(void)
++{
++	__connman_nat_disable(bridge_name);
++}
++
++const char* __connman_p2p_group_get_local_ip(void)
++{
++	if(dhcp_ippool) {
++		const char *gateway = __connman_ippool_get_gateway(dhcp_ippool);
++		return gateway;
++	}
++
++	return NULL;
++}
++
++void __connman_dhcpserver_append_gateway(DBusMessageIter* iter)
++{
++	const char* local_address = __connman_p2p_group_get_local_ip();
++	if(local_address != NULL)
++		connman_dbus_dict_append_basic(iter, "LocalAddress", DBUS_TYPE_STRING, &local_address);
++}
++
++int __connman_p2p_go_init(void)
++{
++	DBG("");
++	return 0;
++}
++
++void __connman_p2p_set_dhcp_pool(struct connman_ippool *ippool)
++{
++	dhcp_ippool = ippool;
++}
++
++void __connman_p2p_go_cleanup(void)
++{
++	DBG("");
++}
+diff --git a/src/peer.c b/src/peer.c
+index bad5c841..385ccd0e 100644
+--- a/src/peer.c
++++ b/src/peer.c
+@@ -33,12 +33,16 @@
+ 
+ #include "connman.h"
+ 
++#define P2P_DEFAULT_BLOCK 0xc0a83100 //192.168.49.
++
++
+ static DBusConnection *connection = NULL;
+ 
+ static GHashTable *peers_table = NULL;
+ 
+ static struct connman_peer_driver *peer_driver;
+ 
++typedef void (*GdhcpaddressclientCb) ();
+ struct _peers_notify {
+ 	int id;
+ 	GHashTable *add;
+@@ -64,10 +68,35 @@ struct connman_peer {
+ 	DBusMessage *pending;
+ 	bool registered;
+ 	bool connection_master;
++	bool is_groupOwner;
+ 	struct connman_ippool *ip_pool;
+ 	GDHCPServer *dhcp_server;
+ 	uint32_t lease_ip;
+ 	GSList *services;
++
++	const char *type;
++	const char *device_address;
++	unsigned char strength;
++	dbus_uint16_t config_methods;
++
++	char *static_ip;
++	char *dhcp_ip;
++	bool is_static_ip;
++	bool is_dhcp_ip;
++	char* pri_dev_type;
++	bool is_autonomous_group;
++	GdhcpaddressclientCb clientCb;
++};
++
++struct connman_peerrequest {
++	struct connman_peer *peer;
++	int dev_passwd_id;
++};
++
++struct connman_peer_invitation {
++	const char * peer_path;
++	const char * signal;
++	const char * go_dev_addr;
+ };
+ 
+ static void settings_changed(struct connman_peer *peer);
+@@ -252,6 +281,28 @@ static const char *state2string(enum connman_peer_state state)
+ 	return NULL;
+ }
+ 
++
++ const char *connman_peer_wps_method2string(enum connman_peer_wps_method method)
++{
++	switch (method) {
++	case CONNMAN_PEER_WPS_UNKNOWN:
++		break;
++	case CONNMAN_PEER_WPS_PBC:
++		return "pbc";
++	case CONNMAN_PEER_WPS_PIN:
++		return "pin";
++	case CONNMAN_PEER_WPS_DISPLAY:
++		return "display";
++	case CONNMAN_PEER_WPS_KEYBOARD:
++		return "keypad";
++	case CONNMAN_PEER_WPS_P2PS:
++		return "p2ps";
++	}
++
++	return NULL;
++}
++
++
+ static bool is_connecting(struct connman_peer *peer)
+ {
+ 	if (peer->state == CONNMAN_PEER_STATE_ASSOCIATION ||
+@@ -644,6 +695,28 @@ static int peer_disconnect(struct connman_peer *peer)
+ 	return err;
+ }
+ 
++static int peer_reject(struct connman_peer *peer)
++{
++	int err = -ENOTSUP;
++
++	connman_agent_cancel(peer);
++	reply_pending(peer, ECONNABORTED);
++
++	connman_peer_set_state(peer, CONNMAN_PEER_STATE_DISCONNECT);
++
++	if (peer->connection_master)
++		stop_dhcp_server(peer);
++	else
++		__connman_dhcp_stop(peer->ipconfig);
++
++	if (peer_driver->reject)
++		err = peer_driver->reject(peer);
++
++	connman_peer_set_state(peer, CONNMAN_PEER_STATE_IDLE);
++
++	return err;
++}
++
+ static DBusMessage *connect_peer(DBusConnection *conn,
+ 					DBusMessage *msg, void *user_data)
+ {
+@@ -705,6 +778,21 @@ static DBusMessage *disconnect_peer(DBusConnection *conn,
+ 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+ }
+ 
++static DBusMessage *reject_peer(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	struct connman_peer *peer = user_data;
++	int err;
++
++	DBG("peer %p", peer);
++
++	err = peer_reject(peer);
++	if (err < 0 && err != -EINPROGRESS)
++		return __connman_error_failed(msg, -err);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
+ struct connman_peer *connman_peer_create(const char *identifier)
+ {
+ 	struct connman_peer *peer;
+@@ -714,6 +802,17 @@ struct connman_peer *connman_peer_create(const char *identifier)
+ 	peer->state = CONNMAN_PEER_STATE_IDLE;
+ 
+ 	peer->refcount = 1;
++	peer->type = "peer";
++	peer->device_address = __connman_util_insert_colon_to_mac_addr(identifier);
++	peer->is_static_ip = false;
++	peer->is_dhcp_ip = false;
++	peer->is_groupOwner = false;
++	peer->static_ip = NULL;
++	peer->dhcp_ip = g_strdup("");
++	peer->config_methods = 0;
++	peer->pri_dev_type = NULL;
++	peer->is_autonomous_group = false;
++	peer->clientCb = NULL;
+ 
+ 	return peer;
+ }
+@@ -754,8 +853,19 @@ const char *connman_peer_get_identifier(struct connman_peer *peer)
+ 
+ void connman_peer_set_name(struct connman_peer *peer, const char *name)
+ {
++	if (!peer || !name)
++		return;
++
+ 	g_free(peer->name);
+-	peer->name = g_strdup(name);
++	peer->name = g_strdup(strlen(name) ? name : " ");
++}
++
++void connman_peer_dhcpclient_cb(struct connman_peer *peer,GdhcpaddressclientCb callback)
++{
++	if (!peer)
++		return;
++
++	peer->clientCb = callback;
+ }
+ 
+ void connman_peer_set_iface_address(struct connman_peer *peer,
+@@ -774,6 +884,54 @@ void connman_peer_set_device(struct connman_peer *peer,
+ 	peer->device = device;
+ 	connman_device_ref(device);
+ }
++void connman_peer_set_strength(struct connman_peer *peer,
++				unsigned char strength)
++{
++	if (!peer)
++		return;
++
++	peer->strength = strength;
++}
++
++void connman_peer_set_config_methods(struct connman_peer *peer,
++				dbus_uint16_t config_methods)
++{
++	if (!peer)
++		return;
++
++	peer->config_methods = config_methods;
++}
++
++void connman_peer_set_pri_dev_type(struct connman_peer *peer,
++				const char* pri_dev_type)
++{
++	if (!peer)
++		return;
++
++	peer->pri_dev_type = pri_dev_type;
++}
++
++int connman_peer_set_ipaddress(struct connman_peer *peer,
++				const char *address, const char *netmask, const char *gateway)
++{
++	if (!peer)
++		return -EINVAL;
++
++	DBG("");
++
++	__connman_ipconfig_set_method(peer->ipconfig, CONNMAN_IPCONFIG_METHOD_MANUAL);
++	__connman_ipconfig_set_local(peer->ipconfig, address);
++
++	unsigned char prefixlen = connman_ipaddress_calc_netmask_len(netmask);
++	if (prefixlen == 255)
++		connman_warn("netmask: %s is invalid", netmask);
++
++	__connman_ipconfig_set_prefixlen(peer->ipconfig, prefixlen);
++	__connman_ipconfig_set_gateway(peer->ipconfig, gateway);
++	__connman_ipconfig_set_dhcp_address(peer->ipconfig, address);
++
++	return 0;
++}
+ 
+ struct connman_device *connman_peer_get_device(struct connman_peer *peer)
+ {
+@@ -800,12 +958,21 @@ void connman_peer_set_as_master(struct connman_peer *peer, bool master)
+ 	peer->connection_master = master;
+ }
+ 
++void connman_peer_set_as_go(struct connman_peer *peer, bool go)
++{
++	if (!peer || !is_connecting(peer))
++		return;
++
++	peer->is_groupOwner = go;
++}
++
+ static void dhcp_callback(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network,
+ 			bool success, gpointer data)
+ {
+ 	struct connman_peer *peer = data;
+ 	int err;
++	const char *identifier = connman_peer_get_identifier(peer);
+ 
+ 	if (!success)
+ 		goto error;
+@@ -831,7 +998,21 @@ static int start_dhcp_client(struct connman_peer *peer)
+ 
+ 	__connman_ipconfig_enable(peer->ipconfig);
+ 
+-	return __connman_dhcp_start(peer->ipconfig, NULL, dhcp_callback, peer);
++	if (peer->is_static_ip) {
++		dhcp_callback(peer->ipconfig, NULL, true, peer);
++		return 0;
++	} else {
++		return __connman_dhcp_start(peer->ipconfig, NULL, dhcp_callback, peer);
++	}
++}
++
++static void stop_dhcp_client(struct connman_peer *peer)
++{
++	if (peer->is_static_ip) {
++		__connman_ipconfig_set_method(peer->ipconfig, CONNMAN_IPCONFIG_METHOD_DHCP);
++		__connman_ipconfig_address_remove(peer->ipconfig);
++	} else
++		__connman_dhcp_stop(peer->ipconfig);
+ }
+ 
+ static void report_error_cb(void *user_context, bool retry, void *user_data)
+@@ -875,6 +1056,14 @@ static int manage_peer_error(struct connman_peer *peer)
+ 	return 0;
+ }
+ 
++enum connman_peer_state connman_peer_get_state(struct connman_peer *peer)
++{
++	if (!peer)
++		return CONNMAN_PEER_STATE_UNKNOWN;
++
++	return peer->state;
++}
++
+ int connman_peer_set_state(struct connman_peer *peer,
+ 					enum connman_peer_state new_state)
+ {
+@@ -898,8 +1087,12 @@ int connman_peer_set_state(struct connman_peer *peer,
+ 	case CONNMAN_PEER_STATE_ASSOCIATION:
+ 		break;
+ 	case CONNMAN_PEER_STATE_CONFIGURATION:
+-		if (peer->connection_master)
++		if (peer->connection_master) {
++
+ 			err = start_dhcp_server(peer);
++			if (err >= 0 && !peer->is_autonomous_group)
++				__connman_p2p_set_dhcp_pool(peer->ip_pool);
++		}
+ 		else
+ 			err = start_dhcp_client(peer);
+ 		if (err < 0)
+@@ -911,17 +1104,30 @@ int connman_peer_set_state(struct connman_peer *peer,
+ 		__connman_technology_set_connected(CONNMAN_SERVICE_TYPE_P2P, true);
+ 		break;
+ 	case CONNMAN_PEER_STATE_DISCONNECT:
+-		if (peer->connection_master)
++		if (peer->connection_master) {
++			if (!peer->is_autonomous_group)
++				__connman_p2p_set_dhcp_pool(NULL);
+ 			stop_dhcp_server(peer);
+-		else
+-			__connman_dhcp_stop(peer->ipconfig);
++		} else
++			stop_dhcp_client(peer);
++
+ 		peer->connection_master = false;
++		peer->is_groupOwner = false;
+ 		peer->sub_device = NULL;
++		peer->is_autonomous_group = false;
++
++		g_free(peer->dhcp_ip);
++		peer->dhcp_ip = g_strdup("");
++		peer->is_dhcp_ip = false;
++
++		__connman_peer_set_static_ip(peer, NULL);
+ 		__connman_technology_set_connected(CONNMAN_SERVICE_TYPE_P2P, false);
+ 		break;
+ 	case CONNMAN_PEER_STATE_FAILURE:
+-		if (manage_peer_error(peer) == 0)
++		if (manage_peer_error(peer) == 0) {
++			peer->state = new_state;
+ 			return 0;
++		}
+ 		break;
+ 	};
+ 
+@@ -935,11 +1141,77 @@ int connman_peer_set_state(struct connman_peer *peer,
+ 	return 0;
+ }
+ 
+-int connman_peer_request_connection(struct connman_peer *peer)
++static void peer_state_cancelled(gpointer key, gpointer value,
++						gpointer user_data)
++{
++	struct connman_peer *peer = value;
++
++	if (peer && peer->state == CONNMAN_PEER_STATE_ASSOCIATION)
++		connman_peer_set_state(peer, CONNMAN_PEER_STATE_IDLE);
++}
++
++void connman_peer_state_change_by_cancelled(void)
+ {
+-	return __connman_agent_request_peer_authorization(peer,
+-					request_authorization_cb, false,
+-					NULL, NULL);
++	g_hash_table_foreach(peers_table, peer_state_cancelled, NULL);
++}
++
++static gboolean peer_request_changed(gpointer data)
++{
++	struct connman_peerrequest *peer_request = data;
++
++	struct connman_peer *peer = peer_request->peer;
++	int dev_passwd_id = peer_request->dev_passwd_id;
++
++	connman_dbus_property_changed_basic(peer->path,
++					 CONNMAN_PEER_INTERFACE, "P2PGONegRequested",
++					 DBUS_TYPE_INT32, &dev_passwd_id);
++
++	g_free(peer_request);
++
++	return FALSE;
++}
++
++static gboolean peer_invitation_changed(gpointer data)
++{
++	struct connman_peer_invitation *peer_invitation = data;
++	struct connman_peer *peer = g_hash_table_lookup(peers_table, peer_invitation->peer_path);
++
++	if (peer && peer->path && peer->registered) {
++		connman_dbus_property_changed_basic(peer->path,
++						 CONNMAN_PEER_INTERFACE, peer_invitation->signal,
++						 DBUS_TYPE_STRING, &peer_invitation->go_dev_addr);
++	}
++
++	g_free(peer_invitation->peer_path);
++	g_free(peer_invitation->signal);
++	g_free(peer_invitation->go_dev_addr);
++	g_free(peer_invitation);
++
++	return FALSE;
++}
++void connman_peer_request_connection(struct connman_peer *peer, int dev_passwd_id)
++{
++	struct connman_peerrequest *peer_request;
++
++	peer_request = g_malloc0(sizeof(struct connman_peerrequest));
++	peer_request->peer = peer;
++	peer_request->dev_passwd_id = dev_passwd_id;
++
++	g_timeout_add(100, peer_request_changed, peer_request);
++}
++
++void connman_peer_invitation_request(const char* peer_path,
++					const char* signal, const char* go_dev_addr)
++{
++	DBG("Sending %s", signal);
++
++	struct connman_peer_invitation *peer_invitation;
++	peer_invitation = g_malloc0(sizeof(struct connman_peer_invitation));
++	peer_invitation->peer_path = g_strdup(peer_path);
++	peer_invitation->signal = g_strdup(signal);
++	peer_invitation->go_dev_addr = g_strdup(go_dev_addr);
++
++	peer_invitation_changed(peer_invitation);
+ }
+ 
+ static void peer_service_free(gpointer data)
+@@ -1075,6 +1347,7 @@ static const GDBusMethodTable peer_methods[] = {
+ 			get_peer_properties) },
+ 	{ GDBUS_ASYNC_METHOD("Connect", NULL, NULL, connect_peer) },
+ 	{ GDBUS_METHOD("Disconnect", NULL, NULL, disconnect_peer) },
++	{ GDBUS_METHOD("RejectPeer", NULL, NULL, reject_peer) },
+ 	{ },
+ };
+ 
+@@ -1148,6 +1421,36 @@ struct connman_peer *connman_peer_get(struct connman_device *device,
+ 	return peer;
+ }
+ 
++struct connman_peer *connman_peer_get_by_path(const char *path)
++{
++	struct connman_peer *peer;
++
++	peer = g_hash_table_lookup(peers_table, path);
++
++	return peer;
++}
++
++void connman_peer_get_local_address(gpointer user_data, DBusMessageIter *iter)
++{
++	struct connman_peer *peer = user_data;
++	const char *local = "";
++
++	if (peer->ipconfig) {
++		local = __connman_ipconfig_get_local(peer->ipconfig);
++
++		connman_dbus_dict_append_basic(iter, "LocalAddress",
++				DBUS_TYPE_STRING, &local);
++	}
++}
++
++void __connman_peer_get_properties_struct(DBusMessageIter *iter, gpointer user_data)
++{
++	struct connman_peer *peer = user_data;
++
++	append_properties(iter, peer);
++}
++
++
+ int connman_peer_driver_register(struct connman_peer_driver *driver)
+ {
+ 	if (peer_driver && peer_driver != driver)
+@@ -1190,11 +1493,70 @@ static void disconnect_peer_hash_table(gpointer key,
+ 	peer_disconnect(peer);
+ }
+ 
++void __connman_peer_set_autonomous_group(struct connman_peer *peer, bool autonomous_group) {
++	if (!peer)
++		return;
++
++	peer->is_autonomous_group = autonomous_group;
++}
++
++void __connman_peer_set_static_ip(struct connman_peer *peer, char* static_ip) {
++	if (!peer)
++		return;
++
++	if (static_ip) {
++		peer->is_static_ip = true;
++		peer->static_ip = g_strdup(static_ip);
++	} else {
++		peer->is_static_ip = false;
++		if(peer->static_ip) {
++			g_free(peer->static_ip);
++			peer->static_ip = NULL;
++		}
++	}
++}
++
++struct connman_peer *__connman_get_connected_peer(void)
++{
++	GList *list, *start;
++
++	list = g_hash_table_get_values(peers_table);
++	start = list;
++	for (; list; list = list->next) {
++		struct connman_peer *peer = list->data;
++
++		if (peer->state == CONNMAN_PEER_STATE_READY) {
++			g_list_free(start);
++			return peer;
++		}
++	}
++	g_list_free(start);
++	return NULL;
++}
++
+ void __connman_peer_disconnect_all(void)
+ {
+ 	g_hash_table_foreach(peers_table, disconnect_peer_hash_table, NULL);
+ }
+ 
++bool __connman_peer_get_connected_exists(void)
++{
++	GList *list, *start;
++
++	list = g_hash_table_get_values(peers_table);
++	start = list;
++	for (; list; list = list->next) {
++		struct connman_peer *peer = list->data;
++
++		if (peer->state == CONNMAN_PEER_STATE_READY) {
++			g_list_free(start);
++			return true;
++		}
++	}
++	g_list_free(start);
++	return false;
++}
++
+ int __connman_peer_init(void)
+ {
+ 	DBG("");
+diff --git a/src/peer_service.c b/src/peer_service.c
+index a457bff7..c73863c8 100644
+--- a/src/peer_service.c
++++ b/src/peer_service.c
+@@ -228,6 +228,20 @@ static int register_peer_service(struct _peer_service *service)
+ 					service_registration_result, service);
+ }
+ 
++static void unregister_all_services(gpointer key, gpointer value,
++						gpointer user_data)
++{
++	struct _peer_service_owner *ps_owner = value;
++	GList *list;
++
++	for (list = ps_owner->services; list; list = list->next) {
++		struct _peer_service *service = list->data;
++
++		if (service->registered)
++			remove_peer_service(service);
++	}
++}
++
+ static void register_all_services(gpointer key, gpointer value,
+ 						gpointer user_data)
+ {
+@@ -244,11 +258,12 @@ static void register_all_services(gpointer key, gpointer value,
+ 
+ void __connman_peer_service_set_driver(struct connman_peer_driver *driver)
+ {
+-	peer_driver = driver;
+-	if (!peer_driver)
+-		return;
++	if (!driver)
++		g_hash_table_foreach(owners_map, unregister_all_services, NULL);
+ 
+-	g_hash_table_foreach(owners_map, register_all_services, NULL);
++	peer_driver = driver;
++	if (peer_driver)
++		g_hash_table_foreach(owners_map, register_all_services, NULL);
+ }
+ 
+ int __connman_peer_service_register(const char *owner, DBusMessage *msg,
+diff --git a/src/sd.c b/src/sd.c
+new file mode 100644
+index 00000000..9be1bde8
+--- /dev/null
++++ b/src/sd.c
+@@ -0,0 +1,382 @@
++/*
++ *
++ *  Connection Manager
++ *
++ *  Copyright (C) 2018-2021 LG Electronics, Inc.
++ *
++ *  This program is free software; you can redistribute it and/or modify
++ *  it under the terms of the GNU General Public License version 2 as
++ *  published by the Free Software Foundation.
++ *
++ *  This program is distributed in the hope that it will be useful,
++ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *  GNU General Public License for more details.
++ *
++ *  You should have received a copy of the GNU General Public License
++ *  along with this program; if not, write to the Free Software
++ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
++ *
++ */
++
++#ifdef HAVE_CONFIG_H
++#include <config.h>
++#endif
++
++#include <errno.h>
++#include <stdio.h>
++#include <string.h>
++#include <netdb.h>
++#include <gdbus.h>
++#include <ctype.h>
++
++#include "../include/sd.h"
++#include <gsupplicant/gsupplicant.h>
++
++#include "connman.h"
++
++static DBusConnection *connection = NULL;
++static DBusMessage *sd_msg = NULL;
++
++#define DISCOVER_SERVICE_FROM_ALL_PEERS "00:00:00:00:00:00"
++#define UPNP_SERVICE "upnp"
++#define BONJOUR_SERVICE "bonjour"
++
++struct connman_service_discovery {
++	GSupplicantInterface *interface;
++	char *peer_service_prefix;
++};
++
++static struct connman_service_discovery *sd = NULL;
++
++static DBusMessage *set_property(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	DBusMessageIter iter, value;
++	const char *name;
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &name);
++	dbus_message_iter_next(&iter);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_VARIANT)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_recurse(&iter, &value);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static DBusMessage *get_properties(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	DBusMessage *reply;
++	DBusMessageIter array, dict;
++
++	reply = dbus_message_new_method_return(msg);
++	if (reply == NULL)
++		return NULL;
++
++	dbus_message_iter_init_append(reply, &array);
++
++	connman_dbus_dict_open(&array, &dict);
++	connman_dbus_dict_close(&array, &dict);
++
++	return reply;
++}
++
++static void request_device_discovery()
++{
++	__connman_device_request_scan(CONNMAN_SERVICE_TYPE_P2P);
++}
++
++static void request_discover_service_callback(int result, GSupplicantInterface *interface,
++								void *user_data, void* result_data)
++{
++	DBusMessage *reply;
++
++	if(sd_msg == NULL)
++		return;
++
++	if(result < 0) {
++		reply = __connman_error_failed(sd_msg, -result);
++		if(reply != NULL)
++			g_dbus_send_message(connection, reply);
++	} else
++		g_dbus_send_reply(connection, sd_msg,
++								DBUS_TYPE_INT32, &result,
++								DBUS_TYPE_INVALID);
++
++	dbus_message_unref(sd_msg);
++	sd_msg = NULL;
++}
++
++static DBusMessage *request_discover_upnp_service(DBusConnection *conn,
++								DBusMessage *msg, void *user_data)
++{
++	DBusMessageIter iter;
++	const char *address, *description;
++	dbus_int32_t version;
++	GSupplicantP2PSDParams *sd_params;
++	int err;
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &address);
++
++	dbus_message_iter_next(&iter);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_INT32)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &version);
++
++	dbus_message_iter_next(&iter);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &description);
++
++	sd_params = g_try_malloc0(sizeof(GSupplicantP2PSDParams));
++	if(sd_params == NULL)
++		return __connman_error_failed(msg, ENOMEM);
++
++	if(g_str_equal(address, DISCOVER_SERVICE_FROM_ALL_PEERS) == FALSE) {
++		const char *addr_no_colon;
++		GString *str_peer_ident = g_string_new(NULL);
++		char *peer_ident;
++		struct connman_service *service;
++		struct connman_network *network;
++		const char *path;
++
++		addr_no_colon = __connman_util_remove_colon_from_mac_addr(address);
++		if(addr_no_colon == NULL) {
++			g_string_free(str_peer_ident, TRUE);
++			g_free(sd_params);
++			return __connman_error_invalid_arguments(msg);
++                }
++
++		g_string_append_printf(str_peer_ident, "%s_%s", sd->peer_service_prefix, addr_no_colon);
++		g_free(addr_no_colon);
++
++		peer_ident = g_string_free(str_peer_ident, FALSE);
++
++		service = __connman_service_lookup_from_ident(peer_ident);
++		if(service == NULL) {
++			g_free(sd_params);
++			return __connman_error_invalid_arguments(msg);
++		}
++
++		network = __connman_service_get_network(service);
++		path = connman_network_get_string(network, "Path");
++		if(path == NULL) {
++			g_free(sd_params);
++			return __connman_error_invalid_arguments(msg);
++		}
++
++		sd_params->peer = g_strdup(path);
++	}
++	sd_params->service_type = UPNP_SERVICE;
++	sd_params->desc = g_strdup(description);
++	sd_params->version = version;
++
++	err = g_supplicant_interface_p2p_sd_request(sd->interface, sd_params,
++												request_discover_service_callback, NULL);
++
++	if(err == -EINPROGRESS) {
++		sd_msg = dbus_message_ref(msg);
++
++		request_device_discovery();
++	} else {
++		g_free(sd_params);
++		return __connman_error_failed(msg, -err);
++	}
++
++	return NULL;
++}
++
++static DBusMessage *request_discover_bonjour_service(DBusConnection *conn,
++								DBusMessage *msg, void *user_data)
++{
++	DBusMessageIter iter, iter_array;
++	const char *address;
++	unsigned char *query = NULL;
++	int len = 0;
++	GSupplicantP2PSDParams *sd_params;
++	int err;
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &address);
++
++	dbus_message_iter_next(&iter);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_ARRAY)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_recurse(&iter, &iter_array);
++
++	dbus_message_iter_get_fixed_array(&iter_array, &query, &len);
++
++	sd_params = g_try_malloc0(sizeof(GSupplicantP2PSDParams));
++	if(sd_params == NULL)
++		return __connman_error_failed(msg, ENOMEM);
++
++	if(g_str_equal(address, DISCOVER_SERVICE_FROM_ALL_PEERS) == FALSE) {
++		const char *addr_no_colon;
++		GString *str_peer_ident = g_string_new(NULL);
++		char *peer_ident;
++		struct connman_service *service;
++		struct connman_network *network;
++		const char *path;
++
++		addr_no_colon = __connman_util_remove_colon_from_mac_addr(address);
++		if(addr_no_colon == NULL) {
++			g_string_free(str_peer_ident, TRUE);
++			g_free(sd_params);
++			return __connman_error_invalid_arguments(msg);
++                }
++
++		g_string_append_printf(str_peer_ident, "%s_%s", sd->peer_service_prefix, addr_no_colon);
++		g_free(addr_no_colon);
++
++                peer_ident = g_string_free(str_peer_ident, FALSE);
++
++		service = __connman_service_lookup_from_ident(peer_ident);
++		if(service == NULL) {
++			g_free(sd_params);
++			return __connman_error_invalid_arguments(msg);
++		}
++
++		network = __connman_service_get_network(service);
++		path = connman_network_get_string(network, "Path");
++		if(path == NULL) {
++			g_free(sd_params);
++			return __connman_error_invalid_arguments(msg);
++		}
++
++		sd_params->peer = g_strdup(path);
++	}
++	sd_params->query = query;
++	sd_params->query_len = len;
++
++	err = g_supplicant_interface_p2p_sd_request(sd->interface, sd_params,
++												request_discover_service_callback, NULL);
++
++	if(err == -EINPROGRESS) {
++		sd_msg = dbus_message_ref(msg);
++
++		request_device_discovery();
++	} else {
++		g_free(sd_params);
++		return __connman_error_failed(msg, -err);
++	}
++
++	return NULL;
++}
++
++static const GDBusMethodTable sd_methods[] = {
++	{ GDBUS_DEPRECATED_METHOD("GetProperties",
++			NULL, GDBUS_ARGS({ "properties", "a{sv}" }),
++			get_properties) },
++	{ GDBUS_METHOD("SetProperty",
++			GDBUS_ARGS({ "name", "s" }, { "value", "v" }),
++			NULL, set_property) },
++	{ GDBUS_ASYNC_METHOD("RequestDiscoverUPnPService",
++			GDBUS_ARGS({ "address", "s" }, { "version", "i" }, { "description", "s" }),
++			GDBUS_ARGS({ "reference", "i" }),
++			request_discover_upnp_service) },
++	{ GDBUS_ASYNC_METHOD("RequestDiscoverBonjourService",
++			GDBUS_ARGS({ "address", "s" }, { "query", "ay" }),
++			GDBUS_ARGS({ "reference", "i" }),
++			request_discover_bonjour_service) },
++	{},
++};
++
++static const GDBusSignalTable sd_signals[] = {
++	{ GDBUS_SIGNAL("PropertyChanged",
++			GDBUS_ARGS({ "name", "s" }, { "value", "v" })) },
++	{ GDBUS_SIGNAL("DiscoveryResponse",
++			GDBUS_ARGS({ "address", "s" }, { "reference", "i" }, { "tlv", "ay" })) },
++	{ },
++};
++
++static void emit_sd_response(const char *dev_addr, int reference, unsigned char *tlv, int tlv_len)
++{
++	DBusMessage *signal;
++	DBusMessageIter iter, array;
++
++	signal = dbus_message_new_signal(CONNMAN_SD_PATH, CONNMAN_SD_INTERFACE, "DiscoveryResponse");
++	if (signal == NULL)
++		return;
++
++	dbus_message_iter_init_append(signal, &iter);
++	dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &dev_addr);
++	dbus_message_iter_append_basic(&iter, DBUS_TYPE_INT32, &reference);
++	dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE_AS_STRING, &array);
++	dbus_message_iter_append_fixed_array(&array, DBUS_TYPE_BYTE, &tlv, tlv_len);
++	dbus_message_iter_close_container(&iter, &array);
++
++	g_dbus_send_message(connection, signal);
++}
++
++void __connman_sd_response_from_p2p_peer(const char *peer_ident, int reference,
++								unsigned char *tlv, int tlv_len)
++{
++	const char *dev_addr;
++
++	dev_addr = __connman_util_insert_colon_to_mac_addr(peer_ident);
++
++	emit_sd_response(dev_addr, reference, tlv, tlv_len);
++	g_free(dev_addr);
++}
++
++void __connman_sd_init(GSupplicantInterface *interface, const char* dev_ident)
++{
++	connman_bool_t res;
++
++	connection = connman_dbus_get_connection();
++
++	sd = g_try_new0(struct connman_service_discovery, 1);
++	if(sd == NULL)
++		return;
++
++	res = g_dbus_register_interface(connection, CONNMAN_SD_PATH, CONNMAN_SD_INTERFACE,
++									sd_methods, sd_signals,
++									NULL, NULL, NULL);
++
++	if(res == FALSE) {
++		g_free(sd);
++		sd = NULL;
++		return;
++	}
++
++	sd->interface = interface;
++	sd->peer_service_prefix = g_strdup_printf("wifi_%s", dev_ident);
++}
++
++void __connman_sd_cleanup(void)
++{
++	if(connection != NULL)
++		g_dbus_unregister_interface(connection, "/", CONNMAN_SD_INTERFACE);
++
++	if(sd != NULL) {
++		g_free(sd->peer_service_prefix);
++		g_free(sd);
++		sd = NULL;
++	}
++}
+diff --git a/src/service.c b/src/service.c
+index 1d2b78a6..712ade14 100644
+--- a/src/service.c
++++ b/src/service.c
+@@ -58,6 +58,7 @@ static bool services_dirty = false;
+ static bool enable_online_to_ready_transition = false;
+ static unsigned int online_check_initial_interval = 0;
+ static unsigned int online_check_max_interval = 0;
++bool block_auto_connect = FALSE;
+ 
+ struct connman_stats {
+ 	bool valid;
+@@ -7257,6 +7258,11 @@ struct connman_service *__connman_service_lookup_from_index(int index)
+ 	return NULL;
+ }
+ 
++struct connman_service *__connman_service_lookup_from_ident(const char *identifier)
++{
++	return lookup_by_identifier(identifier);
++}
++
+ const char *connman_service_get_identifier(struct connman_service *service)
+ {
+ 	return service ? service->identifier : NULL;
+diff --git a/src/storage.c b/src/storage.c
+index 90f03ebc..2de5c7f8 100644
+--- a/src/storage.c
++++ b/src/storage.c
+@@ -161,6 +161,28 @@ GKeyFile *__connman_storage_load_provider_config(const char *ident)
+ 	return keyfile;
+ }
+ 
++GKeyFile *__connman_storage_open_service(const char *service_id)
++{
++	gchar *pathname;
++	GKeyFile *keyfile = NULL;
++
++	pathname = g_strdup_printf("%s/%s/%s", STORAGEDIR, service_id, SETTINGS);
++	if (!pathname)
++		return NULL;
++
++	keyfile =  storage_load(pathname);
++	if (keyfile) {
++		g_free(pathname);
++		return keyfile;
++	}
++
++	g_free(pathname);
++
++	keyfile = g_key_file_new();
++
++	return keyfile;
++}
++
+ gchar **connman_storage_get_services(void)
+ {
+ 	struct dirent *d;
+@@ -263,6 +285,14 @@ int __connman_storage_save_service(GKeyFile *keyfile, const char *service_id)
+ 	return ret;
+ }
+ 
++static bool is_file_exists(const char *path)
++{
++    if (access(path, F_OK) == -1)
++        return false;
++
++    return true;
++}
++
+ static bool remove_file(const char *service_id, const char *file)
+ {
+ 	gchar *pathname;
+@@ -273,7 +303,12 @@ static bool remove_file(const char *service_id, const char *file)
+ 		return false;
+ 
+ 	if (!g_file_test(pathname, G_FILE_TEST_EXISTS)) {
+-		ret = true;
++		if (!is_file_exists(pathname)) {
++			ret = true;
++		} else {
++			unlink(pathname);
++			ret = true;
++		}
+ 	} else if (g_file_test(pathname, G_FILE_TEST_IS_REGULAR)) {
+ 		unlink(pathname);
+ 		ret = true;
+@@ -452,3 +487,127 @@ gchar **__connman_storage_get_providers(void)
+ 
+ 	return providers;
+ }
++
++gchar **__connman_storage_get_p2p_persistents(void)
++{
++	GSList *list = NULL;
++	int num = 0, i = 0;
++	struct dirent *d;
++	gchar *str;
++	DIR *dir;
++	struct stat buf;
++	int ret;
++	char **persistents;
++	GSList *iter;
++
++	dir = opendir(STORAGEDIR);
++	if (dir == NULL)
++		return NULL;
++
++	while ((d = readdir(dir))) {
++		if (strcmp(d->d_name, ".") == 0 ||
++				strcmp(d->d_name, "..") == 0 ||
++				strncmp(d->d_name, "p2p_persistent_", 15) != 0)
++			continue;
++
++		if (d->d_type == DT_DIR) {
++			str = g_strdup_printf("%s/%s/settings", STORAGEDIR,
++					d->d_name);
++			ret = stat(str, &buf);
++			g_free(str);
++			if (ret < 0)
++				continue;
++			list = g_slist_prepend(list, g_strdup(d->d_name));
++			num += 1;
++		}
++	}
++
++	closedir(dir);
++
++	persistents = g_try_new0(char *, num + 1);
++	for (iter = list; iter != NULL; iter = g_slist_next(iter)) {
++		if (persistents != NULL)
++			persistents[i] = iter->data;
++		else
++			g_free(iter->data);
++		i += 1;
++	}
++	g_slist_free(list);
++
++	return persistents;
++}
++
++int __connman_storage_get_p2p_persistents_count(void)
++{
++	int i;
++	int cnt = 0;
++	gchar **persistents;
++
++	persistents = __connman_storage_get_p2p_persistents();
++
++	for (i = 0; persistents && persistents[i]; i++) {
++		DBG("loop : %s\n", persistents[i]);
++
++		if (strncmp(persistents[i], "p2p_persistent_", 15) != 0)
++			continue;
++
++		cnt++;
++	}
++
++	if (persistents != NULL)
++		g_strfreev(persistents);
++
++	return cnt;
++}
++
++void __connman_storage_del_unlinked_file(void)
++{
++	struct dirent *d, *sub_d;
++	gchar *str, *path;
++	DIR *dir, *sub_dir;
++
++	dir = opendir(STORAGEDIR);
++	if (dir == NULL)
++		return;
++
++	while ((d = readdir(dir))) {
++
++		if (strcmp(d->d_name, ".") == 0 ||
++				strcmp(d->d_name, "..") == 0 ||
++				strncmp(d->d_name, "p2p_", 4) == 0)
++			continue;
++
++		if (d->d_type == DT_DIR) {
++			path = g_strdup_printf("%s/%s/", STORAGEDIR,d->d_name);
++			sub_dir = opendir(path);
++			if (sub_dir == NULL) {
++				g_free(path);
++				continue;
++			}
++
++			while ((sub_d = readdir(sub_dir))) {
++				if (strcmp(sub_d->d_name, ".") == 0 ||
++						strcmp(sub_d->d_name, "..") == 0) {
++					continue;
++				}
++
++				if (strncmp(sub_d->d_name, "settings.", 9) == 0) {
++					str = g_strdup_printf("%s/%s/%s", STORAGEDIR, d->d_name, sub_d->d_name);
++					unlink(str);
++					g_free(str);
++				}
++			}
++			g_free(path);
++			closedir(sub_dir);
++		}
++		else {
++			if (strncmp(d->d_name, "settings.", 9) == 0) {
++				str = g_strdup_printf("%s/%s", STORAGEDIR, d->d_name);
++				unlink(str);
++				g_free(str);
++			}
++		}
++	}
++
++	closedir(dir);
++}
+diff --git a/src/technology.c b/src/technology.c
+index d8c265b1..1332e57c 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -67,6 +67,8 @@ struct connman_technology {
+ 	char *tethering_ident;
+ 	char *tethering_passphrase;
+ 	int tethering_freq;
++	char *tethering_ipaddress;
++	unsigned int tethering_channel;
+ 
+ 	int period;
+ 	int interval;
+@@ -84,6 +86,7 @@ struct connman_technology {
+ 	guint pending_timeout;
+ 
+ 	GSList *scan_pending;
++	GSList *iface_prop_pending;
+ 
+ 	bool rfkill_driven;
+ 	bool softblocked;
+@@ -95,6 +98,7 @@ static GSList *driver_list = NULL;
+ 
+ static int technology_enabled(struct connman_technology *technology);
+ static int technology_disabled(struct connman_technology *technology);
++static int set_p2p_enable(struct connman_technology *technology, bool status);
+ 
+ static gint compare_priority(gconstpointer a, gconstpointer b)
+ {
+@@ -167,12 +171,14 @@ static const char *get_name(enum connman_service_type type)
+ static void technology_save(struct connman_technology *technology)
+ {
+ 	GKeyFile *keyfile;
++	GError *error = NULL;
+ 	gchar *identifier;
+ 	const char *name = get_name(technology->type);
+ 
+ 	DBG("technology %p type %d name %s", technology, technology->type,
+ 									name);
+-	if (!name)
++
++	if (!name || (technology->type == CONNMAN_SERVICE_TYPE_P2P))
+ 		return;
+ 
+ 	keyfile = __connman_storage_load_global();
+@@ -183,8 +189,27 @@ static void technology_save(struct connman_technology *technology)
+ 	if (!identifier)
+ 		goto done;
+ 
+-	g_key_file_set_boolean(keyfile, identifier, "Enable",
+-				technology->enable_persistent);
++	if (technology->type == CONNMAN_SERVICE_TYPE_P2P) {
++			g_key_file_set_boolean(keyfile, "WiFi", "P2PListen",
++						technology->enable_p2p_listen_persistent);
++		goto done;
++	}
++
++	// Update only if a WiFi Enable key is present and new value is ture
++	if (technology->type == CONNMAN_SERVICE_TYPE_WIFI) {
++		g_key_file_get_boolean(keyfile, identifier, "Enable", &error);
++		if (error == NULL) {
++			g_key_file_set_boolean(keyfile, identifier, "Enable",
++						technology->enable_persistent);
++		} else if (error && technology->enable_persistent) {
++			g_key_file_set_boolean(keyfile, identifier, "Enable",
++						technology->enable_persistent);
++			g_clear_error(&error);
++		}
++	} else {
++		g_key_file_set_boolean(keyfile, identifier, "Enable",
++					technology->enable_persistent);
++	}
+ 
+ 	g_key_file_set_boolean(keyfile, identifier, "Tethering",
+ 				technology->tethering_persistent);
+@@ -201,12 +226,15 @@ static void technology_save(struct connman_technology *technology)
+ 		g_free(enc);
+ 	}
+ 
+-	if (technology->tethering_freq == 0)
+-		technology->tethering_freq = 2412;
++	if (technology->tethering_channel)
++		g_key_file_set_integer(keyfile, identifier,
++					"Tethering.Channel",
++					technology->tethering_channel);
+ 
+-	g_key_file_set_integer(keyfile, identifier,
+-				"Tethering.Freq",
+-				technology->tethering_freq);
++	if (technology->tethering_ipaddress)
++		g_key_file_set_string(keyfile, identifier,
++					"Tethering.IP",
++					technology->tethering_ipaddress);
+ 
+ done:
+ 	g_free(identifier);
+@@ -421,11 +449,15 @@ static void technology_load(struct connman_technology *technology)
+ 	keyfile = __connman_storage_load_global();
+ 	/* Fallback on disabling technology if file not found. */
+ 	if (!keyfile) {
+-		if (technology->type == CONNMAN_SERVICE_TYPE_ETHERNET)
++		if (technology->type == CONNMAN_SERVICE_TYPE_ETHERNET || technology->type == CONNMAN_SERVICE_TYPE_WIFI)
+ 			/* We enable ethernet by default */
+ 			technology->enable_persistent = true;
+ 		else
+ 			technology->enable_persistent = false;
++
++		if (technology->type == CONNMAN_SERVICE_TYPE_P2P)
++			technology->enable_p2p_listen_persistent = true;
++
+ 		return;
+ 	}
+ 
+@@ -444,6 +476,15 @@ static void technology_load(struct connman_technology *technology)
+ 
+ 		need_saving = true;
+ 		g_clear_error(&error);
++			if (technology->type == CONNMAN_SERVICE_TYPE_P2P) {
++				enable = g_key_file_get_boolean(keyfile, "WiFi", "P2PListen", &error);
++				if (!error)
++					technology->enable_p2p_listen_persistent = enable;
++				else {
++					technology->enable_p2p_listen_persistent = true;
++					g_clear_error(&error);
++				}
++			}
+ 	}
+ 
+ 	enable = g_key_file_get_boolean(keyfile, identifier,
+@@ -466,9 +507,11 @@ static void technology_load(struct connman_technology *technology)
+ 	if (enc)
+ 		technology->tethering_passphrase = g_strcompress(enc);
+ 
+-	technology->tethering_freq = g_key_file_get_integer(keyfile,
+-				identifier, "Tethering.Freq", NULL);
++	technology->tethering_channel = g_key_file_get_integer(keyfile,
++				identifier, "Tethering.Channel", NULL);
+ 
++	technology->tethering_ipaddress = g_key_file_get_string(keyfile,
++				identifier, "Tethering.IP", NULL);
+ done:
+ 	g_free(identifier);
+ 
+@@ -535,6 +578,48 @@ static bool connman_technology_load_offlinemode(void)
+ 	return offlinemode;
+ }
+ 
++static void append_interfaces(DBusMessageIter *iter, void *user_data)
++{
++	struct connman_technology *technology = user_data;
++	GSList *list;
++
++	for (list = technology->device_list; list; list = list->next) {
++		struct connman_device *device = list->data;
++		const char *iface = connman_device_get_interface(device);
++
++		dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, &iface);
++	}
++}
++
++static void interface_changed(struct connman_technology *technology)
++{
++	DBG("interface_changed for path  %s", technology->path);
++	connman_dbus_property_changed_array(technology->path,
++						CONNMAN_TECHNOLOGY_INTERFACE,
++						"Interfaces",
++						DBUS_TYPE_STRING,
++						append_interfaces, technology);
++}
++
++void connman_technology_interface_changed(struct connman_technology *technology)
++{
++	interface_changed(technology);
++}
++
++static void append_p2plistenparams(DBusMessageIter *iter, void *user_data)
++{
++	struct connman_technology *technology = user_data;
++
++	if (!technology)
++		return;
++
++	connman_dbus_dict_append_basic(iter, "Period",
++					DBUS_TYPE_INT32, &technology->period);
++
++	connman_dbus_dict_append_basic(iter, "Interval",
++					DBUS_TYPE_INT32, &technology->interval);
++}
++
+ static void append_properties(DBusMessageIter *iter,
+ 		struct connman_technology *technology)
+ {
+@@ -570,6 +655,11 @@ static void append_properties(DBusMessageIter *iter,
+ 					DBUS_TYPE_BOOLEAN,
+ 					&val);
+ 
++	connman_dbus_dict_append_array(&dict, "Interfaces",
++					DBUS_TYPE_STRING,
++					append_interfaces,
++					technology);
++
+ 	if (technology->tethering_ident)
+ 		connman_dbus_dict_append_basic(&dict, "TetheringIdentifier",
+ 					DBUS_TYPE_STRING,
+@@ -584,6 +674,28 @@ static void append_properties(DBusMessageIter *iter,
+ 				DBUS_TYPE_INT32,
+ 				&technology->tethering_freq);
+ 
++	if(technology->p2p_identifier)
++		connman_dbus_dict_append_basic(&dict, "P2PIdentifier",
++					DBUS_TYPE_STRING,
++					&technology->p2p_identifier);
++
++	val = technology->p2p_persistent;
++	connman_dbus_dict_append_basic(&dict, "P2PPersistent",
++					DBUS_TYPE_BOOLEAN,
++					&val);
++
++	connman_dbus_dict_append_dict(&dict, "P2PListenParams",
++					append_p2plistenparams, technology);
++
++	connman_dbus_dict_append_basic(&dict, "P2PListenChannel",
++					DBUS_TYPE_UINT32,
++					&technology->p2p_listen_channel);
++
++	val = technology->p2p_listen;
++	connman_dbus_dict_append_basic(&dict, "P2PListen",
++					DBUS_TYPE_BOOLEAN,
++					&val);
++
+ 	connman_dbus_dict_close(iter, &dict);
+ }
+ 
+@@ -745,16 +857,23 @@ static int technology_enabled(struct connman_technology *technology)
+ 	if (technology->enabled)
+ 		return -EALREADY;
+ 
+-	technology->enabled = true;
+-
++	struct connman_technology *p2p;
+ 	if (technology->type == CONNMAN_SERVICE_TYPE_WIFI) {
+-		struct connman_technology *p2p;
+-
++		
+ 		p2p = technology_find(CONNMAN_SERVICE_TYPE_P2P);
+-		if (p2p && !p2p->enabled && p2p->enable_persistent)
++		if (p2p && !p2p->enabled && p2p->enable_persistent){
+ 			technology_enabled(p2p);
++		}
+ 	}
+ 
++	if (technology->type == CONNMAN_SERVICE_TYPE_P2P) {
++		p2p = technology_find(CONNMAN_SERVICE_TYPE_P2P);
++		if (p2p){
++			(void)set_p2p_enable(p2p,true);
++		}
++	}
++
++	technology->enabled = true;
+ 	if (technology->tethering_persistent)
+ 		enable_tethering(technology);
+ 
+@@ -808,6 +927,10 @@ static int technology_disabled(struct connman_technology *technology)
+ 	if (!technology->enabled)
+ 		return -EALREADY;
+ 
++	if (technology->type == CONNMAN_SERVICE_TYPE_P2P) {
++		(void)set_p2p_enable(technology,false);
++	}
++
+ 	technology->enabled = false;
+ 
+ 	powered_changed(technology);
+@@ -826,7 +949,7 @@ static int technology_disable(struct connman_technology *technology)
+ 	if (technology->type == CONNMAN_SERVICE_TYPE_P2P) {
+ 		technology->enable_persistent = false;
+ 		__connman_device_stop_scan(CONNMAN_SERVICE_TYPE_P2P);
+-		__connman_peer_disconnect_all();
++		//__connman_peer_disconnect_all();
+ 		return technology_disabled(technology);
+ 	} else if (technology->type == CONNMAN_SERVICE_TYPE_WIFI) {
+ 		struct connman_technology *p2p;
+@@ -855,6 +978,51 @@ static int technology_disable(struct connman_technology *technology)
+ 	return err;
+ }
+ 
++static int remove_persistent_info(struct connman_technology *technology,
++													const char *identifier)
++{
++	int result = -EOPNOTSUPP;
++	GSList *tech_drivers;
++
++	__sync_synchronize();
++	if (technology->enabled == FALSE)
++		return -EACCES;
++
++	for (tech_drivers = technology->driver_list; tech_drivers != NULL;
++		tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (driver == NULL || driver->remove_persistent_info == NULL)
++			continue;
++
++		result = driver->remove_persistent_info(technology, identifier);
++	}
++
++	return result;
++}
++
++static int remove_persistent_info_all(struct connman_technology *technology)
++{
++	int result = -EOPNOTSUPP;
++	GSList *tech_drivers;
++
++	__sync_synchronize();
++	if (technology->enabled == FALSE)
++		return -EACCES;
++
++	for (tech_drivers = technology->driver_list; tech_drivers != NULL;
++		tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (driver == NULL || driver->remove_persistent_info_all == NULL)
++			continue;
++
++		result = driver->remove_persistent_info_all(technology);
++	}
++
++	return result;
++}
++
+ static DBusMessage *set_powered(struct connman_technology *technology,
+ 				DBusMessage *msg, bool powered)
+ {
+@@ -893,6 +1061,10 @@ make_reply:
+ 
+ 	return reply;
+ }
++bool connman_technology_get_enable_p2p_listen(struct connman_technology *technology)
++{
++	return technology->enable_p2p_listen_persistent;
++}
+ bool connman_technology_get_p2p_listen(struct connman_technology *technology)
+ {
+ 	return technology->p2p_listen;
+@@ -914,6 +1086,17 @@ void connman_technology_set_p2p_listen(struct connman_technology *technology, bo
+ 			DBUS_TYPE_BOOLEAN,
+ 			&listen_enabled);
+ }
++
++void __connman_technology_p2p_invitation_result(struct connman_technology *technology, int status)
++{
++	if(technology->type != CONNMAN_SERVICE_TYPE_P2P)
++		return;
++
++	connman_dbus_property_changed_basic(technology->path,
++			CONNMAN_TECHNOLOGY_INTERFACE, "P2PInvitationResult",
++			DBUS_TYPE_INT32, &status);
++}
++
+ static DBusMessage *set_p2p_listen(struct connman_technology *technology,
+ 				DBusMessage *msg, bool enable)
+ {
+@@ -993,6 +1176,43 @@ void connman_technology_set_p2p_listen_channel(struct connman_technology *techno
+ 				&technology->p2p_listen_channel);
+ 	}
+ }
++
++bool connman_technology_get_p2p_persistent(struct connman_technology *technology)
++{
++	return technology->p2p_persistent;
++}
++
++void connman_technology_set_p2p_persistent(struct connman_technology *technology, bool enabled)
++{
++	GSList *tech_drivers;
++	int err = 0;
++	dbus_bool_t persistent_enabled;
++
++	if (technology->p2p_persistent == enabled)
++		return;
++
++	technology->p2p_persistent = enabled;
++
++	for (tech_drivers = technology->driver_list; tech_drivers != NULL;
++		tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_persistent)
++			continue;
++
++		err = driver->set_p2p_persistent(technology, enabled);
++		if (err < 0)
++			connman_error("Failed to set P2P persistent state");
++	}
++
++	persistent_enabled = technology->p2p_persistent;
++	connman_dbus_property_changed_basic(technology->path,
++			CONNMAN_TECHNOLOGY_INTERFACE,
++			"P2PPersistent",
++			DBUS_TYPE_BOOLEAN,
++			&persistent_enabled);
++}
++
+ static DBusMessage *set_p2p_persistent(struct connman_technology *technology,
+ 													DBusMessage *msg, bool enabled)
+ {
+@@ -1038,6 +1258,27 @@ make_reply:
+ 
+ 	return reply;
+ }
++
++void connman_technology_set_p2p_identifier(struct connman_technology *technology, const char *p2p_identifier)
++{
++
++	if (technology->p2p_identifier) {
++		g_free(technology->p2p_identifier);
++		technology->p2p_identifier = NULL;
++	}
++
++	if(p2p_identifier == NULL)
++		return;
++
++	technology->p2p_identifier = g_strdup(p2p_identifier);
++
++	connman_dbus_property_changed_basic(technology->path,
++			CONNMAN_TECHNOLOGY_INTERFACE,
++			"P2PIdentifier",
++			DBUS_TYPE_STRING,
++			&technology->p2p_identifier);
++}
++
+ static int set_p2p_identifier(struct connman_technology *technology,
+ 											const char *p2p_identifier)
+ {
+@@ -1212,6 +1453,62 @@ make_reply:
+ 	return reply;
+ }
+ 
++static int set_p2p_enable(struct connman_technology *technology,
++				 bool status)
++{
++	int err = 0;
++	GSList *tech_drivers = NULL;
++
++	__sync_synchronize();
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P) {
++		return -EOPNOTSUPP;
++	}
++
++
++	for (tech_drivers = technology->driver_list; tech_drivers != NULL;
++			tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_enable)
++			continue;
++
++		err = driver->set_p2p_enable(technology, status);
++		return err;
++	}
++
++	return err;
++}
++
++void connman_technology_set_p2p(struct connman_technology *technology, bool enabled)
++{
++	dbus_bool_t p2p_enabled;
++	DBG("Set p2p enable..enter");
++
++	if (!technology) {
++		DBG("Set p2p enable..tech null");
++		return;
++	}
++
++	if (enabled == technology->enabled)
++		return;
++
++	technology->enabled = enabled;
++	p2p_enabled = enabled;
++
++	powered_changed(technology);
++
++	connman_dbus_property_changed_basic(technology->path,
++		CONNMAN_TECHNOLOGY_INTERFACE,
++		"P2P",
++		DBUS_TYPE_BOOLEAN,
++		&p2p_enabled);
++}
++
++bool is_technology_enabled(struct connman_technology *technology)
++{
++	return technology == NULL ? false : technology->enabled;
++}
++
+ static DBusMessage *set_property(DBusConnection *conn,
+ 					DBusMessage *msg, void *data)
+ {
+@@ -1414,6 +1711,24 @@ static DBusMessage *set_property(DBusConnection *conn,
+ 		dbus_message_iter_get_basic(&value, &enable);
+ 
+ 		return set_powered(technology, msg, enable);
++	}	else if (g_str_equal(name, "RemovePersistentInfo") == TRUE) {
++		const char *identifier;
++		int res;
++
++		dbus_message_iter_get_basic(&value, &identifier);
++
++		if (technology->type != CONNMAN_SERVICE_TYPE_P2P)
++			return __connman_error_not_supported(msg);
++
++		if (!strncmp(identifier, "all", 3))
++			res = remove_persistent_info_all(technology);
++		else if (strlen(identifier) != 17)
++			return __connman_error_invalid_arguments(msg);
++		else
++			res = remove_persistent_info(technology, identifier);
++
++		if (res < 0)
++			return __connman_error_failed(msg, -res);
+ 	} else
+ 		return __connman_error_invalid_property(msg);
+ 
+@@ -1513,6 +1828,46 @@ void __connman_technology_notify_regdom_by_device(struct connman_device *device,
+ 	connman_technology_regdom_notify(technology, alpha2);
+ }
+ 
++int __connman_technology_set_p2p_go(DBusMessage *msg, const char *ident, const char *passphrase)
++{
++	struct connman_technology *technology;
++	GSList *tech_drivers;
++	int result = 0;
++	int err;
++
++	technology = technology_find(CONNMAN_SERVICE_TYPE_P2P);
++
++	DBG("technology %p", technology);
++
++	if (!technology)
++		return -EINVAL;
++
++	if (strlen(ident) < 1 || strlen(passphrase) < 1){
++		ident = NULL;
++		passphrase = NULL;
++	}
++
++	for (tech_drivers = technology->driver_list; tech_drivers;
++			tech_drivers = g_slist_next(tech_drivers)) {
++		struct connman_technology_driver *driver = tech_drivers->data;
++
++		if (!driver || !driver->set_p2p_go)
++			continue;
++
++		err = driver->set_p2p_go(msg, technology, ident, passphrase);
++
++		if (result == -EINPROGRESS)
++			continue;
++
++		if (err == -EINPROGRESS || err == 0) {
++			result = err;
++			continue;
++		}
++	}
++
++	return 0;
++}
++
+ static DBusMessage *scan(DBusConnection *conn, DBusMessage *msg, void *data)
+ {
+ 	struct connman_technology *technology = data;
+@@ -1535,7 +1890,112 @@ static DBusMessage *scan(DBusConnection *conn, DBusMessage *msg, void *data)
+ 
+ 	return NULL;
+ }
++void connman_technology_wps_failed_notify(struct connman_technology *technology)
++{
++	g_dbus_emit_signal(connection, technology->path,
++		CONNMAN_TECHNOLOGY_INTERFACE, "WPSFailed",
++		DBUS_TYPE_INVALID);
++}
++static DBusMessage *cancel_p2p(DBusConnection *conn, DBusMessage *msg, void *data)
++{
++	struct connman_technology *technology = data;
++	int err;
+ 
++	if (technology->type != CONNMAN_SERVICE_TYPE_P2P &&
++				!technology->enabled)
++		return __connman_error_failed(msg, EOPNOTSUPP);
++
++	err = __connman_device_request_cancel_p2p(technology->type);
++	if (err < 0)
++		return __connman_error_failed(msg, -err);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static void reply_interface_properties(struct connman_device *device, void *user_data)
++{
++	DBusMessage *msg = user_data;
++	DBusMessage *reply;
++	DBusMessageIter iter, dict;
++
++	reply = dbus_message_new_method_return(msg);
++	if (!reply) {
++		reply = __connman_error_failed(msg, ENOMEM);
++		g_dbus_send_message(connection, reply);
++		dbus_message_unref(msg);
++		return;
++	}
++
++	dbus_message_iter_init_append(reply, &iter);
++
++	connman_dbus_dict_open(&iter, &dict);
++
++	if (connman_device_get_type(device) == CONNMAN_DEVICE_TYPE_WIFI) {
++		uint32_t value = 0;
++
++		value = connman_device_get_integer(device, "WiFi.RSSI");
++		connman_dbus_dict_append_basic(&dict, "WiFi.RSSI",
++								DBUS_TYPE_UINT32, &value);
++
++		value = connman_device_get_integer(device, "WiFi.LinkSpeed");
++		connman_dbus_dict_append_basic(&dict, "WiFi.LinkSpeed",
++								DBUS_TYPE_UINT32, &value);
++
++		value = connman_device_get_integer(device, "WiFi.Frequency");
++		connman_dbus_dict_append_basic(&dict, "WiFi.Frequency",
++								DBUS_TYPE_UINT32, &value);
++
++		value = connman_device_get_integer(device, "WiFi.Noise");
++		connman_dbus_dict_append_basic(&dict, "WiFi.Noise",
++								DBUS_TYPE_UINT32, &value);
++	}
++
++	connman_dbus_dict_close(&iter, &dict);
++
++	g_dbus_send_message(connection, reply);
++
++	dbus_message_unref(msg);
++}
++static DBusMessage *get_interface_properties(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	struct connman_technology *technology = user_data;
++	DBusMessageIter iter;
++	GSList *list;
++	char *interface = NULL;
++
++	if (!dbus_message_iter_init(msg, &iter))
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &interface);
++
++	if (!interface)
++		return __connman_error_invalid_arguments(msg);
++
++	struct connman_device *device = NULL;
++
++	for (list = technology->device_list; list; list = list->next) {
++		struct connman_device *current_device = list->data;
++		const char *iface = connman_device_get_interface(current_device);
++
++		if (g_strcmp0(iface, interface) == 0) {
++			device = current_device;
++			break;
++		}
++	}
++
++	if (!device)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_ref(msg);
++
++	connman_device_request_signal_info(device, reply_interface_properties, msg);
++
++	return NULL;
++}
+ static const GDBusMethodTable technology_methods[] = {
+ 	{ GDBUS_DEPRECATED_METHOD("GetProperties",
+ 			NULL, GDBUS_ARGS({ "properties", "a{sv}" }),
+@@ -1544,6 +2004,11 @@ static const GDBusMethodTable technology_methods[] = {
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" }),
+ 			NULL, set_property) },
+ 	{ GDBUS_ASYNC_METHOD("Scan", NULL, NULL, scan) },
++	{ GDBUS_METHOD("CancelP2P", NULL, NULL, cancel_p2p) },
++	{ GDBUS_ASYNC_METHOD("GetInterfaceProperties",
++			GDBUS_ARGS({ "interface", "s" }),
++			GDBUS_ARGS({ "properties", "a{sv}"}),
++			get_interface_properties) },
+ 	{ },
+ };
+ 
+@@ -1625,6 +2090,7 @@ static void technology_put(struct connman_technology *technology)
+ 	g_free(technology->regdom);
+ 	g_free(technology->tethering_ident);
+ 	g_free(technology->tethering_passphrase);
++	g_free(technology->p2p_identifier);
+ 	g_free(technology);
+ }
+ 
+@@ -1866,8 +2332,8 @@ void __connman_technology_remove_interface(enum connman_service_type type,
+ 	}
+ 
+ 	name = connman_inet_ifname(index);
+-	connman_info("Remove interface %s [ %s ]", name,
+-				__connman_service_type2string(type));
++	connman_info("Remove interface %s [ %s ] index %d", name,
++				__connman_service_type2string(type), index);
+ 	g_free(name);
+ 
+ 	technology = technology_find(type);
+@@ -1932,7 +2398,13 @@ int __connman_technology_add_device(struct connman_device *device)
+ 		__connman_device_disable(device);
+ 
+ done:
+-	technology->device_list = g_slist_prepend(technology->device_list,
++	if (connman_setting_get_bool("SupportP2P0Interface") == TRUE &&
++					g_strcmp0(connman_device_get_string(device, "Interface"),
++						connman_option_get_string("WiFiDevice")) == 0)
++		technology->device_list = g_slist_append(technology->device_list,
++								device);
++	else
++		technology->device_list = g_slist_prepend(technology->device_list,
+ 								device);
+ 
+ 	return 0;
+@@ -2300,3 +2772,42 @@ void __connman_technology_cleanup(void)
+ 
+ 	dbus_connection_unref(connection);
+ }
++
++static void append_station_mac(DBusMessageIter *iter, void *user_data)
++{
++	GHashTable *sta_hash = __connman_tethering_get_sta_hash();
++
++	if (sta_hash == NULL)
++		return;
++
++	GHashTableIter iterator;
++	gpointer key, value;
++	g_hash_table_iter_init (&iterator, sta_hash);
++
++	struct connman_station_info *info_found;
++
++	while (g_hash_table_iter_next (&iterator, &key, &value))
++	{
++		info_found = value;
++		const char* temp = info_found->mac;
++		dbus_message_iter_append_basic(iter,
++						DBUS_TYPE_STRING, &temp);
++	}
++}
++
++void __connman_technology_sta_count_changed(enum connman_service_type type, int stacount)
++{
++	struct connman_technology *technology;
++
++	technology = technology_find(type);
++	if (technology == NULL)
++		return;
++
++	connman_dbus_property_changed_basic(technology->path,
++					CONNMAN_TECHNOLOGY_INTERFACE, "StaCount",
++					DBUS_TYPE_INT32, &stacount);
++
++	connman_dbus_property_changed_array(technology->path,
++					CONNMAN_TECHNOLOGY_INTERFACE, "StationMac",
++					DBUS_TYPE_STRING, append_station_mac, NULL);
++}
+diff --git a/src/tethering.c b/src/tethering.c
+index f930a26b..784917d5 100644
+--- a/src/tethering.c
++++ b/src/tethering.c
+@@ -29,6 +29,7 @@
+ #include <sys/stat.h>
+ #include <unistd.h>
+ #include <stdio.h>
++#include <stdbool.h>
+ #include <sys/ioctl.h>
+ #include <net/if.h>
+ #include <string.h>
+@@ -49,9 +50,13 @@
+ #endif
+ 
+ #define BRIDGE_NAME "tether"
++#define SUBNET_MASK_24 "255.255.255.0"
+ 
+ #define DEFAULT_MTU	1500
+ 
++#define CONNMAN_STATION_STR_INFO_LEN 64
++#define CONNMAN_STATION_MAC_INFO_LEN 32
++
+ static char *private_network_primary_dns = NULL;
+ static char *private_network_secondary_dns = NULL;
+ 
+@@ -60,6 +65,7 @@ static GDHCPServer *tethering_dhcp_server = NULL;
+ static struct connman_ippool *dhcp_ippool = NULL;
+ static DBusConnection *connection;
+ static GHashTable *pn_hash;
++static GHashTable *sta_hash;
+ 
+ static GHashTable *clients_table;
+ 
+@@ -82,6 +88,75 @@ struct connman_private_network {
+ 	char *primary_dns;
+ 	char *secondary_dns;
+ };
++int connman_technology_tethering_add_station(enum connman_service_type type,
++                                               const char *mac)
++{
++	const char *str_type;
++	char *lower_mac;
++	char *path;
++	struct connman_station_info *station_info;
++
++	__sync_synchronize();
++
++	DBG("type %d", type);
++
++	str_type = __connman_service_type2string(type);
++	if (str_type == NULL)
++		return 0;
++
++	path = g_strdup_printf("%s/technology/%s", CONNMAN_PATH, str_type);
++
++	station_info = g_try_new0(struct connman_station_info, 1);
++	if(station_info == NULL)
++		return -ENOMEM;
++
++	lower_mac = g_ascii_strdown(mac, -1);
++
++	memcpy(station_info->mac, lower_mac, strlen(lower_mac) + 1);
++	station_info->path = path;
++	station_info->type = g_strdup(str_type);
++
++	g_hash_table_insert(sta_hash, station_info->mac, station_info);
++
++	g_free(lower_mac);
++	return 0;
++}
++int connman_technology_tethering_remove_station(const char *mac)
++{
++	char *lower_mac;
++	struct connman_station_info *info_found;
++
++	__sync_synchronize();
++
++	lower_mac = g_ascii_strdown(mac, -1);
++
++	info_found = g_hash_table_lookup(sta_hash, lower_mac);
++	if (info_found == NULL)
++		return -EACCES;
++
++	g_free(lower_mac);
++	g_hash_table_remove(sta_hash, info_found->mac);
++	g_free(info_found->path);
++	g_free(info_found->type);
++	g_free(info_found);
++
++	return 0;
++}
++int __connman_tethering_sta_count()
++{
++	if (sta_hash != NULL)
++		return g_hash_table_size(sta_hash);
++	else
++		return 0;
++}
++
++GHashTable *__connman_tethering_get_sta_hash()
++{
++	if (sta_hash != NULL)
++		return sta_hash;
++	else
++		return NULL;
++}
+ 
+ const char *__connman_tethering_get_bridge(void)
+ {
+diff --git a/src/util.c b/src/util.c
+index 03b14cdc..78a312ca 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -102,3 +102,108 @@ unsigned int __connman_util_random_delay_ms(unsigned int secs)
+        __connman_util_get_random(&rand);
+        return rand % (secs * 1000);
+ }
++
++char *__connman_util_insert_colon_to_mac_addr(const char *mac_addr)
++{
++	char *result = g_try_malloc(18);
++	int i;
++
++	if (!mac_addr || strlen(mac_addr) < 12) {
++		g_free(result);
++		return NULL;
++	}
++
++	for (i=0; i<6; i++) {
++		result[i*3] = mac_addr[i*2];
++		result[i*3+1] = mac_addr[i*2+1];
++	}
++
++	result[2] = ':';
++	result[5] = ':';
++	result[8] = ':';
++	result[11] = ':';
++	result[14] = ':';
++	result[17] = '\0';
++
++	DBG("before: %s, after: %s", mac_addr, result);
++
++	return result;
++}
++
++char *__connman_util_remove_colon_from_mac_addr(const char *mac_addr)
++{
++	char *result;
++	int i=0;
++
++	if(mac_addr == NULL || strlen(mac_addr) != 17)
++		return NULL;
++
++	result = g_try_malloc(13);
++	if(result == NULL)
++		return NULL;
++
++	for(i=0; i<6; i++) {
++		result[i*2] = mac_addr[i*3];
++		result[i*2+1] = mac_addr[i*3+1];
++	}
++	result[12] = '\0';
++
++	return result;
++}
++
++
++void __connman_util_byte_to_string(unsigned char *src, char *dest, int len)
++{
++	int i=0;
++
++	for(i=0; i<len; i++) {
++		snprintf(&dest[i*2], 3, "%02x", src[i]);
++	}
++
++	dest[len*2] = '\0';
++}
++
++char *__connman_util_mac_binary_to_string(const unsigned char binmac[6]){
++	return g_strdup_printf("%02x:%02x:%02x:%02x:%02x:%02x",
++	                       binmac[0], binmac[1], binmac[2],
++	                       binmac[3], binmac[4], binmac[5]);
++}
++
++char *__connman_util_mac_binary_to_string_no_colon(const unsigned char binmac[6]){
++	return g_strdup_printf("%02x%02x%02x%02x%02x%02x",
++	                       binmac[0], binmac[1], binmac[2],
++	                       binmac[3], binmac[4], binmac[5]);
++}
++
++char *__connman_util_ipaddr_binary_to_string(const unsigned char addr[4]){
++	return g_strdup_printf("%u.%u.%u.%u",
++	                       addr[0], addr[1], addr[2], addr[3]);
++}
++
++static unsigned char char_to_hex_value(char c)
++{
++	c = toupper(c);
++
++	if (c >= 'A')
++		return c - 'A' + 10;
++	else
++		return c - '0';
++}
++
++static unsigned char char2_to_hex_value(const char c[2])
++{
++	return char_to_hex_value(c[0]) * 16 + char_to_hex_value(c[1]);
++}
++
++void __connman_util_mac_string_to_binary(const char* mac_string, unsigned char binmac[6])
++{
++	if (mac_string == NULL || strlen(mac_string) != 17)
++		return;
++
++	binmac[0] = char2_to_hex_value(mac_string);
++	binmac[1] = char2_to_hex_value(mac_string+3);
++	binmac[2] = char2_to_hex_value(mac_string+6);
++	binmac[3] = char2_to_hex_value(mac_string+9);
++	binmac[4] = char2_to_hex_value(mac_string+12);
++	binmac[5] = char2_to_hex_value(mac_string+15);
++}

--- a/meta-luneos/recipes-connectivity/connman/connman/0003-Add-Changes-for-p2p-addService-setwifidisplayinfo-fi.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0003-Add-Changes-for-p2p-addService-setwifidisplayinfo-fi.patch
@@ -1,0 +1,615 @@
+From 029a398daeb95c89b615dca6c08501aabd5bde2b Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Thu, 27 Oct 2022 18:50:35 +0530
+Subject: [PATCH] Add Changes for p2p addService, setwifidisplayinfo,
+ findService api
+
+:Release Notes:
+Add Changes for p2p addService, setwifidisplayinfo, findService api
+
+:Detailed Notes:
+Add Changes for p2p addService, setwifidisplayinfo, findService api
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11085] - Add Changes for p2p addService, setwifidisplayinfo,
+              findService api
+
+Change-Id: Ibacea86fb166383574f1a24512b94bbf4392a39f
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338046
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ gdhcp/server.c       |   3 ++
+ include/technology.h |   7 ++-
+ plugins/ethernet.c   |   3 ++
+ plugins/wifi.c       |  22 ++++----
+ src/manager.c        |   8 +--
+ src/service.c        |  95 ++++++++++++++++++++++++++++++---
+ src/technology.c     | 102 +++++++++++++++++++++++++++--------
+ src/tethering.c      | 124 +++++++++++++++++++++++++++++++++++++++++++
+ 8 files changed, 316 insertions(+), 48 deletions(-)
+
+diff --git a/gdhcp/server.c b/gdhcp/server.c
+index 52ea2a55..f82c4bbd 100644
+--- a/gdhcp/server.c
++++ b/gdhcp/server.c
+@@ -255,6 +255,9 @@ static uint32_t find_free_or_expired_nip(GDHCPServer *dhcp_server,
+ 		if ((ip_addr & 0xff) == 0xff)
+ 			continue;
+ 
++		if (htonl(ip_addr) == dhcp_server->server_nip)
++			continue;
++
+ 		lease = find_lease_by_nip(dhcp_server, ip_addr);
+ 		if (lease)
+ 			continue;
+diff --git a/include/technology.h b/include/technology.h
+index 124dbb07..4accc58d 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -45,10 +45,9 @@ void connman_technology_regdom_notify(struct connman_technology *technology,
+ 
+ enum connman_service_type connman_technology_get_type
+ 				(struct connman_technology *technology);
+-
+-bool connman_technology_get_wifi_tethering(const struct connman_technology *technology,
+-					const char **ssid, const char **psk, int *freq);
+-
++bool connman_technology_get_wifi_tethering(const char **ssid,
++							const char **psk);
++unsigned int connman_technology_get_wifi_tethering_channel(void);
+ bool connman_technology_is_tethering_allowed(enum connman_service_type type);
+ bool is_technology_enabled(struct connman_technology *technology);
+ 
+diff --git a/plugins/ethernet.c b/plugins/ethernet.c
+index 0bf7fc41..27a3dcf3 100644
+--- a/plugins/ethernet.c
++++ b/plugins/ethernet.c
+@@ -347,6 +347,7 @@ static void eth_tech_add_interface(struct connman_technology *technology,
+ 
+ 	eth_interface_list = g_list_prepend(eth_interface_list,
+ 					(GINT_TO_POINTER((int) index)));
++	connman_technology_interface_changed(technology);
+ }
+ 
+ static void eth_tech_remove_interface(struct connman_technology *technology,
+@@ -356,6 +357,7 @@ static void eth_tech_remove_interface(struct connman_technology *technology,
+ 
+ 	eth_interface_list = g_list_remove(eth_interface_list,
+ 					GINT_TO_POINTER((int) index));
++	connman_technology_interface_changed(technology);
+ }
+ 
+ static void eth_tech_enable_tethering(struct connman_technology *technology,
+@@ -407,6 +409,7 @@ static void eth_tech_disable_tethering(struct connman_technology *technology,
+ }
+ 
+ static int eth_tech_set_tethering(struct connman_technology *technology,
++				const char *identifier, const char *passphrase,
+ 				const char *bridge, bool enabled)
+ {
+ 	if (!connman_technology_is_tethering_allowed(
+diff --git a/plugins/wifi.c b/plugins/wifi.c
+index f2a5302a..101c0e7a 100644
+--- a/plugins/wifi.c
++++ b/plugins/wifi.c
+@@ -6000,29 +6000,27 @@ static void tech_remove(struct connman_technology *technology)
+ 
+ static GSupplicantSSID *ssid_ap_init(const char *ssid, const char *passphrase)
+ {
+-    struct connman_technology *technology;
++    
+ 	GSupplicantSSID *ap;
+-	int freq;
+-	bool ret;
++	unsigned int channel;
++	unsigned int freq;
+ 
+ 	ap = g_try_malloc0(sizeof(GSupplicantSSID));
+ 	if (!ap)
+ 		return NULL;
+ 
+-	ret = connman_technology_get_wifi_tethering(technology,
+-						&ssid, &passphrase,
+-						&freq);
+-	if (ret == false)
+-		return NULL;
++	channel = connman_technology_get_wifi_tethering_channel();
++
++	if (channel)
++		freq = 2412 + ((channel - 1) * 5);
++	else
++		freq = 2412;
+ 
+ 	ap->mode = G_SUPPLICANT_MODE_MASTER;
+ 	ap->ssid = ssid;
+ 	ap->ssid_len = strlen(ssid);
+ 	ap->scan_ssid = 0;
+-	if (freq)
+-		ap->freq = freq;
+-	else
+-		ap->freq = 2412;
++	ap->freq = freq;
+ 
+ 	if (!passphrase || strlen(passphrase) == 0) {
+ 		ap->security = G_SUPPLICANT_SECURITY_NONE;
+diff --git a/src/manager.c b/src/manager.c
+index e325c908..5442756b 100644
+--- a/src/manager.c
++++ b/src/manager.c
+@@ -432,7 +432,8 @@ static int parse_peers_service_specs(DBusMessageIter *array,
+ 							query, query_len);
+ 		} else if (!g_strcmp0(key, "UpnpService")) {
+ 			dbus_message_iter_get_basic(&inter, spec);
+-			*spec_len = strlen((const char *)*spec)+1;
++			if (*spec)
++				*spec_len = strlen((const char *)*spec)+1;
+ 		} else if (!g_strcmp0(key, "UpnpVersion")) {
+ 			dbus_message_iter_get_basic(&inter, version);
+ 		} else if (!g_strcmp0(key, "WiFiDisplayIEs")) {
+@@ -483,10 +484,9 @@ static DBusMessage *register_peer_service(DBusConnection *conn,
+ 
+ 	ret = __connman_peer_service_register(owner, msg, spec, spec_len,
+ 					query, query_len, version,master);
+-	if (!ret)
++	if (!ret || ret == -EINPROGRESS)
+ 		return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+-	if (ret == -EINPROGRESS)
+-		return NULL;
++	
+ error:
+ 	return __connman_error_failed(msg, -ret);
+ }
+diff --git a/src/service.c b/src/service.c
+index 712ade14..f38c88ff 100644
+--- a/src/service.c
++++ b/src/service.c
+@@ -156,6 +156,7 @@ static struct connman_ipconfig *create_ip6config(struct connman_service *service
+ 		int index);
+ static void dns_changed(struct connman_service *service);
+ static void vpn_auto_connect(void);
++static void append_bsses(DBusMessageIter *iter, void *user_data);
+ 
+ struct find_data {
+ 	const char *path;
+@@ -2540,6 +2541,57 @@ int connman_service_iterate_services(connman_service_iterate_cb cb,
+ 	return ret;
+ }
+ 
++static void append_bss(DBusMessageIter *iter, void *key, void *value)
++{
++	char *bss_id = key;
++	struct connman_bss *bss_props = value;
++	DBusMessageIter item;
++	int signal = 0;
++	int frequency = 0;
++
++	connman_dbus_dict_open(iter, &item);
++
++	if (!bss_id || !bss_props)
++		goto empty_dict;
++
++	signal = connman_network_get_bss_signal(bss_props);
++	frequency = connman_network_get_bss_frequency(bss_props);
++
++	connman_dbus_dict_append_basic(&item, "Id",
++						DBUS_TYPE_STRING, &bss_id);
++
++	connman_dbus_dict_append_basic(&item, "Signal",
++						DBUS_TYPE_INT32, &signal);
++
++	connman_dbus_dict_append_basic(&item, "Frequency",
++						DBUS_TYPE_INT32, &frequency);
++
++empty_dict:
++	connman_dbus_dict_close(iter, &item);
++}
++
++static void append_bsses(DBusMessageIter *iter, void *user_data)
++{
++	GHashTable *bsses = user_data;
++	GHashTableIter hash;
++	gpointer key, value;
++
++	if (!bsses) {
++		// Empty array when no BSSes.
++		return;
++	}
++
++	g_hash_table_iter_init(&hash, bsses);
++
++	while (g_hash_table_iter_next(&hash, &key, &value)) {
++		DBusMessageIter dict;
++
++		dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &dict);
++		append_bss(&dict, key, value);
++		dbus_message_iter_close_container(iter, &dict);
++	}
++}
++
+ static void append_properties(DBusMessageIter *dict, dbus_bool_t limited,
+ 					struct connman_service *service)
+ {
+@@ -2605,9 +2657,21 @@ static void append_properties(DBusMessageIter *dict, dbus_bool_t limited,
+ 						append_ethernet, service);
+ 		break;
+ 	case CONNMAN_SERVICE_TYPE_WIFI:
+-	case CONNMAN_SERVICE_TYPE_ETHERNET:
++		if (service->network) {
++			connman_dbus_dict_append_array(dict, "BSS",
++											DBUS_TYPE_DICT_ENTRY,
++											append_bsses,
++											connman_network_get_bss_table(service->network));
++		}
+ 	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++		if (service->network) {
++			str = connman_network_get_address(service->network);
++			if (str)
++				connman_dbus_dict_append_basic(dict, "Address",
++												DBUS_TYPE_STRING, &str);
++		}
+ 	case CONNMAN_SERVICE_TYPE_GADGET:
++	case CONNMAN_SERVICE_TYPE_ETHERNET:
+ 		connman_dbus_dict_append_dict(dict, "Ethernet",
+ 						append_ethernet, service);
+ 		break;
+@@ -3518,6 +3582,10 @@ static void do_auto_connect(struct connman_service *service,
+ 	 */
+ 	if (service->type != CONNMAN_SERVICE_TYPE_VPN)
+ 		__connman_service_auto_connect(reason);
++	/* Only user interaction should get VPN connected in failure state. */
++	else if (service->state == CONNMAN_SERVICE_STATE_FAILURE &&
++				reason != CONNMAN_SERVICE_CONNECT_REASON_USER)
++		return;
+ 
+ 	vpn_auto_connect();
+ }
+@@ -5923,14 +5991,27 @@ static int service_update_preferred_order(struct connman_service *default_servic
+ 		struct connman_service *new_service,
+ 		enum connman_service_state new_state)
+ {
+-	if (!default_service || default_service == new_service)
+-		return 0;
++	unsigned int *tech_array;
++	int i;
+ 
+-	if (service_compare_preferred(default_service, new_service) > 0) {
+-		switch_default_service(default_service,
+-				new_service);
+-		__connman_connection_update_gateway();
++	if (!default_service || default_service == new_service ||
++			default_service->state != new_state)
+ 		return 0;
++
++	tech_array = connman_setting_get_uint_list("PreferredTechnologies");
++	if (tech_array) {
++
++		for (i = 0; tech_array[i] != 0; i += 1) {
++			if (default_service->type == tech_array[i])
++				return -EALREADY;
++
++			if (new_service->type == tech_array[i]) {
++				switch_default_service(default_service,
++						new_service);
++				__connman_connection_update_gateway();
++				return 0;
++			}
++		}
+ 	}
+ 
+ 	return -EALREADY;
+diff --git a/src/technology.c b/src/technology.c
+index 1332e57c..b048c62e 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -259,14 +259,21 @@ int connman_technology_tethering_notify(struct connman_technology *technology,
+ 							bool enabled)
+ {
+ 	int err;
++	const char *ip;
+ 
+ 	DBG("technology %p enabled %u", technology, enabled);
+ 
+ 	if (technology->tethering == enabled)
+ 		return -EALREADY;
+ 
++	ip = technology->tethering_ipaddress;
++
+ 	if (enabled) {
+-		err = __connman_tethering_set_enabled();
++		if (!ip || strlen(ip) == 0)
++			err = __connman_tethering_set_enabled();
++		else
++			err = __connman_tethering_set_enabled_with_ip(ip);
++
+ 		if (err < 0)
+ 			return err;
+ 	} else
+@@ -399,12 +406,12 @@ enum connman_service_type connman_technology_get_type
+ 	return technology->type;
+ }
+ 
+-bool connman_technology_get_wifi_tethering(const struct connman_technology *technology,
+-					const char **ssid, const char **psk,
+-					int *freq)
++bool connman_technology_get_wifi_tethering(const char **ssid,
++							const char **psk)
+ {
+ 	bool force = true;
+ 
++    struct connman_technology *technology;
+ 	if (!ssid || !psk)
+ 		return false;
+ 
+@@ -424,11 +431,22 @@ bool connman_technology_get_wifi_tethering(const struct connman_technology *tech
+ 
+ 	*ssid = technology->tethering_ident;
+ 	*psk = technology->tethering_passphrase;
+-	*freq = technology->tethering_freq;
++	//*freq = technology->tethering_freq;
+ 
+ 	return true;
+ }
+ 
++unsigned int connman_technology_get_wifi_tethering_channel(void)
++{
++	struct connman_technology *technology;
++
++	technology = technology_find(CONNMAN_SERVICE_TYPE_WIFI);
++	if (!technology)
++		return 0;
++
++	return technology->tethering_channel;
++}
++
+ static void free_rfkill(gpointer data)
+ {
+ 	struct connman_rfkill *rfkill = data;
+@@ -670,9 +688,15 @@ static void append_properties(DBusMessageIter *iter,
+ 					DBUS_TYPE_STRING,
+ 					&technology->tethering_passphrase);
+ 
+-	connman_dbus_dict_append_basic(&dict, "TetheringFreq",
+-				DBUS_TYPE_INT32,
+-				&technology->tethering_freq);
++	if (technology->tethering_ipaddress)
++		connman_dbus_dict_append_basic(&dict, "TetheringIPAddress",
++					DBUS_TYPE_STRING,
++					&technology->tethering_ipaddress);
++
++	if (technology->tethering_channel)
++		connman_dbus_dict_append_basic(&dict, "TetheringChannel",
++					DBUS_TYPE_UINT32,
++					&technology->tethering_channel);
+ 
+ 	if(technology->p2p_identifier)
+ 		connman_dbus_dict_append_basic(&dict, "P2PIdentifier",
+@@ -1597,10 +1621,19 @@ static DBusMessage *set_property(DBusConnection *conn,
+ 		if (technology->type != CONNMAN_SERVICE_TYPE_WIFI)
+ 			return __connman_error_not_supported(msg);
+ 
+-		err = __connman_service_check_passphrase(CONNMAN_SERVICE_SECURITY_PSK,
+-							str);
+-		if (err < 0)
+-			return __connman_error_passphrase_required(msg);
++		/* Allow empty passphrases for setting up an AP with open
++		 * security type */
++
++		if (strlen(str) == 0) {
++			g_free(technology->tethering_passphrase);
++			technology->tethering_passphrase = NULL;
++		}
++		else {
++			err = __connman_service_check_passphrase(CONNMAN_SERVICE_SECURITY_PSK,
++								str);
++			if (err < 0)
++				return __connman_error_passphrase_required(msg);
++		}
+ 
+ 		if (g_strcmp0(technology->tethering_passphrase, str) != 0) {
+ 			g_free(technology->tethering_passphrase);
+@@ -1613,26 +1646,53 @@ static DBusMessage *set_property(DBusConnection *conn,
+ 					DBUS_TYPE_STRING,
+ 					&technology->tethering_passphrase);
+ 		}
+-	} else if (g_str_equal(name, "TetheringFreq")) {
+-		dbus_int32_t freq;
++	} else if (g_str_equal(name, "TetheringChannel")) {
++		dbus_uint32_t channel;
++
++		if (type != DBUS_TYPE_UINT32)
++			return __connman_error_invalid_arguments(msg);
++
++		dbus_message_iter_get_basic(&value, &channel);
+ 
+-		if (type != DBUS_TYPE_INT32)
++		if (technology->type != CONNMAN_SERVICE_TYPE_WIFI)
++			return __connman_error_not_supported(msg);
++
++		if (channel == 0 || channel > 13)
+ 			return __connman_error_invalid_arguments(msg);
+ 
+-		dbus_message_iter_get_basic(&value, &freq);
++		if (technology->tethering_channel != channel) {
++
++			technology->tethering_channel = channel;
++			technology_save(technology);
++
++			connman_dbus_property_changed_basic(technology->path,
++					CONNMAN_TECHNOLOGY_INTERFACE,
++					"TetheringChannel",
++					DBUS_TYPE_UINT32,
++					&technology->tethering_channel);
++		}
++	} else if (g_str_equal(name, "TetheringIPAddress")) {
++		const char *str;
++
++		dbus_message_iter_get_basic(&value, &str);
+ 
+ 		if (technology->type != CONNMAN_SERVICE_TYPE_WIFI)
+ 			return __connman_error_not_supported(msg);
+ 
+-		if (freq >= 0) {
+-			technology->tethering_freq = freq;
++		if (strlen(str) == 0) {
++				g_free(technology->tethering_ipaddress);
++				technology->tethering_ipaddress = NULL;
++		}
++		if (g_strcmp0(technology->tethering_ipaddress, str) != 0) {
++			g_free(technology->tethering_ipaddress);
++			technology->tethering_ipaddress = g_strdup(str);
+ 			technology_save(technology);
+ 
+ 			connman_dbus_property_changed_basic(technology->path,
+ 					CONNMAN_TECHNOLOGY_INTERFACE,
+-					"TetheringFreq",
+-					DBUS_TYPE_INT32,
+-					&technology->tethering_freq);
++					"TetheringIPAddress",
++					DBUS_TYPE_STRING,
++					&technology->tethering_ipaddress);
+ 		}
+ 	} else if (g_str_equal(name, "P2PListen")) {
+ 		bool enable;
+diff --git a/src/tethering.c b/src/tethering.c
+index 784917d5..8e847a7e 100644
+--- a/src/tethering.c
++++ b/src/tethering.c
+@@ -438,6 +438,130 @@ void __connman_tethering_list_clients(DBusMessageIter *array)
+ 	g_hash_table_foreach(clients_table, append_client, array);
+ }
+ 
++static char *get_ip(uint32_t ip)
++{
++	struct in_addr addr;
++
++	addr.s_addr = htonl(ip);
++
++	return g_strdup(inet_ntoa(addr));
++}
++int __connman_tethering_set_enabled_with_ip(const char *ip)
++{
++	int index;
++	int err;
++	const char *gateway;
++	const char *broadcast;
++	const char *subnet_mask;
++	const char *start_ip;
++	const char *end_ip;
++	const char *dns;
++	unsigned char prefixlen;
++	char **ns;
++
++	DBG("enabled %d", tethering_enabled + 1);
++
++	if (__sync_fetch_and_add(&tethering_enabled, 1) != 0)
++		return 0;
++
++	err = __connman_bridge_create(BRIDGE_NAME);
++	if (err < 0) {
++		__sync_fetch_and_sub(&tethering_enabled, 1);
++		return 0;
++	}
++
++	index = connman_inet_ifindex(BRIDGE_NAME);
++
++	__connman_ippool_newaddr(index, ip, 24);
++
++	struct in_addr inp;
++	uint32_t start, mask;
++
++	if (inet_aton(ip, &inp) == 0)
++		return 0;
++
++	start = ntohl(inp.s_addr);
++	mask = ~(0xffffffff >> 24);
++
++	start = start & mask;
++
++	gateway = ip;
++	broadcast = get_ip(start + 255);
++	subnet_mask = SUBNET_MASK_24;
++	start_ip = get_ip(start + 2);
++	end_ip = get_ip(start + 254);
++
++	err = __connman_bridge_enable(BRIDGE_NAME, gateway,
++			connman_ipaddress_calc_netmask_len(subnet_mask),
++			broadcast);
++	if (err < 0 && err != -EALREADY) {
++		__connman_ippool_free(dhcp_ippool);
++		__connman_ippool_deladdr(index, ip, 24);
++		__connman_bridge_remove(BRIDGE_NAME);
++		__sync_fetch_and_sub(&tethering_enabled, 1);
++		return -EADDRNOTAVAIL;
++	}
++
++	ns = connman_setting_get_string_list("FallbackNameservers");
++	if (ns) {
++		if (ns[0]) {
++			g_free(private_network_primary_dns);
++			private_network_primary_dns = g_strdup(ns[0]);
++		}
++		if (ns[1]) {
++			g_free(private_network_secondary_dns);
++			private_network_secondary_dns = g_strdup(ns[1]);
++		}
++
++		DBG("Fallback ns primary %s secondary %s",
++			private_network_primary_dns,
++			private_network_secondary_dns);
++	}
++
++	dns = gateway;
++	if (__connman_dnsproxy_add_listener(index) < 0) {
++		connman_error("Can't add listener %s to DNS proxy",
++								BRIDGE_NAME);
++		dns = private_network_primary_dns;
++		DBG("Serving %s nameserver to clients", dns);
++	}
++
++	tethering_dhcp_server = dhcp_server_start(BRIDGE_NAME,
++						gateway, subnet_mask,
++						start_ip, end_ip,
++						24 * 3600, dns);
++	if (!tethering_dhcp_server) {
++		__connman_bridge_disable(BRIDGE_NAME);
++		__connman_ippool_free(dhcp_ippool);
++		__connman_ippool_deladdr(index, ip, 24);
++		__connman_bridge_remove(BRIDGE_NAME);
++		__sync_fetch_and_sub(&tethering_enabled, 1);
++		return -EOPNOTSUPP;
++	}
++
++	prefixlen = connman_ipaddress_calc_netmask_len(subnet_mask);
++	err = __connman_nat_enable(BRIDGE_NAME, start_ip, prefixlen);
++	if (err < 0) {
++		connman_error("Cannot enable NAT %d/%s", err, strerror(-err));
++		dhcp_server_stop(tethering_dhcp_server);
++		__connman_bridge_disable(BRIDGE_NAME);
++		__connman_ippool_free(dhcp_ippool);
++		__connman_ippool_deladdr(index, ip, 24);
++		__connman_bridge_remove(BRIDGE_NAME);
++		__sync_fetch_and_sub(&tethering_enabled, 1);
++		return -EOPNOTSUPP;
++	}
++
++	err = __connman_ipv6pd_setup(BRIDGE_NAME);
++	if (err < 0 && err != -EINPROGRESS)
++		DBG("Cannot setup IPv6 prefix delegation %d/%s", err,
++			strerror(-err));
++
++	DBG("tethering started");
++
++	return 0;
++}
++
+ static void setup_tun_interface(unsigned int flags, unsigned change,
+ 		void *data)
+ {

--- a/meta-luneos/recipes-connectivity/connman/connman/0004-Add-Changes-for-tethering-setState-api.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0004-Add-Changes-for-tethering-setState-api.patch
@@ -1,0 +1,167 @@
+From 3472cdcdfbfa953e77c1b5722a786f3b703843a9 Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Thu, 27 Oct 2022 19:23:51 +0530
+Subject: [PATCH] Add Changes for tethering setState api
+
+:Release Notes:
+Add Changes for tethering setState api
+
+:Detailed Notes:
+Add Changes for tethering setState api
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11079] - Add Changes for tethering setState
+
+Change-Id: Id25f43498b0320c2761791660d78408fcf0a4965
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338047
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: Ban Word Checker <ban_word@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ gsupplicant/supplicant.c | 23 +++++++++++++++++++++++
+ include/technology.h     |  1 +
+ src/technology.c         |  7 ++++---
+ src/tethering.c          | 19 +++++++++++++++++++
+ 4 files changed, 47 insertions(+), 3 deletions(-)
+
+diff --git a/gsupplicant/supplicant.c b/gsupplicant/supplicant.c
+index 5e37e33b..353fe9d6 100644
+--- a/gsupplicant/supplicant.c
++++ b/gsupplicant/supplicant.c
+@@ -4819,6 +4819,20 @@ go_next:
+ 
+ 	return;
+ }
++
++static void signal_invitation_received(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	SUPPLICANT_DBG("signal invitation received");
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_invitation_received(iter, interface);
++}
++
+ static void empty_free_function(void* ptr)
+ {
+ 	// Does nothing
+@@ -5787,11 +5801,20 @@ static struct {
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationSuccess", signal_group_success },
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationFailure", signal_group_failure },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "PersistentGroupAdded", signal_persistent_group_added	},
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "PersistentGroupRemoved", signal_persistent_group_removed	},
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GroupStarted", signal_group_started },
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GroupFinished", signal_group_finished },
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "GONegotiationRequest", signal_group_request },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ServiceDiscoveryResponse", signal_sd_response	},
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ServiceDiscoveryASPResponse", signal_sd_asp_response	},
+ 
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionStart", signal_p2ps_prov_start	},
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionDone",	 signal_p2ps_prov_done	},
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationResult", signal_invitation_result },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationReceived", signal_invitation_received	},
+ 	{ SUPPLICANT_INTERFACE ".Group", "PeerJoined", signal_group_peer_joined },
++	{ SUPPLICANT_INTERFACE ".Group", "PeerJoinedWithIP", signal_peer_joined_with_ip },
+ 	{ SUPPLICANT_INTERFACE ".Group", "PeerDisconnected", signal_group_peer_disconnected },
+ 
+ 	{ }
+diff --git a/include/technology.h b/include/technology.h
+index 4accc58d..6f721ee5 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -77,6 +77,7 @@ struct connman_technology_driver {
+ 	int (*set_p2p_enable) (struct connman_technology *technology,
+ 								bool status);
+ 	int (*set_tethering) (struct connman_technology *technology,
++				const char *identifier, const char *passphrase,
+ 				const char *bridge, bool enabled);
+ 	int (*set_regdom) (struct connman_technology *technology,
+ 						const char *alpha2);
+diff --git a/src/technology.c b/src/technology.c
+index b048c62e..535a9040 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -304,8 +304,7 @@ static int set_tethering(struct connman_technology *technology,
+ 	if (!bridge)
+ 		return -EOPNOTSUPP;
+ 
+-	if (technology->type == CONNMAN_SERVICE_TYPE_WIFI &&
+-	    (!ident || !passphrase))
++	if (technology->type == CONNMAN_SERVICE_TYPE_WIFI && !ident)
+ 		return -EINVAL;
+ 
+ 	for (tech_drivers = technology->driver_list; tech_drivers;
+@@ -315,7 +314,8 @@ static int set_tethering(struct connman_technology *technology,
+ 		if (!driver || !driver->set_tethering)
+ 			continue;
+ 
+-		err = driver->set_tethering(technology, bridge, enabled);
++		err = driver->set_tethering(technology, ident, passphrase,
++				bridge, enabled);
+ 
+ 		if (result == -EINPROGRESS)
+ 			continue;
+@@ -2150,6 +2150,7 @@ static void technology_put(struct connman_technology *technology)
+ 	g_free(technology->regdom);
+ 	g_free(technology->tethering_ident);
+ 	g_free(technology->tethering_passphrase);
++	g_free(technology->tethering_ipaddress);
+ 	g_free(technology->p2p_identifier);
+ 	g_free(technology);
+ }
+diff --git a/src/tethering.c b/src/tethering.c
+index 8e847a7e..8351b2d1 100644
+--- a/src/tethering.c
++++ b/src/tethering.c
+@@ -88,6 +88,20 @@ struct connman_private_network {
+ 	char *primary_dns;
+ 	char *secondary_dns;
+ };
++
++static void destroy_station(gpointer key, gpointer value, gpointer user_data)
++{
++	struct connman_station_info *station_info;
++
++	__sync_synchronize();
++
++	station_info = value;
++
++	g_free(station_info->path);
++	g_free(station_info->type);
++	g_free(station_info);
++}
++
+ int connman_technology_tethering_add_station(enum connman_service_type type,
+                                                const char *mac)
+ {
+@@ -805,6 +819,9 @@ int __connman_private_network_request(DBusMessage *msg, const char *owner)
+ 
+ 	g_hash_table_insert(pn_hash, pn->path, pn);
+ 
++	sta_hash = g_hash_table_new_full(g_str_hash, g_str_equal,
++						NULL, NULL);
++
+ 	return 0;
+ 
+ error:
+@@ -880,6 +897,8 @@ void __connman_tethering_cleanup(void)
+ 		return;
+ 
+ 	g_hash_table_destroy(pn_hash);
++	g_hash_table_foreach(sta_hash, destroy_station, NULL);
++	g_hash_table_destroy(sta_hash);
+ 
+ 	g_hash_table_destroy(clients_notify->remove);
+ 	g_free(clients_notify);

--- a/meta-luneos/recipes-connectivity/connman/connman/0005-Add-Changes-for-p2p-create-group-api.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0005-Add-Changes-for-p2p-create-group-api.patch
@@ -1,0 +1,160 @@
+From 6e2bcbd9e611126279d0131db30eca86dc32e7d8 Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Thu, 27 Oct 2022 19:41:57 +0530
+Subject: [PATCH] Add Changes for p2p create group api
+
+:Release Notes:
+Add Changes for p2p create group api
+
+:Detailed Notes:
+Add Changes for p2p create group api
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11075] - Add Changes for p2p create group api
+
+Change-Id: Idcfe8874f04f68d6e6eee75e5b47efbd16ada39a
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338048
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: Ban Word Checker <ban_word@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ src/manager.c | 91 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 91 insertions(+)
+
+diff --git a/src/manager.c b/src/manager.c
+index 5442756b..93e59782 100644
+--- a/src/manager.c
++++ b/src/manager.c
+@@ -139,6 +139,24 @@ static DBusMessage *get_technologies(DBusConnection *conn,
+ 	return reply;
+ }
+ 
++static DBusMessage *get_sta_count(DBusConnection *conn,
++               DBusMessage *msg, void *data)
++{
++	DBusMessage *reply;
++	int sta_count = 0;
++
++	reply = dbus_message_new_method_return(msg);
++	if (reply == NULL)
++		return NULL;
++
++	sta_count = __connman_tethering_sta_count();
++
++	dbus_message_append_args(reply,
++				DBUS_TYPE_INT32, &sta_count, DBUS_TYPE_INVALID);
++
++	return reply;
++}
++
+ static DBusMessage *remove_provider(DBusConnection *conn,
+ 				    DBusMessage *msg, void *data)
+ {
+@@ -522,6 +540,64 @@ error:
+ 
+ }
+ 
++static DBusMessage *create_group(DBusConnection *conn,
++		DBusMessage *msg, void *data)
++{
++	DBusMessageIter iter;
++	const char *identifier, *passphrase;
++	int err;
++
++	DBG("");
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++				return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++			return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &identifier);
++
++	if (strlen(identifier) > (P2P_MAX_SSID - P2P_WILDCARD_SSID_LEN))
++			return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_next(&iter);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++			return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &passphrase);
++
++	if ((strlen(passphrase) > 1 && strlen(passphrase) < 8) || strlen(passphrase) > 63)
++			return __connman_error_passphrase_required(msg);
++
++	err = __connman_technology_set_p2p_go(msg, identifier, passphrase);
++
++	if (err < 0)
++			return __connman_error_failed(msg, -err);
++
++	return NULL;
++}
++
++static void append_group_structs(DBusMessageIter *iter, void *user_data)
++{
++	__connman_group_list_struct(iter);
++}
++
++static DBusMessage *get_groups(DBusConnection *conn,
++					DBusMessage *msg, void *data)
++{
++	DBusMessage *reply;
++
++	reply = dbus_message_new_method_return(msg);
++	if (!reply)
++		return NULL;
++
++	__connman_dbus_append_objpath_dict_array(reply,
++			append_group_structs, NULL);
++
++	return reply;
++}
++
+ static const GDBusMethodTable manager_methods[] = {
+ 	{ GDBUS_METHOD("GetProperties",
+ 			NULL, GDBUS_ARGS({ "properties", "a{sv}" }),
+@@ -532,6 +608,9 @@ static const GDBusMethodTable manager_methods[] = {
+ 	{ GDBUS_METHOD("GetTechnologies",
+ 			NULL, GDBUS_ARGS({ "technologies", "a(oa{sv})" }),
+ 			get_technologies) },
++	{ GDBUS_METHOD("GetStaCount",
++			NULL, GDBUS_ARGS({ "stacount", "i" }),
++			get_sta_count) },
+ 	{ GDBUS_DEPRECATED_METHOD("RemoveProvider",
+ 			GDBUS_ARGS({ "provider", "o" }), NULL,
+ 			remove_provider) },
+@@ -584,6 +663,13 @@ static const GDBusMethodTable manager_methods[] = {
+ 	{ GDBUS_METHOD("UnregisterPeerService",
+ 			GDBUS_ARGS({ "specification", "a{sv}" }), NULL,
+ 			unregister_peer_service) },
++	{ GDBUS_ASYNC_METHOD("CreateGroup",
++			GDBUS_ARGS({ "identifier", "s" },{ "passphrase", "s" }),
++			GDBUS_ARGS({ "path", "o" }),
++			create_group) },
++	{ GDBUS_METHOD("GetGroups",
++			NULL, GDBUS_ARGS({ "groups", "a(oa{sv})" }),
++			get_groups) },
+ 	{ },
+ };
+ 
+@@ -604,6 +690,11 @@ static const GDBusSignalTable manager_signals[] = {
+ 	{ GDBUS_SIGNAL("TetheringClientsChanged",
+ 			GDBUS_ARGS({ "registered", "as" },
+ 					{ "removed", "as" })) },
++    { GDBUS_SIGNAL("GroupAdded",
++			GDBUS_ARGS({ "path", "o" },
++					{ "properties", "a{sv}" })) },
++	{ GDBUS_SIGNAL("GroupRemoved",
++			GDBUS_ARGS({ "path", "o"})) },
+ 	{ },
+ };
+ 

--- a/meta-luneos/recipes-connectivity/connman/connman/0006-Add-Changes-for-No-Internet-issue-connman.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0006-Add-Changes-for-No-Internet-issue-connman.patch
@@ -1,0 +1,870 @@
+From de9c3c3b1bd7368903270f1937e29599471ada52 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Thu, 15 Dec 2022 14:16:58 +0100
+Subject: [PATCH] Add Changes for No Internet issue connman
+
+:Release Notes:
+Add Changes for No Internet issue connman
+
+:Detailed Notes:
+Add Changes for No Internet issue connman
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11077] - Add Changes for No Internet issue connman
+
+Change-Id: If7c9b04ce8aa56d67f3cf1ba8edf547bbdea353f
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338301
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: Ban Word Checker <ban_word@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ src/connman.h  |   4 +-
+ src/ipconfig.c |   2 +-
+ src/service.c  | 275 ++++++++++++++++++++++++++++++++++++++++++-------
+ src/session.c  |   2 +-
+ src/wispr.c    |  74 +++++++------
+ 5 files changed, 285 insertions(+), 72 deletions(-)
+
+diff --git a/src/connman.h b/src/connman.h
+index 68176086..6bd5642f 100644
+--- a/src/connman.h
++++ b/src/connman.h
+@@ -390,7 +390,7 @@ const char *__connman_ipconfig_type2string(enum connman_ipconfig_type type);
+ enum connman_ipconfig_method __connman_ipconfig_string2method(const char *method);
+ 
+ void __connman_ipconfig_append_ipv4(struct connman_ipconfig *ipconfig,
+-							DBusMessageIter *iter);
++							DBusMessageIter *iter, struct connman_service *service);
+ void __connman_ipconfig_append_ipv4config(struct connman_ipconfig *ipconfig,
+ 							DBusMessageIter *iter);
+ void __connman_ipconfig_append_ipv6(struct connman_ipconfig *ipconfig,
+@@ -730,6 +730,8 @@ int __connman_service_set_mdns(struct connman_service *service,
+ 
+ void __connman_service_set_string(struct connman_service *service,
+ 					const char *key, const char *value);
++int __connman_service_online_check_failed(struct connman_service *service,
++					enum connman_ipconfig_type type);
+ void __connman_service_online_check(struct connman_service *service,
+ 					enum connman_ipconfig_type type,
+ 					bool success);
+diff --git a/src/ipconfig.c b/src/ipconfig.c
+index 34b1724a..ac03b69e 100644
+--- a/src/ipconfig.c
++++ b/src/ipconfig.c
+@@ -1896,7 +1896,7 @@ int __connman_ipconfig_ipv6_set_privacy(struct connman_ipconfig *ipconfig,
+ }
+ 
+ void __connman_ipconfig_append_ipv4(struct connman_ipconfig *ipconfig,
+-							DBusMessageIter *iter)
++							DBusMessageIter *iter, struct connman_service *service)
+ {
+ 	struct connman_ipaddress *append_addr = NULL;
+ 	const char *str;
+diff --git a/src/service.c b/src/service.c
+index 1d2b78a6..8b8c484e 100644
+--- a/src/service.c
++++ b/src/service.c
+@@ -1454,12 +1454,12 @@ static void start_online_check(struct connman_service *service,
+ 			"Default service remains in READY state.");
+ 		return;
+ 	}
+-	enable_online_to_ready_transition =
++	/*enable_online_to_ready_transition =
+ 		connman_setting_get_bool("EnableOnlineToReadyTransition");
+ 	online_check_initial_interval =
+ 		connman_setting_get_uint("OnlineCheckInitialInterval");
+ 	online_check_max_interval =
+-		connman_setting_get_uint("OnlineCheckMaxInterval");
++		connman_setting_get_uint("OnlineCheckMaxInterval");*/
+ 
+ 	if (type != CONNMAN_IPCONFIG_TYPE_IPV4 || check_proxy_setup(service)) {
+ 		cancel_online_check(service);
+@@ -1595,7 +1595,7 @@ bool __connman_service_index_is_default(int index)
+ 	return __connman_service_get_index(service) == index;
+ }
+ 
+-static void start_wispr_when_connected(struct connman_service *service)
++/*static void start_wispr_when_connected(struct connman_service *service)
+ {
+ 	if (!connman_setting_get_bool("EnableOnlineCheck")) {
+ 		connman_info("Online check disabled. "
+@@ -1612,7 +1612,7 @@ static void start_wispr_when_connected(struct connman_service *service)
+ 			CONNMAN_IPCONFIG_TYPE_IPV6))
+ 		__connman_service_wispr_start(service,
+ 					CONNMAN_IPCONFIG_TYPE_IPV6);
+-}
++}*/
+ 
+ static void default_changed(void)
+ {
+@@ -1637,8 +1637,18 @@ static void default_changed(void)
+ 		if (service->domainname &&
+ 				connman_setting_get_bool("AllowDomainnameUpdates"))
+ 			__connman_utsname_set_domainname(service->domainname);
++            
++			if (__connman_service_is_connected_state(service,
++						CONNMAN_IPCONFIG_TYPE_IPV4))
++			__connman_service_wispr_start(service,
++						CONNMAN_IPCONFIG_TYPE_IPV4);
+ 
+-		start_wispr_when_connected(service);
++			if (__connman_service_is_connected_state(service,
++						CONNMAN_IPCONFIG_TYPE_IPV6))
++			__connman_service_wispr_start(service,
++					CONNMAN_IPCONFIG_TYPE_IPV6);
++
++		// start_wispr_when_connected(service);
+ 
+ 		/*
+ 		 * Connect VPN automatically when new default service
+@@ -1835,7 +1845,7 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 		return;
+ 
+ 	if (service->ipconfig_ipv4)
+-		__connman_ipconfig_append_ipv4(service->ipconfig_ipv4, iter);
++		__connman_ipconfig_append_ipv4(service->ipconfig_ipv4, iter, service);
+ }
+ 
+ static void append_ipv6(DBusMessageIter *iter, void *user_data)
+@@ -3498,11 +3508,11 @@ static void do_auto_connect(struct connman_service *service,
+ 	 * Only user interaction should get VPN or WIFI connected in failure
+ 	 * state.
+ 	 */
+-	if (service->state == CONNMAN_SERVICE_STATE_FAILURE &&
++	/*if (service->state == CONNMAN_SERVICE_STATE_FAILURE &&
+ 				reason != CONNMAN_SERVICE_CONNECT_REASON_USER &&
+ 				(service->type == CONNMAN_SERVICE_TYPE_VPN ||
+ 				service->type == CONNMAN_SERVICE_TYPE_WIFI))
+-		return;
++		return;*/
+ 
+ 	/*
+ 	 * Do not use the builtin auto connect, instead rely on the
+@@ -3595,6 +3605,9 @@ int __connman_service_reset_ipconfig(struct connman_service *service,
+ 	return err;
+ }
+ 
++#define online_check_initial_interval 1
++#define online_check_max_interval 12
++
+ void __connman_service_wispr_start(struct connman_service *service,
+ 					enum connman_ipconfig_type type)
+ {
+@@ -3736,8 +3749,15 @@ static DBusMessage *set_property(DBusConnection *conn,
+ 
+ 		nameserver_add_all(service, CONNMAN_IPCONFIG_TYPE_ALL);
+ 		dns_configuration_changed(service);
++		if (__connman_service_is_connected_state(service,
++						CONNMAN_IPCONFIG_TYPE_IPV4))
++			__connman_service_wispr_start(service, CONNMAN_IPCONFIG_TYPE_IPV4);
++
++		if (__connman_service_is_connected_state(service,
++						CONNMAN_IPCONFIG_TYPE_IPV6))
++			__connman_service_wispr_start(service, CONNMAN_IPCONFIG_TYPE_IPV6);
+ 
+-		start_wispr_when_connected(service);
++		// start_wispr_when_connected(service);
+ 
+ 		service_save(service);
+ 	} else if (g_str_equal(name, "Timeservers.Configuration")) {
+@@ -4231,7 +4251,7 @@ static bool auto_connect_service(GList *services,
+ 			continue;
+ 		}
+ 
+-		if (service->connect_reason ==
++		/*if (service->connect_reason ==
+ 				CONNMAN_SERVICE_CONNECT_REASON_NATIVE) {
+ 			DBG("service %p uses native autonnect, skip", service);
+ 			continue;
+@@ -4240,7 +4260,7 @@ static bool auto_connect_service(GList *services,
+ 		index = __connman_service_get_index(service);
+ 		if (g_hash_table_lookup(passphrase_requested,
+ 					GINT_TO_POINTER(index)))
+-			return true;
++			return true;*/
+ 
+ 		if (service->pending ||
+ 				is_connecting(service->state) ||
+@@ -4571,7 +4591,7 @@ static DBusMessage *connect_service(DBusConnection *conn,
+ 		struct connman_service *temp = list->data;
+ 
+ 		if (!is_connecting(temp->state) && !is_connected(temp->state))
+-			continue;
++			break;
+ 
+ 		if (service == temp)
+ 			continue;
+@@ -4723,11 +4743,16 @@ static void apply_relevant_default_downgrade(struct connman_service *service)
+ 	struct connman_service *def_service;
+ 
+ 	def_service = connman_service_get_default();
+-	if (!def_service || def_service != service ||
+-		def_service->state != CONNMAN_SERVICE_STATE_ONLINE)
++	if (!def_service)
+ 		return;
+ 
+-	downgrade_state(def_service);
++	//downgrade_state(def_service);
++	if (def_service == service &&
++			def_service->state == CONNMAN_SERVICE_STATE_ONLINE) {
++		def_service->state = CONNMAN_SERVICE_STATE_READY;
++		__connman_notifier_leave_online(def_service->type);
++		state_changed(def_service);
++	}
+ }
+ 
+ static void switch_default_service(struct connman_service *default_service,
+@@ -4973,6 +4998,108 @@ static DBusMessage *move_service(DBusConnection *conn,
+ 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+ }
+ 
++static DBusMessage *move_default(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++
++	struct connman_service *service = user_data;
++	struct connman_service *target;
++	enum connman_ipconfig_method target4, target6;
++	enum connman_ipconfig_method service4, service6;
++
++	DBG("service %p", service);
++
++	target = connman_service_get_default();
++	if (!target || target == service)
++		return __connman_error_already_exists(msg);
++
++	if (target->type == CONNMAN_SERVICE_TYPE_VPN) {
++		/*
++		 * We only allow VPN route splitting if there are
++		 * routes defined for a given VPN.
++		 */
++		if (!__connman_provider_check_routes(target->provider)) {
++			connman_info("Cannot move service. "
++				"No routes defined for provider %s",
++				__connman_provider_get_ident(target->provider));
++			return __connman_error_invalid_service(msg);
++		}
++
++		__connman_service_set_split_routing(target, true);
++	} else
++		__connman_service_set_split_routing(target, false);
++
++	__connman_service_set_split_routing(service, false);
++
++	target4 = __connman_ipconfig_get_method(target->ipconfig_ipv4);
++	target6 = __connman_ipconfig_get_method(target->ipconfig_ipv6);
++	service4 = __connman_ipconfig_get_method(service->ipconfig_ipv4);
++	service6 = __connman_ipconfig_get_method(service->ipconfig_ipv6);
++
++	DBG("target %s method %d/%d state %d/%d split %d", target->identifier,
++		target4, target6, target->state_ipv4, target->state_ipv6,
++		target->do_split_routing);
++
++	DBG("service %s method %d/%d state %d/%d", service->identifier,
++				service4, service6,
++				service->state_ipv4, service->state_ipv6);
++
++	/*
++	 * If method is OFF, then we do not need to check the corresponding
++	 * ipconfig state.
++	 */
++	if (target4 == CONNMAN_IPCONFIG_METHOD_OFF) {
++		if (service6 != CONNMAN_IPCONFIG_METHOD_OFF) {
++			if (!check_suitable_state(target->state_ipv6,
++							service->state_ipv6))
++				return __connman_error_invalid_service(msg);
++		}
++	}
++
++	if (target6 == CONNMAN_IPCONFIG_METHOD_OFF) {
++		if (service4 != CONNMAN_IPCONFIG_METHOD_OFF) {
++			if (!check_suitable_state(target->state_ipv4,
++							service->state_ipv4))
++				return __connman_error_invalid_service(msg);
++		}
++	}
++
++	if (service4 == CONNMAN_IPCONFIG_METHOD_OFF) {
++		if (target6 != CONNMAN_IPCONFIG_METHOD_OFF) {
++			if (!check_suitable_state(target->state_ipv6,
++							service->state_ipv6))
++				return __connman_error_invalid_service(msg);
++		}
++	}
++
++	if (service6 == CONNMAN_IPCONFIG_METHOD_OFF) {
++		if (target4 != CONNMAN_IPCONFIG_METHOD_OFF) {
++			if (!check_suitable_state(target->state_ipv4,
++							service->state_ipv4))
++				return __connman_error_invalid_service(msg);
++		}
++	}
++
++	g_get_current_time(&service->modified);
++	service_save(service);
++	service_save(target);
++
++	/*
++	 * If the service which goes down is the default service and is
++	 * online, we downgrade directly its state to ready so:
++	 * the service which goes up, needs to recompute its state which
++	 * is triggered via downgrading it - if relevant - to state ready.
++	 */
++	switch_default_service(target, service);
++
++	__connman_connection_update_gateway();
++
++	service_schedule_changed();
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++
++}
++
+ static DBusMessage *move_before(DBusConnection *conn,
+ 					DBusMessage *msg, void *user_data)
+ {
+@@ -4995,6 +5122,12 @@ static DBusMessage *reset_counters(DBusConnection *conn,
+ 	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+ }
+ 
++static DBusMessage *set_default(DBusConnection *conn,
++					DBusMessage *msg, void *user_data)
++{
++	return move_default(conn, msg, user_data);
++}
++
+ static void service_schedule_added(struct connman_service *service)
+ {
+ 	DBG("service %p", service);
+@@ -5052,6 +5185,8 @@ static const GDBusMethodTable service_methods[] = {
+ 			GDBUS_ARGS({ "service", "o" }), NULL,
+ 			move_after) },
+ 	{ GDBUS_METHOD("ResetCounters", NULL, NULL, reset_counters) },
++	{ GDBUS_ASYNC_METHOD("SetDefault", NULL, NULL,
++			      set_default) },
+ 	{ },
+ };
+ 
+@@ -5357,16 +5492,16 @@ static gint service_compare(gconstpointer a, gconstpointer b)
+ 	b_connected = is_connected(state_b);
+ 
+ 	if (a_connected && b_connected) {
+-		int rval;
++		/*int rval;
+ 
+-		/* Compare the VPN transport and the service */
++		/* Compare the VPN transport and the service 
+ 		if ((service_a->type == CONNMAN_SERVICE_TYPE_VPN ||
+ 				service_b->type == CONNMAN_SERVICE_TYPE_VPN) &&
+ 				service_b->type != service_a->type) {
+ 			rval = service_compare_vpn(service_a, service_b);
+ 			if (rval)
+ 				return rval;
+-		}
++		}*/
+ 
+ 		if (service_a->order > service_b->order)
+ 			return -1;
+@@ -5374,9 +5509,9 @@ static gint service_compare(gconstpointer a, gconstpointer b)
+ 		if (service_a->order < service_b->order)
+ 			return 1;
+ 
+-		rval = service_compare_preferred(service_a, service_b);
++		/*	rval = service_compare_preferred(service_a, service_b);
+ 		if (rval)
+-			return rval;
++			return rval;*/
+ 	}
+ 
+ 	if (state_a != state_b) {
+@@ -5407,11 +5542,26 @@ static gint service_compare(gconstpointer a, gconstpointer b)
+ 		return 1;
+ 
+ 	if (service_a->type != service_b->type) {
+-		int rval;
++		/*int rval;
+ 
+ 		rval = service_compare_preferred(service_a, service_b);
+ 		if (rval)
+-			return rval;
++			return rval;*/
++
++		unsigned int *tech_array;
++		int i;
++
++		tech_array = connman_setting_get_uint_list(
++						"PreferredTechnologies");
++		if (tech_array) {
++			for (i = 0; tech_array[i]; i++) {
++				if (tech_array[i] == service_a->type)
++					return -1;
++
++				if (tech_array[i] == service_b->type)
++					return 1;
++			}
++		}
+ 
+ 		if (service_a->type == CONNMAN_SERVICE_TYPE_ETHERNET)
+ 			return -1;
+@@ -6023,14 +6173,14 @@ static int service_indicate_state(struct connman_service *service)
+ 		break;
+ 
+ 	case CONNMAN_SERVICE_STATE_IDLE:
+-		if (old_state == CONNMAN_SERVICE_STATE_FAILURE &&
++		/*if (old_state == CONNMAN_SERVICE_STATE_FAILURE &&
+ 				service->connect_reason ==
+ 					CONNMAN_SERVICE_CONNECT_REASON_NATIVE &&
+ 				service->error ==
+ 					CONNMAN_SERVICE_ERROR_INVALID_KEY) {
+ 			__connman_service_clear_error(service);
+ 			service_complete(service);
+-		}
++		}*/
+ 
+ 		if (old_state != CONNMAN_SERVICE_STATE_DISCONNECT)
+ 			__connman_service_disconnect(service);
+@@ -6148,14 +6298,13 @@ static int service_indicate_state(struct connman_service *service)
+ 		break;
+ 
+ 	case CONNMAN_SERVICE_STATE_FAILURE:
+-		if (service->connect_reason == CONNMAN_SERVICE_CONNECT_REASON_USER ||
+-			service->connect_reason == CONNMAN_SERVICE_CONNECT_REASON_NATIVE) {
++		if (service->connect_reason == CONNMAN_SERVICE_CONNECT_REASON_USER) {
+ 			connman_agent_report_error(service, service->path,
+ 						error2string(service->error),
+ 						report_error_cb,
+ 						get_dbus_sender(service),
+ 						NULL);
+-			goto notifier;
++			//goto notifier;
+ 		}
+ 		service_complete(service);
+ 		break;
+@@ -6165,7 +6314,7 @@ static int service_indicate_state(struct connman_service *service)
+ 
+ 	__connman_connection_update_gateway();
+ 
+-notifier:
++//notifier:
+ 	if ((old_state == CONNMAN_SERVICE_STATE_ONLINE &&
+ 			new_state != CONNMAN_SERVICE_STATE_READY) ||
+ 		(old_state == CONNMAN_SERVICE_STATE_READY &&
+@@ -6352,12 +6501,11 @@ static gboolean redo_wispr_ipv6(gpointer user_data)
+ 	return FALSE;
+ }
+ 
+-void __connman_service_online_check(struct connman_service *service,
+-					enum connman_ipconfig_type type,
+-					bool success)
++int __connman_service_online_check_failed(struct connman_service *service,
++					enum connman_ipconfig_type type)
+ {
+ 	GSourceFunc redo_func;
+-	unsigned int *interval;
++	int *interval;
+ 	enum connman_service_state current_state;
+ 
+ 	if (type == CONNMAN_IPCONFIG_TYPE_IPV4) {
+@@ -6368,7 +6516,7 @@ void __connman_service_online_check(struct connman_service *service,
+ 		redo_func = redo_wispr_ipv6;
+ 	}
+ 
+-	if(!enable_online_to_ready_transition)
++	/*if(!enable_online_to_ready_transition)
+ 		goto redo_func;
+ 
+ 	if (success) {
+@@ -6383,7 +6531,7 @@ void __connman_service_online_check(struct connman_service *service,
+ 		}
+ 	}
+ 
+-redo_func:
++redo_func:*/
+ 	DBG("service %p type %s interval %d", service,
+ 		__connman_ipconfig_type2string(type), *interval);
+ 
+@@ -6395,6 +6543,8 @@ redo_func:
+ 	 */
+ 	if (*interval < online_check_max_interval)
+ 		(*interval)++;
++
++	return EAGAIN;
+ }
+ 
+ int __connman_service_ipconfig_indicate_state(struct connman_service *service,
+@@ -6476,8 +6626,10 @@ int __connman_service_ipconfig_indicate_state(struct connman_service *service,
+ 		if (service->state == CONNMAN_SERVICE_STATE_IDLE)
+ 			return -EINVAL;
+ 
+-		if (type == CONNMAN_IPCONFIG_TYPE_IPV4)
++		if (type == CONNMAN_IPCONFIG_TYPE_IPV4){
+ 			service_rp_filter(service, false);
++			service->state_ipv6 = new_state;
++			}
+ 
+ 		break;
+ 
+@@ -6501,6 +6653,11 @@ int __connman_service_ipconfig_indicate_state(struct connman_service *service,
+ 	if (!is_connected(old_state) && is_connected(new_state))
+ 		nameserver_add_all(service, type);
+ 
++/*	if(new_state==CONNMAN_SERVICE_STATE_READY) {
++		service->state_ipv4 = CONNMAN_SERVICE_STATE_ONLINE;
++		state_changed(service);
++	}*/
++
+ 	__connman_timeserver_sync(service);
+ 
+ 	return service_indicate_state(service);
+@@ -6781,8 +6938,7 @@ int __connman_service_connect(struct connman_service *service,
+ 				service->provider)
+ 			connman_provider_disconnect(service->provider);
+ 
+-	if (reason == CONNMAN_SERVICE_CONNECT_REASON_USER ||
+-			reason == CONNMAN_SERVICE_CONNECT_REASON_NATIVE) {
++	if (reason == CONNMAN_SERVICE_CONNECT_REASON_USER) {
+ 		if (err == -ENOKEY || err == -EPERM) {
+ 			DBusMessage *pending = NULL;
+ 			const char *dbus_sender = get_dbus_sender(service);
+@@ -6805,12 +6961,12 @@ int __connman_service_connect(struct connman_service *service,
+ 			if (service->hidden && err != -EINPROGRESS)
+ 				service->pending = pending;
+ 
+-			if (err == -EINPROGRESS) {
++			/*if (err == -EINPROGRESS) {
+ 				index = __connman_service_get_index(service);
+ 				g_hash_table_replace(passphrase_requested,
+ 						GINT_TO_POINTER(index),
+ 						GINT_TO_POINTER(true));
+-			}
++			}*/
+ 
+ 			return err;
+ 		}
+@@ -6855,6 +7011,11 @@ int __connman_service_disconnect(struct connman_service *service)
+ 	__connman_ipconfig_address_remove(service->ipconfig_ipv4);
+ 	settings_changed(service, service->ipconfig_ipv4);
+ 
++	if (service->type == CONNMAN_SERVICE_TYPE_WIFI &&
++			__connman_ipconfig_get_method(service->ipconfig_ipv4) == CONNMAN_IPCONFIG_METHOD_MANUAL) {
++		__connman_ipconfig_set_method(service->ipconfig_ipv4, CONNMAN_IPCONFIG_METHOD_DHCP);
++	}
++
+ 	__connman_ipconfig_address_remove(service->ipconfig_ipv6);
+ 	settings_changed(service, service->ipconfig_ipv6);
+ 
+@@ -7444,6 +7605,7 @@ static void trigger_autoconnect(struct connman_service *service)
+ struct connman_service * __connman_service_create_from_network(struct connman_network *network)
+ {
+ 	struct connman_service *service;
++	struct connman_device *device;
+ 	const char *ident, *group;
+ 	char *name;
+ 	unsigned int *auto_connect_types, *favorite_types;
+@@ -7530,7 +7692,40 @@ struct connman_service * __connman_service_create_from_network(struct connman_ne
+ 	service_register(service);
+ 	service_schedule_added(service);
+ 
+-	trigger_autoconnect(service);
++	//trigger_autoconnect(service);
++	connman_network_set_autoconnect(network,
++				service->favorite && service->autoconnect);
++	if (service->favorite) {
++		device = connman_network_get_device(service->network);
++		if (device && !connman_device_get_scanning(device,
++						CONNMAN_SERVICE_TYPE_UNKNOWN)) {
++
++			switch (service->type) {
++			case CONNMAN_SERVICE_TYPE_UNKNOWN:
++			case CONNMAN_SERVICE_TYPE_SYSTEM:
++			case CONNMAN_SERVICE_TYPE_P2P:
++				break;
++
++			case CONNMAN_SERVICE_TYPE_GADGET:
++			case CONNMAN_SERVICE_TYPE_ETHERNET:
++				if (service->autoconnect) {
++					__connman_service_connect(service,
++						CONNMAN_SERVICE_CONNECT_REASON_AUTO);
++					break;
++				}
++
++				/* fall through */
++			case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++			case CONNMAN_SERVICE_TYPE_GPS:
++			case CONNMAN_SERVICE_TYPE_VPN:
++			case CONNMAN_SERVICE_TYPE_WIFI:
++			case CONNMAN_SERVICE_TYPE_CELLULAR:
++				do_auto_connect(service,
++					CONNMAN_SERVICE_CONNECT_REASON_AUTO);
++				break;
++			}
++		}
++	}
+ 
+ 	__connman_notifier_service_add(service, service->name);
+ 
+diff --git a/src/session.c b/src/session.c
+index eeefe3f2..a8046ab8 100644
+--- a/src/session.c
++++ b/src/session.c
+@@ -836,7 +836,7 @@ static void append_ipconfig_ipv4(DBusMessageIter *iter, void *user_data)
+ 	if (!ipconfig_ipv4)
+ 		return;
+ 
+-	__connman_ipconfig_append_ipv4(ipconfig_ipv4, iter);
++	__connman_ipconfig_append_ipv4(ipconfig_ipv4, iter, service);
+ }
+ 
+ static void append_ipconfig_ipv6(DBusMessageIter *iter, void *user_data)
+diff --git a/src/wispr.c b/src/wispr.c
+index 8c6ed6c7..8efa95f3 100644
+--- a/src/wispr.c
++++ b/src/wispr.c
+@@ -30,6 +30,9 @@
+ 
+ #include "connman.h"
+ 
++#define STATUS_URL_IPV4  "http://ipv4.connman.net/online/status.html"
++#define STATUS_URL_IPV6  "http://ipv6.connman.net/online/status.html"
++
+ struct connman_wispr_message {
+ 	bool has_error;
+ 	const char *current_element;
+@@ -243,8 +246,10 @@ static void free_connman_wispr_portal(gpointer data)
+ 	if (!wispr_portal)
+ 		return;
+ 
+-	wispr_portal_context_unref(wispr_portal->ipv4_context);
+-	wispr_portal_context_unref(wispr_portal->ipv6_context);
++	//wispr_portal_context_unref(wispr_portal->ipv4_context);
++	//wispr_portal_context_unref(wispr_portal->ipv6_context);
++	free_connman_wispr_portal_context(wispr_portal->ipv4_context);
++	free_connman_wispr_portal_context(wispr_portal->ipv6_context);
+ 
+ 	g_free(wispr_portal);
+ }
+@@ -479,11 +484,13 @@ static void portal_manage_status(GWebResult *result,
+ 				&str))
+ 		connman_info("Client-Timezone: %s", str);
+ 
++	free_connman_wispr_portal_context(wp_context);
++    
+ 	__connman_service_ipconfig_indicate_state(service,
+ 					CONNMAN_SERVICE_STATE_ONLINE, type);
+ 
+-	if (enable_online_to_ready_transition)
+-		__connman_service_online_check(service, type, true);
++	/*if (enable_online_to_ready_transition)
++		__connman_service_online_check(service, type, true);*/
+ }
+ 
+ static bool wispr_route_request(const char *address, int ai_family,
+@@ -539,7 +546,7 @@ static void wispr_portal_request_portal(
+ {
+ 	DBG("");
+ 
+-	wispr_portal_context_ref(wp_context);
++	//wispr_portal_context_ref(wp_context);
+ 	wp_context->request_id = g_web_request_get(wp_context->web,
+ 					wp_context->status_url,
+ 					wispr_portal_web_result,
+@@ -548,7 +555,7 @@ static void wispr_portal_request_portal(
+ 
+ 	if (wp_context->request_id == 0) {
+ 		wispr_portal_error(wp_context);
+-		wispr_portal_context_unref(wp_context);
++		//wispr_portal_context_unref(wp_context);
+ 	}
+ }
+ 
+@@ -616,13 +623,13 @@ static void wispr_portal_browser_reply_cb(struct connman_service *service,
+ 	if (!authentication_done) {
+ 		free_wispr_routes(wp_context);
+ 		wispr_portal_error(wp_context);
+-		wispr_portal_context_unref(wp_context);
++		//wispr_portal_context_unref(wp_context);
+ 		return;
+ 	}
+ 
+ 	/* Restarting the test */
+ 	__connman_service_wispr_start(service, wp_context->type);
+-	wispr_portal_context_unref(wp_context);
++	//wispr_portal_context_unref(wp_context);
+ }
+ 
+ static void wispr_portal_request_wispr_login(struct connman_service *service,
+@@ -646,8 +653,9 @@ static void wispr_portal_request_wispr_login(struct connman_service *service,
+ 				return;
+ 		}
+ 
+-		wispr_portal_context_unref(wp_context);
+-		return;
++		//wispr_portal_context_unref(wp_context);
++		free_connman_wispr_portal_context(wp_context);
++        return;
+ 	}
+ 
+ 	g_free(wp_context->wispr_username);
+@@ -698,12 +706,12 @@ static bool wispr_manage_message(GWebResult *result,
+ 
+ 		wp_context->wispr_result = CONNMAN_WISPR_RESULT_LOGIN;
+ 
+-		wispr_portal_context_ref(wp_context);
++		//wispr_portal_context_ref(wp_context);
+ 		if (__connman_agent_request_login_input(wp_context->service,
+ 					wispr_portal_request_wispr_login,
+ 					wp_context) != -EINPROGRESS) {
+ 			wispr_portal_error(wp_context);
+-			wispr_portal_context_unref(wp_context);
++			//wispr_portal_context_unref(wp_context);
+ 		} else
+ 			return true;
+ 
+@@ -753,7 +761,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 		if (length > 0) {
+ 			g_web_parser_feed_data(wp_context->wispr_parser,
+ 								chunk, length);
+-			wispr_portal_context_unref(wp_context);
++			//wispr_portal_context_unref(wp_context);
+ 			return true;
+ 		}
+ 
+@@ -771,7 +779,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 
+ 	switch (status) {
+ 	case 000:
+-		wispr_portal_context_ref(wp_context);
++		//wispr_portal_context_ref(wp_context);
+ 		__connman_agent_request_browser(wp_context->service,
+ 				wispr_portal_browser_reply_cb,
+ 				wp_context->status_url, wp_context);
+@@ -783,10 +791,10 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 		if (g_web_result_get_header(result, "X-ConnMan-Status",
+ 						&str)) {
+ 			portal_manage_status(result, wp_context);
+-			wispr_portal_context_unref(wp_context);
++			//wispr_portal_context_unref(wp_context);
+ 			return false;
+ 		} else {
+-			wispr_portal_context_ref(wp_context);
++			//wispr_portal_context_ref(wp_context);
+ 			__connman_agent_request_browser(wp_context->service,
+ 					wispr_portal_browser_reply_cb,
+ 					wp_context->redirect_url, wp_context);
+@@ -803,7 +811,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 			!g_web_result_get_header(result, "Location",
+ 							&redirect)) {
+ 
+-			wispr_portal_context_ref(wp_context);
++			//wispr_portal_context_ref(wp_context);
+ 			__connman_agent_request_browser(wp_context->service,
+ 					wispr_portal_browser_reply_cb,
+ 					wp_context->status_url, wp_context);
+@@ -814,7 +822,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 
+ 		wp_context->redirect_url = g_strdup(redirect);
+ 
+-		wispr_portal_context_ref(wp_context);
++		//wispr_portal_context_ref(wp_context);
+ 		wp_context->request_id = g_web_request_get(wp_context->web,
+ 				redirect, wispr_portal_web_result,
+ 				wispr_route_request, wp_context);
+@@ -822,12 +830,19 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 		goto done;
+ 	case 400:
+ 	case 404:
+-		__connman_service_online_check(wp_context->service,
+-						wp_context->type, false);
++	/*	__connman_service_online_check(wp_context->service,
++						wp_context->type, false);*/
++
++	if (__connman_service_online_check_failed(wp_context->service,
++						wp_context->type) == 0) {
++			wispr_portal_error(wp_context);
++			free_connman_wispr_portal_context(wp_context);
++			return false;
++		}
+ 
+ 		break;
+ 	case 505:
+-		wispr_portal_context_ref(wp_context);
++		//wispr_portal_context_ref(wp_context);
+ 		__connman_agent_request_browser(wp_context->service,
+ 				wispr_portal_browser_reply_cb,
+ 				wp_context->status_url, wp_context);
+@@ -840,7 +855,7 @@ static bool wispr_portal_web_result(GWebResult *result, gpointer user_data)
+ 	wp_context->request_id = 0;
+ done:
+ 	wp_context->wispr_msg.message_type = -1;
+-	wispr_portal_context_unref(wp_context);
++	//wispr_portal_context_unref(wp_context);
+ 	return false;
+ }
+ 
+@@ -875,7 +890,7 @@ static void proxy_callback(const char *proxy, void *user_data)
+ 					xml_wispr_parser_callback, wp_context);
+ 
+ 	wispr_portal_request_portal(wp_context);
+-	wispr_portal_context_unref(wp_context);
++	//wispr_portal_context_unref(wp_context);
+ }
+ 
+ static gboolean no_proxy_callback(gpointer user_data)
+@@ -951,10 +966,10 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
+ 
+ 	if (wp_context->type == CONNMAN_IPCONFIG_TYPE_IPV4) {
+ 		g_web_set_address_family(wp_context->web, AF_INET);
+-		wp_context->status_url = online_check_ipv4_url;
++		wp_context->status_url = STATUS_URL_IPV4;
+ 	} else {
+ 		g_web_set_address_family(wp_context->web, AF_INET6);
+-		wp_context->status_url = online_check_ipv6_url;
++		wp_context->status_url = STATUS_URL_IPV6;
+ 	}
+ 
+ 	for (i = 0; nameservers[i]; i++)
+@@ -970,7 +985,7 @@ static int wispr_portal_detect(struct connman_wispr_portal_context *wp_context)
+ 
+ 		if (wp_context->token == 0) {
+ 			err = -EINVAL;
+-			wispr_portal_context_unref(wp_context);
++			//wispr_portal_context_unref(wp_context);
+ 		}
+ 	} else if (wp_context->timeout == 0) {
+ 		wp_context->timeout = g_idle_add(no_proxy_callback, wp_context);
+@@ -1019,7 +1034,8 @@ int __connman_wispr_start(struct connman_service *service,
+ 
+ 	/* If there is already an existing context, we wipe it */
+ 	if (wp_context)
+-		wispr_portal_context_unref(wp_context);
++		//wispr_portal_context_unref(wp_context);
++		free_connman_wispr_portal_context(wp_context);
+ 
+ 	wp_context = create_wispr_portal_context();
+ 	if (!wp_context)
+@@ -1077,13 +1093,13 @@ int __connman_wispr_init(void)
+ 						g_direct_equal, NULL,
+ 						free_connman_wispr_portal);
+ 
+-	online_check_ipv4_url =
++	/*online_check_ipv4_url =
+ 		connman_setting_get_string("OnlineCheckIPv4URL");
+ 	online_check_ipv6_url =
+ 		connman_setting_get_string("OnlineCheckIPv6URL");
+ 
+ 	enable_online_to_ready_transition =
+-		connman_setting_get_bool("EnableOnlineToReadyTransition");
++		connman_setting_get_bool("EnableOnlineToReadyTransition");*/
+ 
+ 	return 0;
+ }
+-- 
+2.37.3.windows.1
+

--- a/meta-luneos/recipes-connectivity/connman/connman/0007-Fix-for-create-group-api-and-crash-issue.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0007-Fix-for-create-group-api-and-crash-issue.patch
@@ -1,0 +1,1285 @@
+From 93374ace07c26124ded33a8d5e78c4b81de6939f Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Tue, 1 Nov 2022 17:50:06 +0530
+Subject: [PATCH] Fix for create group api and crash issue
+
+:Release Notes:
+Fix for create group api and crash issue
+
+:Detailed Notes:
+Fix for create group api and crash issue
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11079] - Fix for create group api and crash issue
+
+Change-Id: I17b556c60ce3c696ce1b985dca10eb5f83af7cf2
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338350
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ client/commands.c         |  27 +++-----
+ gsupplicant/gsupplicant.h |  83 +++++++++++++++++++++++-
+ gsupplicant/supplicant.c  | 132 +++++++++++++++++++++++++++++++++++++-
+ include/technology.h      |   9 +++
+ plugins/ethernet.c        |  12 ++--
+ plugins/wifi.c            |  21 ++++--
+ src/connman.h             |   6 ++
+ src/device.c              | 116 +++++++++++++++++++++++++++++++++
+ src/inet.c                |   7 ++
+ src/network.c             |   8 +++
+ src/peer.c                |  72 +++++++++++++++++++--
+ src/rtnl.c                | 125 ++++++++++++++++++------------------
+ src/technology.c          |  43 +++++++++++++
+ src/wispr.c               |   5 ++
+ 14 files changed, 568 insertions(+), 98 deletions(-)
+
+diff --git a/client/commands.c b/client/commands.c
+index 53cc14c8..f8b43921 100644
+--- a/client/commands.c
++++ b/client/commands.c
+@@ -557,16 +557,14 @@ static int tether_update(struct tether_properties *tether)
+ {
+ 	int ret;
+ 
+-	if (tether->ssid_result == 0 && tether->passphrase_result == 0 &&
+-			tether->freq_result == 0) {
++	if (tether->ssid_result == 0 && tether->passphrase_result == 0) {
+ 		ret = tether_set("wifi", tether->set_tethering);
+ 		g_free(tether);
+ 		return ret;
+ 	}
+ 
+ 	if (tether->ssid_result != -EINPROGRESS &&
+-			tether->passphrase_result != -EINPROGRESS &&
+-			tether->freq_result != -EINPROGRESS) {
++			tether->passphrase_result != -EINPROGRESS) {
+ 		g_free(tether);
+ 		return 0;
+ 	}
+@@ -622,9 +620,9 @@ static int tether_set_freq_return(DBusMessageIter *iter, int errnum,
+ 	return tether_update(tether);
+ }
+ 
+-static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering, int freq)
++static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering)
+ {
+-	struct tether_properties *tether = g_new0(struct tether_properties, 1);
++	struct tether_properties *tether = g_new(struct tether_properties, 1);
+ 
+ 	tether->set_tethering = set_tethering;
+ 
+@@ -640,17 +638,9 @@ static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering, int
+ 			tether_set_passphrase_return, tether,
+ 			"TetheringPassphrase", DBUS_TYPE_STRING, &passphrase);
+ 
+-	if (freq > 0) {
+-		tether->freq_result =__connmanctl_dbus_set_property(connection,
+-				"/net/connman/technology/wifi",
+-				"net.connman.Technology",
+-				tether_set_freq_return, tether,
+-				"TetheringFreq", DBUS_TYPE_INT32, &freq);
+-	}
+ 
+ 	if (tether->ssid_result != -EINPROGRESS &&
+-			tether->passphrase_result != -EINPROGRESS &&
+-			tether->freq_result != -EINPROGRESS) {
++			tether->passphrase_result != -EINPROGRESS) {
+ 		g_free(tether);
+ 		return -ENXIO;
+ 	}
+@@ -666,6 +656,9 @@ static int cmd_tether(char *args[], int num, struct connman_option *options)
+ 	if (num < 3)
+ 		return -EINVAL;
+ 
++	passphrase = args[num - 1];
++	ssid = args[num - 2];
++
+ 	set_tethering = parse_boolean(args[2]);
+ 
+ 	if (strcmp(args[1], "wifi") == 0) {
+@@ -689,7 +682,7 @@ static int cmd_tether(char *args[], int num, struct connman_option *options)
+ 		ssid = args[num - 2];
+ 
+ 		if (num > 3)
+-			return tether_set_ssid(ssid, passphrase, set_tethering, freq);
++			return tether_set_ssid(ssid, passphrase, set_tethering);
+ 	}
+ 
+ 	if (num > 3)
+@@ -2800,7 +2793,7 @@ static const struct {
+ 	  "Disables given technology or offline mode",
+ 	  lookup_technology_offline },
+ 	{ "tether", "<technology> on|off\n"
+-	            "            wifi [on|off] <ssid> <passphrase> [<freq>] ",
++	            "            wifi [on|off] <ssid> <passphrase> ",
+ 	                                  NULL,            cmd_tether,
+ 	  "Enable, disable tethering, set SSID and passphrase for wifi",
+ 	  lookup_tether },
+diff --git a/gsupplicant/gsupplicant.h b/gsupplicant/gsupplicant.h
+index ba934c18..b29a66d7 100644
+--- a/gsupplicant/gsupplicant.h
++++ b/gsupplicant/gsupplicant.h
+@@ -404,6 +404,11 @@ typedef void (*GSupplicantInterfaceCallback) (int result,
+ 					GSupplicantInterface *interface,
+ 							void *user_data);
+ 
++typedef void (*GSupplicantInterfaceBcmCallback) (int result,
++					GSupplicantInterface *interface,
++						const char *cmd_response,
++							void *user_data);
++int dev_type_str2bin(const char *type, unsigned char dev_type[8]);
+ void g_supplicant_interface_cancel(GSupplicantInterface *interface);
+ 
+ int g_supplicant_interface_create(const char *ifname, const char *driver,
+@@ -463,8 +468,56 @@ int g_supplicant_interface_p2p_wps_start(GSupplicantInterface *interface,
+ 													GSupplicantP2PWPSParams *wps_data,
+ 													GSupplicantInterfaceCallback callback,
+ 													void *user_data);
++
++int g_supplicant_interface_p2p_remove_all_persistent_groups(GSupplicantInterface *interface);
++int g_supplicant_interface_p2p_add_persistent_group(GSupplicantInterface *interface,
++										GSupplicantSSID *ssid, void *user_data);
++
++int g_supplicant_interface_p2p_sd_request(GSupplicantInterface *interface,
++				GSupplicantP2PSDParams *sd_data,
++				GSupplicantInterfaceCallbackWithData callback,
++				void *user_data);
++
++int g_supplicant_interface_p2p_sd_cancel_request(GSupplicantInterface *interface,
++				dbus_uint64_t request_id,
++				GSupplicantInterfaceCallback callback,
++				void *user_data);
++
++int g_supplicant_interface_p2p_replace_service(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback,
++				GSupplicantP2PServiceParams *p2p_service_params,
++				void *user_data);
++
++int g_supplicant_interface_p2p_asp_provision_request(GSupplicantInterface *interface,
++										  GSupplicantP2PASPProvisionRequestParams *sd_data,
++										  GSupplicantInterfaceCallback callback,
++										  void *user_data);
++
++int g_supplicant_interface_p2p_asp_provision_response(GSupplicantInterface *interface,
++                                                      GSupplicantP2PASPProvisionResponseParams *params,
++                                                      GSupplicantInterfaceCallback callback,
++                                                      void *user_data);
++
++int g_supplicant_interface_p2p_read_device_address(GSupplicantInterface *interface,
++                                                   GSupplicantInterfaceCallback callback, void *user_data);
++
++const unsigned char *g_supplicant_interface_p2p_get_device_address(GSupplicantInterface *interface);
++
++
+ int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
+ 				GSupplicantP2PServiceParams *p2p_service_params);
++
++int g_supplicant_interface_p2p_reject(GSupplicantInterface *interface,
++					GSupplicantPeerParams *peer_params, GSupplicantInterfaceCallback callback,
++					void *user_data);
++
++int g_supplicant_interface_p2p_client_remove(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++					char* peer_path);
++
++int g_supplicant_interface_p2p_cancel(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback, void *user_data);
++
+ int g_supplicant_interface_p2p_flush(GSupplicantInterface *interface,
+ 				GSupplicantInterfaceCallback callback, void *user_data);
+ int g_supplicant_interface_p2p_invite(GSupplicantInterface *interface,
+@@ -487,6 +540,10 @@ int g_supplicant_interface_disconnect(GSupplicantInterface *interface,
+ int g_supplicant_interface_set_bss_expiration_age(GSupplicantInterface *interface,
+ 					unsigned int bss_expiration_age);
+ 
++int g_supplicant_interface_wps_cancel(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++							void *user_data);
++
+ int g_supplicant_interface_set_apscan(GSupplicantInterface *interface,
+ 							unsigned int ap_scan);
+ 
+@@ -572,12 +629,18 @@ dbus_uint16_t g_supplicant_bss_get_frequency(GSupplicantBss *bss);
+ 
+ GSupplicantInterface *g_supplicant_peer_get_interface(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_path(GSupplicantPeer *peer);
++dbus_uint16_t g_supplicant_peer_get_config_methods(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_identifier(GSupplicantPeer *peer);
+ const void *g_supplicant_peer_get_device_address(GSupplicantPeer *peer);
+ const void *g_supplicant_peer_get_iface_address(GSupplicantPeer *peer);
++const char *g_supplicant_peer_get_ip_address(GSupplicantPeer *peer);
++
+ const char *g_supplicant_peer_get_name(GSupplicantPeer *peer);
+ const unsigned char *g_supplicant_peer_get_widi_ies(GSupplicantPeer *peer,
+ 								int *length);
++dbus_int32_t g_supplicant_peer_get_level(GSupplicantPeer *peer);
++const char *g_supplicant_peer_get_pri_dev_type(GSupplicantPeer *peer);
++int g_supplicant_peer_get_failure_status(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_wps_pbc(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_wps_pin(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_in_a_group(GSupplicantPeer *peer);
+@@ -590,9 +653,27 @@ const char *g_supplicant_peer_identifier_from_intf_address(const char* pintf_add
+ const char *g_supplicant_peer_wfds_get_identifier(GSupplicantPeer *peer);
+ int g_supplicant_peer_wfds_get_asp_services(GSupplicantPeer *peer, GSupplicantP2PService** services);
+ const char *g_supplicant_peer_wfds_get_peer_name(GSupplicantPeer *peer);
+-char *g_supplicant_group_get_ssid(GSupplicantGroup *group);
++
++int g_supplicant_interface_bcm_private_cmd(GSupplicantInterface *interface,const char *driver_cmd,
++			GSupplicantInterfaceBcmCallback callback,void *user_data);
++
++GSupplicantInterface *g_supplicant_group_get_interface(GSupplicantGroup *group);
++GSupplicantInterface *g_supplicant_group_get_orig_interface(GSupplicantGroup *group);
++char *g_supplicant_group_get_object_path(GSupplicantGroup *group);
++char *g_supplicant_group_get_bssid_no_colon(GSupplicantGroup *group);
++GSupplicantGroup *g_supplicant_get_group(const char *path);
++GSupplicantP2PPersistentGroup* g_supplicant_interface_get_p2p_persistent_group(GSupplicantInterface *interface, GSupplicantGroup *group);
+ unsigned int g_supplicant_network_get_keymgmt(GSupplicantNetwork *network);
+ 
++int g_supplicant_group_get_role(GSupplicantGroup *group);
++char *g_supplicant_group_get_ssid(GSupplicantGroup *group);
++char *g_supplicant_group_get_passphrase(GSupplicantGroup *group);
++int g_supplicant_group_get_frequency(GSupplicantGroup *group);
++bool g_supplicant_group_get_persistent(GSupplicantGroup *group);
++char *g_supplicant_group_get_ip_addr(GSupplicantGroup *group);
++char *g_supplicant_group_get_ip_mask(GSupplicantGroup *group);
++char *g_supplicant_group_get_go_ip_addr(GSupplicantGroup *group);
++
+ struct _GSupplicantCallbacks {
+ 	void (*system_ready) (void);
+ 	void (*system_killed) (void);
+diff --git a/gsupplicant/supplicant.c b/gsupplicant/supplicant.c
+index 353fe9d6..cc0a16e9 100644
+--- a/gsupplicant/supplicant.c
++++ b/gsupplicant/supplicant.c
+@@ -1115,6 +1115,16 @@ static void remove_group(gpointer data)
+ 	g_free(group);
+ }
+ 
++static void callback_wps_state(GSupplicantInterface *interface)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->wps_state == NULL)
++		return;
++
++	callbacks_pointer->wps_state(interface);
++}
+ 
+ static void remove_interface(gpointer data)
+ {
+@@ -3615,6 +3625,58 @@ static void signal_wps_event(const char *path, DBusMessageIter *iter)
+ 	dbus_message_iter_next(iter);
+ 
+ 	supplicant_dbus_property_foreach(iter, wps_event_args, interface);
++
++	callback_wps_state(interface);
++}
++
++static void signal_station_connected(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++	const char *sta_mac = NULL;
++
++	SUPPLICANT_DBG("path %s %s", path, SUPPLICANT_PATH);
++
++	if (callbacks_pointer->station_added == NULL)
++		return;
++
++	if (g_strcmp0(path, "/") == 0)
++		return;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
++
++	dbus_message_iter_get_basic(iter, &sta_mac);
++	if (sta_mac == NULL)
++		return;
++
++	SUPPLICANT_DBG("New station %s connected", sta_mac);
++	callbacks_pointer->station_added(sta_mac);
++}
++
++static void signal_station_disconnected(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++	const char *sta_mac = NULL;
++
++	SUPPLICANT_DBG("path %s %s", path, SUPPLICANT_PATH);
++
++	if (callbacks_pointer->station_removed == NULL)
++		return;
++
++	if (g_strcmp0(path, "/") == 0)
++		return;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
++
++	dbus_message_iter_get_basic(iter, &sta_mac);
++	if (sta_mac == NULL)
++		return;
++
++	SUPPLICANT_DBG("Station %s disconnected", sta_mac);
++	callbacks_pointer->station_removed(sta_mac);
+ }
+ 
+ static void create_peer_identifier(GSupplicantPeer *peer)
+@@ -4948,6 +5010,62 @@ static void interface_p2p_prov_disc_request_or_response(DBusMessageIter *iter,
+ 		                                     (void *)pin);
+ 	}
+ }
++
++static void signal_prov_disc_requested_pbc(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, true, "pbc");
++}
++
++static void signal_prov_disc_requested_enter_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, true, "enter_pin");
++}
++
++static void signal_prov_disc_requested_disp_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, true, "disp_pin");
++}
++
++static void signal_prov_disc_response_enter_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, false, "enter_pin");
++}
++
++static void signal_prov_disc_response_disp_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, false, "disp_pin");
++}
++
+ static void interface_p2p_prov_disc_fail(DBusMessageIter *iter, void *user_data)
+ {
+ 	GSupplicantInterface *interface = user_data;
+@@ -5789,6 +5907,9 @@ static struct {
+ 	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_sta_authorized    },
+ 	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_sta_deauthorized  },
+ 
++	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_station_connected   },
++	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_station_disconnected },
++
+ 	{ SUPPLICANT_INTERFACE ".BSS", "PropertiesChanged", signal_bss_changed   },
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Credentials", signal_wps_credentials },
+@@ -5811,6 +5932,15 @@ static struct {
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionStart", signal_p2ps_prov_start	},
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionDone",	 signal_p2ps_prov_done	},
++
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryPBCRequest",	signal_prov_disc_requested_pbc },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryRequestEnterPin",	signal_prov_disc_requested_enter_pin },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryRequestDisplayPin",	signal_prov_disc_requested_disp_pin },
++
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryResponseEnterPin",	signal_prov_disc_response_enter_pin },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryResponseDisplayPin",	signal_prov_disc_response_disp_pin },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryFailure",	signal_prov_disc_fail },
++
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationResult", signal_invitation_result },
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationReceived", signal_invitation_received	},
+ 	{ SUPPLICANT_INTERFACE ".Group", "PeerJoined", signal_group_peer_joined },
+@@ -6063,7 +6193,7 @@ static void p2p_device_config_result(const char *error,
+ 	dbus_free(config);
+ }
+ 
+-static int dev_type_str2bin(const char *type, unsigned char dev_type[8])
++int dev_type_str2bin(const char *type, unsigned char dev_type[8])
+ {
+ 	int length, pos, end;
+ 	char b[3] = {};
+diff --git a/include/technology.h b/include/technology.h
+index 6f721ee5..ffc951d2 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -39,6 +39,9 @@ struct connman_technology;
+ 
+ int connman_technology_tethering_notify(struct connman_technology *technology,
+ 							bool enabled);
++void connman_technology_interface_changed(struct connman_technology *technology);
++int connman_technology_add_station(enum connman_service_type type, const char *mac);
++int connman_technology_remove_station(char *mac);
+ int connman_technology_set_regdom(const char *alpha2);
+ void connman_technology_regdom_notify(struct connman_technology *technology,
+ 							const char *alpha2);
+@@ -58,10 +61,16 @@ bool connman_technology_get_enable_p2p_listen(struct connman_technology *technol
+ bool connman_technology_get_p2p_listen(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen(struct connman_technology *technology,
+ 							bool enabled);
++void __connman_technology_p2p_invitation_result(struct connman_technology *technology,
++							int status);
++void connman_technology_set_p2p_listen_params(struct connman_technology *technology,
++						int period, int interval);
+ unsigned int connman_technology_get_p2p_listen_channel(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen_channel(struct connman_technology *technology,
+ 									unsigned int listen_channel);
+ void connman_technology_wps_failed_notify(struct connman_technology *technology);
++bool connman_technology_get_p2p_persistent(struct connman_technology *technology);
++void connman_technology_set_p2p_persistent(struct connman_technology *technology, bool enabled);
+ 
+ struct connman_technology_driver {
+ 	const char *name;
+diff --git a/plugins/ethernet.c b/plugins/ethernet.c
+index 27a3dcf3..265a7b09 100644
+--- a/plugins/ethernet.c
++++ b/plugins/ethernet.c
+@@ -73,7 +73,7 @@ static int get_vlan_vid(const char *ifname)
+ 		return -errno;
+ 
+ 	vifr.cmd = GET_VLAN_VID_CMD;
+-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
++	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
+ 
+ 	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
+ 		vid = vifr.u.VID;
+@@ -99,16 +99,14 @@ static int get_dsa_port(const char *ifname)
+ 		return -errno;
+ 
+ 	memset(&ifr, 0, sizeof(ifr));
+-	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name) - 1);
++	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+ 
+ 	/* check if it is a vlan and get physical interface name*/
+ 	vifr.cmd = GET_VLAN_REALDEV_NAME_CMD;
+-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
++	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
+ 
+-	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0) {
+-		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name) - 1);
+-		ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+-	}
++	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
++		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name));
+ 
+ 	/* get driver info */
+ 	drvinfocmd.cmd =  ETHTOOL_GDRVINFO;
+diff --git a/plugins/wifi.c b/plugins/wifi.c
+index 101c0e7a..051ba7dc 100644
+--- a/plugins/wifi.c
++++ b/plugins/wifi.c
+@@ -750,7 +750,10 @@ static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technolo
+ 
+ 		info->wifi = wifi;
+ 		info->technology = technology;
+-
++		
++		group_msg = dbus_message_ref(msg);
++		DBG("piyush log connman group_msg :   %s", group_msg);
++		
+ 		if (identifier || passphrase) {
+ 			snprintf(p2p_ssid, P2P_MAX_SSID, "%s%s", P2P_WILDCARD_SSID, identifier);
+ 			info->ssid = ssid_ap_init(p2p_ssid, passphrase);
+@@ -763,7 +766,6 @@ static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technolo
+ 					NULL, info);
+ 		}
+ 
+-		group_msg = dbus_message_ref(msg);
+ 		create_group_flag = true;
+ 	}
+ 
+@@ -5507,6 +5509,7 @@ static void assoc_status_code(GSupplicantInterface *interface, int status_code)
+ 
+ static void p2p_group_started(GSupplicantGroup *group)
+ {
++	DBG("piyush 1 log connman group_msg :  ");
+ 	struct wifi_data *wifi;
+ 	GSList *item;
+ 	GSupplicantP2PPersistentGroup *persistent_group;
+@@ -5520,7 +5523,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 	if (!wifi)
+ 		return;
+-
++	DBG("piyush 2 log connman group_msg :  ");
+ 	const char* bssid_no_colon = g_supplicant_group_get_bssid_no_colon(group);
+ 	const char *ssid = g_supplicant_group_get_ssid(group);
+ 	const char *passphrase = g_supplicant_group_get_passphrase(group);
+@@ -5533,6 +5536,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 	/* persistent check */
+ 	item = wifi->persistent_groups;
++		DBG("piyush 3 log connman group_msg :  ");
+ 	while(item != NULL) {
+ 		persistent_group = item->data;
+ 
+@@ -5558,6 +5562,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 		item = g_slist_next(item);
+ 	}
++		DBG("piyush 4 log connman group_msg :  ");
+ 	bool is_group_owner = false;
+ 	if (g_supplicant_group_get_role(group) == G_SUPPLICANT_GROUP_ROLE_GO) {
+ 		is_group_owner = true;
+@@ -5568,7 +5573,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 		if (create_group_flag)
+ 			__connman_p2p_go_set_enabled();
+ 	}
+-
++	DBG("piyush 5 log connman group_msg :  ");
+ 	int freq = g_supplicant_group_get_frequency(group);
+ 	bool persistent = g_supplicant_group_get_persistent(group);
+ 
+@@ -5576,7 +5581,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 					is_group_owner, persistent, go_path, create_group_flag, freq);
+ 
+ 	const char *connman_group_path = __connman_group_get_path(connman_group);
+-
++	DBG("piyush 6 log connman group_msg :  ");
+ 	if (is_group_owner) {
+ 		p2p_go_identifier = g_strdup(__connman_group_get_identifier(connman_group));
+ 	} else {
+@@ -5600,8 +5605,10 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 			peer_changed(supplicant_peer, G_SUPPLICANT_PEER_GROUP_JOINED);
+ 		}
+ 	}
+-
++		DBG("piyush 7 log connman group_msg :  ");
++	DBG("piyush 1new log connman group_msg :   %c", group_msg);
+ 	if (is_group_owner && create_group_flag) {
++		DBG("piyush 8 log connman group_msg :  ");
+ 		g_dbus_send_reply(connection, group_msg,
+ 						DBUS_TYPE_OBJECT_PATH, &connman_group_path,
+ 						DBUS_TYPE_INVALID);
+@@ -6320,6 +6327,8 @@ static int wifi_init(void)
+ {
+ 	int err;
+ 
++	connection = connman_dbus_get_connection();
++
+ 	err = connman_network_driver_register(&network_driver);
+ 	if (err < 0)
+ 		return err;
+diff --git a/src/connman.h b/src/connman.h
+index d4714122..8c8f2e4f 100644
+--- a/src/connman.h
++++ b/src/connman.h
+@@ -471,6 +471,7 @@ typedef void (* dhcpv6_cb) (struct connman_network *network,
+ typedef void (* dhcp_cb) (struct connman_ipconfig *ipconfig,
+ 			struct connman_network *opt_network,
+ 			bool success, gpointer data);
++char *__connman_dhcp_get_client_address(struct connman_ipconfig *ipconfig);
+ char *__connman_dhcp_get_server_address(struct connman_ipconfig *ipconfig);
+ int __connman_dhcp_start(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network, dhcp_cb callback,
+@@ -509,6 +510,8 @@ int __connman_connection_gateway_add(struct connman_service *service,
+ 					const char *peer);
+ void __connman_connection_gateway_remove(struct connman_service *service,
+ 					enum connman_ipconfig_type type);
++char *find_service_gateway(struct connman_service *service);
++
+ int __connman_connection_get_vpn_index(int phy_index);
+ int __connman_connection_get_vpn_phy_index(int vpn_index);
+ 
+@@ -577,6 +580,8 @@ enum connman_service_type __connman_device_get_service_type(struct connman_devic
+ struct connman_device *__connman_device_find_device(enum connman_service_type type);
+ int __connman_device_request_scan(enum connman_service_type type);
+ int __connman_device_request_scan_full(enum connman_service_type type);
++int __connman_device_request_start_wps(enum connman_service_type type, const char *pin);
++int __connman_device_request_cancel_wps(enum connman_service_type type);
+ int __connman_device_request_cancel_p2p(enum connman_service_type type);
+ int __connman_device_request_hidden_scan(struct connman_device *device,
+ 				const char *ssid, unsigned int ssid_len,
+@@ -770,6 +775,7 @@ int __connman_service_indicate_default(struct connman_service *service);
+ int __connman_service_connect(struct connman_service *service,
+ 			enum connman_service_connect_reason reason);
+ int __connman_service_disconnect(struct connman_service *service);
++int __connman_service_disconnect_all(void);
+ void __connman_service_set_active_session(bool enable, GSList *list);
+ void __connman_service_auto_connect(enum connman_service_connect_reason reason);
+ bool __connman_service_remove(struct connman_service *service);
+diff --git a/src/device.c b/src/device.c
+index 6d4feaad..f1560b81 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -1232,6 +1232,122 @@ void __connman_device_stop_scan(enum connman_service_type type)
+ 	}
+ }
+ 
++static int device_start_wps(struct connman_device *device, const char *pin)
++{
++	if (!device->driver || !device->driver->start_wps)
++		return -EOPNOTSUPP;
++
++	if (device->powered == FALSE)
++	        return -ENOLINK;
++
++	__connman_device_disconnect(device);
++
++	return device->driver->start_wps(device, pin);
++}
++
++int __connman_device_request_start_wps(enum connman_service_type type, const char *pin)
++{
++	bool success = FALSE;
++	int last_err = -ENOSYS;
++	GSList *list;
++	int err;
++
++	switch (type) {
++	case CONNMAN_SERVICE_TYPE_UNKNOWN:
++	case CONNMAN_SERVICE_TYPE_SYSTEM:
++	case CONNMAN_SERVICE_TYPE_ETHERNET:
++	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++	case CONNMAN_SERVICE_TYPE_CELLULAR:
++	case CONNMAN_SERVICE_TYPE_GPS:
++	case CONNMAN_SERVICE_TYPE_VPN:
++	case CONNMAN_SERVICE_TYPE_GADGET:
++		return -EOPNOTSUPP;
++	case CONNMAN_SERVICE_TYPE_WIFI:
++		break;
++	}
++
++	for (list = device_list; list != NULL; list = list->next) {
++		struct connman_device *device = list->data;
++		enum connman_service_type service_type =
++			__connman_device_get_service_type(device);
++
++		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN &&
++				service_type != type) {
++			continue;
++		}
++
++		err = device_start_wps(device, pin);
++		if (err == 0) {
++			success = TRUE;
++		} else {
++			last_err = err;
++			DBG("device %p err %d", device, err);
++		}
++	}
++
++	if (success == TRUE)
++		return 0;
++
++	return last_err;
++}
++
++static int device_cancel_wps(struct connman_device *device)
++{
++	if (!device->driver || !device->driver->cancel_wps)
++		return -EOPNOTSUPP;
++
++	if (device->powered == FALSE)
++		return -ENOLINK;
++
++	return device->driver->cancel_wps(device);
++}
++
++int __connman_device_request_cancel_wps(enum connman_service_type type)
++{
++	bool success = FALSE;
++	int last_err = -ENOSYS;
++	GSList *list;
++	int err;
++
++	switch (type) {
++	case CONNMAN_SERVICE_TYPE_UNKNOWN:
++	case CONNMAN_SERVICE_TYPE_SYSTEM:
++	case CONNMAN_SERVICE_TYPE_ETHERNET:
++	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++	case CONNMAN_SERVICE_TYPE_CELLULAR:
++	case CONNMAN_SERVICE_TYPE_GPS:
++	case CONNMAN_SERVICE_TYPE_VPN:
++	case CONNMAN_SERVICE_TYPE_GADGET:
++		return -EOPNOTSUPP;
++	case CONNMAN_SERVICE_TYPE_WIFI:
++		break;
++	}
++
++	for (list = device_list; list != NULL; list = list->next) {
++		struct connman_device *device = list->data;
++		enum connman_service_type service_type =
++			__connman_device_get_service_type(device);
++
++		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN &&
++			service_type != type) {
++			continue;
++		}
++
++		err = device_cancel_wps(device);
++		if (err == 0) {
++			success = TRUE;
++		} else {
++			last_err = err;
++			DBG("device %p err %d", device, err);
++		}
++	}
++
++	if (success == TRUE)
++		return 0;
++
++	return last_err;
++}
++
+ static int device_cancel_p2p(struct connman_device *device)
+ {
+ 	if (!device->driver || !device->driver->cancel_p2p)
+diff --git a/src/inet.c b/src/inet.c
+index 4039a73c..df94d1ee 100644
+--- a/src/inet.c
++++ b/src/inet.c
+@@ -1836,6 +1836,13 @@ int __connman_inet_ipv6_send_rs(int index, int timeout,
+ 	return 0;
+ }
+ 
++static inline void ipv6_addr_advert_mult(const struct in6_addr *addr,
++					struct in6_addr *advert)
++{
++	ipv6_addr_set(advert, htonl(0xFF020000), 0, htonl(0x2),
++			htonl(0xFF000000) | addr->s6_addr32[3]);
++}
++
+ #define MSG_SIZE_SEND 1452
+ 
+ static int inc_len(int len, int inc)
+diff --git a/src/network.c b/src/network.c
+index a46c763c..123a5183 100644
+--- a/src/network.c
++++ b/src/network.c
+@@ -489,6 +489,8 @@ static void dhcp_callback(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network,
+ 			bool success, gpointer data)
+ {
++	connman_info("DHCP success %d",success);
++
+ 	network->connecting = false;
+ 
+ 	if (success)
+@@ -1246,6 +1248,7 @@ static void network_destruct(struct connman_network *network)
+ 	g_free(network->wifi.private_key_passphrase);
+ 	g_free(network->wifi.phase2_auth);
+ 	g_free(network->wifi.pin_wps);
++	g_hash_table_destroy(network->wifi.bss);
+ 
+ 	g_free(network->path);
+ 	g_free(network->group);
+@@ -1253,9 +1256,11 @@ static void network_destruct(struct connman_network *network)
+ 	g_free(network->name);
+ 	g_free(network->identifier);
+ 	acd_host_free(network->acd_host);
++	g_free(network->address);
+ 
+ 	network->device = NULL;
+ 
++	network->wifi.bss = NULL;
+ 	g_free(network);
+ }
+ 
+@@ -1290,6 +1295,7 @@ struct connman_network *connman_network_create(const char *identifier,
+ 	network->identifier = ident;
+ 	network->acd_host = NULL;
+ 	network->ipv4ll_timeout = 0;
++	network->wifi.bss   = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+ 
+ 	network_list = g_slist_prepend(network_list, network);
+ 
+@@ -1814,6 +1820,8 @@ int __connman_network_connect(struct connman_network *network)
+ 	if (!network->device)
+ 		return -ENODEV;
+ 
++	__connman_device_disconnect(network->device);
++
+ 	network->connecting = true;
+ 
+ 	err = network->driver->connect(network);
+diff --git a/src/peer.c b/src/peer.c
+index 385ccd0e..cc585bae 100644
+--- a/src/peer.c
++++ b/src/peer.c
+@@ -111,7 +111,7 @@ static void stop_dhcp_server(struct connman_peer *peer)
+ 	peer->dhcp_server = NULL;
+ 
+ 	if (peer->ip_pool)
+-		__connman_ippool_free(peer->ip_pool);
++		__connman_ippool_unref(peer->ip_pool);
+ 	peer->ip_pool = NULL;
+ 	peer->lease_ip = 0;
+ }
+@@ -124,13 +124,30 @@ static void dhcp_server_debug(const char *str, void *data)
+ static void lease_added(unsigned char *mac, uint32_t ip)
+ {
+ 	GList *list, *start;
++	char *mac_no_colon = __connman_util_mac_binary_to_string_no_colon(mac);
++
++	if (!mac_no_colon){
++		connman_info("Failed to get mac");
++		return;
++	}
++
++	const char* identifier = g_supplicant_peer_identifier_from_intf_address(mac_no_colon);
++	g_free(mac_no_colon);
++
++	if (!identifier)
++		return;
+ 
+ 	start = list = g_hash_table_get_values(peers_table);
+ 	for (; list; list = list->next) {
+ 		struct connman_peer *temp = list->data;
+ 
+-		if (!memcmp(temp->iface_address, mac, ETH_ALEN)) {
++		if (!g_strcmp0(temp->identifier, identifier)) {
+ 			temp->lease_ip = ip;
++			if (temp->is_static_ip) {
++				temp->is_static_ip = false;
++				if (temp->clientCb)
++					temp->clientCb();
++			}
+ 			settings_changed(temp);
+ 			break;
+ 		}
+@@ -169,7 +186,8 @@ static int start_dhcp_server(struct connman_peer *peer)
+ 	else
+ 		index = connman_device_get_index(peer->device);
+ 
+-	peer->ip_pool = __connman_ippool_create(index, 2, 1, NULL, NULL);
++	peer->ip_pool = __connman_ippool_create_with_block(index, 2, 252,
++						P2P_DEFAULT_BLOCK, NULL, NULL);
+ 	if (!peer->ip_pool)
+ 		goto error;
+ 
+@@ -237,6 +255,7 @@ static void peer_free(gpointer data)
+ 	}
+ 
+ 	if (peer->ipconfig) {
++		__connman_dhcp_stop(peer->ipconfig);
+ 		__connman_ipconfig_set_ops(peer->ipconfig, NULL);
+ 		__connman_ipconfig_set_data(peer->ipconfig, NULL);
+ 		__connman_ipconfig_unref(peer->ipconfig);
+@@ -255,7 +274,7 @@ static void peer_free(gpointer data)
+ 
+ 	g_free(peer->identifier);
+ 	g_free(peer->name);
+-
++	g_free(peer->device_address);
+ 	g_free(peer);
+ }
+ 
+@@ -349,6 +368,10 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 
+ 		local = __connman_ippool_get_gateway(peer->ip_pool);
+ 		remote = trans;
++		if (peer->lease_ip == 0)
++			peer->is_dhcp_ip = false;
++		else
++			peer->is_dhcp_ip = true;
+ 	} else if (peer->ipconfig) {
+ 		local = __connman_ipconfig_get_local(peer->ipconfig);
+ 
+@@ -365,6 +388,10 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 						DBUS_TYPE_STRING, &local);
+ 	connman_dbus_dict_append_basic(iter, "Remote",
+ 						DBUS_TYPE_STRING, &remote);
++
++	g_free(peer->dhcp_ip);
++	peer->dhcp_ip = g_strdup(remote);
++
+ 	if (dhcp)
+ 		g_free(dhcp);
+ }
+@@ -412,6 +439,27 @@ static void append_peer_services(DBusMessageIter *iter, void *user_data)
+ 	dbus_message_iter_close_container(iter, &container);
+ }
+ 
++static void append_peer(DBusMessageIter *dict, void *user_data)
++{
++	dbus_bool_t val;
++	struct connman_peer *peer = user_data;
++
++	connman_dbus_dict_append_basic(dict, "DeviceAddress", DBUS_TYPE_STRING,
++					&peer->device_address);
++
++	val = peer->is_groupOwner;
++	connman_dbus_dict_append_basic(dict, "GroupOwner", DBUS_TYPE_BOOLEAN,
++					&val);
++
++	if (peer->config_methods)
++		connman_dbus_dict_append_basic(dict, "ConfigMethod", DBUS_TYPE_UINT16,
++					&peer->config_methods);
++
++	if (peer->pri_dev_type)
++		connman_dbus_dict_append_basic(dict, "DeviceType", DBUS_TYPE_STRING,
++					&peer->pri_dev_type);
++}
++
+ static void append_properties(DBusMessageIter *iter, struct connman_peer *peer)
+ {
+ 	const char *state = state2string(peer->state);
+@@ -419,14 +467,30 @@ static void append_properties(DBusMessageIter *iter, struct connman_peer *peer)
+ 
+ 	connman_dbus_dict_open(iter, &dict);
+ 
++	connman_dbus_dict_append_basic(&dict, "Type",
++					DBUS_TYPE_STRING, &peer->type);
+ 	connman_dbus_dict_append_basic(&dict, "State",
+ 					DBUS_TYPE_STRING, &state);
+ 	connman_dbus_dict_append_basic(&dict, "Name",
+ 					DBUS_TYPE_STRING, &peer->name);
++	connman_dbus_dict_append_basic(&dict, "Strength",
++					DBUS_TYPE_BYTE, &peer->strength);
++	connman_dbus_dict_append_dict(&dict, "P2P", append_peer, peer);
++
+ 	connman_dbus_dict_append_dict(&dict, "IPv4", append_ipv4, peer);
+ 	connman_dbus_dict_append_array(&dict, "Services",
+ 					DBUS_TYPE_DICT_ENTRY,
+ 					append_peer_services, peer);
++
++	if (is_connected(peer)) {
++		if (peer->is_static_ip)
++			connman_dbus_dict_append_basic(&dict, "IPAddress",
++				DBUS_TYPE_STRING, &peer->static_ip);
++		else if (peer->is_dhcp_ip)
++			connman_dbus_dict_append_basic(&dict, "IPAddress",
++				DBUS_TYPE_STRING, &peer->dhcp_ip);
++	}
++
+ 	connman_dbus_dict_close(iter, &dict);
+ }
+ 
+diff --git a/src/rtnl.c b/src/rtnl.c
+index a87296ff..c9e84dab 100644
+--- a/src/rtnl.c
++++ b/src/rtnl.c
+@@ -1308,71 +1308,75 @@ static const char *type2string(uint16_t type)
+ static GIOChannel *channel = NULL;
+ static guint channel_watch = 0;
+ 
+-#define RTNL_REQUEST_SIZE (NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct rtgenmsg)))
++struct rtnl_request {
++	struct nlmsghdr hdr;
++	struct rtgenmsg msg;
++};
++#define RTNL_REQUEST_SIZE  (sizeof(struct nlmsghdr) + sizeof(struct rtgenmsg))
+ 
+ static GSList *request_list = NULL;
+ static guint32 request_seq = 0;
+ 
+-static struct nlmsghdr *find_request(guint32 seq)
++static struct rtnl_request *find_request(guint32 seq)
+ {
+ 	GSList *list;
+ 
+ 	for (list = request_list; list; list = list->next) {
+-		struct nlmsghdr *hdr = list->data;
++		struct rtnl_request *req = list->data;
+ 
+-		if (hdr->nlmsg_seq == seq)
+-			return hdr;
++		if (req->hdr.nlmsg_seq == seq)
++			return req;
+ 	}
+ 
+ 	return NULL;
+ }
+ 
+-static int send_request(struct nlmsghdr *hdr)
++static int send_request(struct rtnl_request *req)
+ {
+ 	struct sockaddr_nl addr;
+ 	int sk;
+ 
+ 	DBG("%s len %d type %d flags 0x%04x seq %d",
+-				type2string(hdr->nlmsg_type),
+-				hdr->nlmsg_len, hdr->nlmsg_type,
+-				hdr->nlmsg_flags, hdr->nlmsg_seq);
++				type2string(req->hdr.nlmsg_type),
++				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
++				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+ 
+ 	sk = g_io_channel_unix_get_fd(channel);
+ 
+ 	memset(&addr, 0, sizeof(addr));
+ 	addr.nl_family = AF_NETLINK;
+ 
+-	return sendto(sk, hdr, hdr->nlmsg_len, 0,
++	return sendto(sk, req, req->hdr.nlmsg_len, 0,
+ 				(struct sockaddr *) &addr, sizeof(addr));
+ }
+ 
+-static int queue_request(struct nlmsghdr *hdr)
++static int queue_request(struct rtnl_request *req)
+ {
+-	request_list = g_slist_append(request_list, hdr);
++	request_list = g_slist_append(request_list, req);
+ 
+ 	if (g_slist_length(request_list) > 1)
+ 		return 0;
+ 
+-	return send_request(hdr);
++	return send_request(req);
+ }
+ 
+ static int process_response(guint32 seq)
+ {
+-	struct nlmsghdr *hdr;
++	struct rtnl_request *req;
+ 
+ 	DBG("seq %d", seq);
+ 
+-	hdr = find_request(seq);
+-	if (hdr) {
+-		request_list = g_slist_remove(request_list, hdr);
+-		g_free(hdr);
++	req = find_request(seq);
++	if (req) {
++		request_list = g_slist_remove(request_list, req);
++		g_free(req);
+ 	}
+ 
+-	hdr = g_slist_nth_data(request_list, 0);
+-	if (!hdr)
++	req = g_slist_nth_data(request_list, 0);
++	if (!req)
+ 		return 0;
+ 
+-	return send_request(hdr);
++	return send_request(req);
+ }
+ 
+ static void rtnl_message(void *buf, size_t len)
+@@ -1470,65 +1474,62 @@ static gboolean netlink_event(GIOChannel *chan, GIOCondition cond, gpointer data
+ 
+ static int send_getlink(void)
+ {
+-	struct nlmsghdr *hdr;
+-	struct rtgenmsg *msg;
++	struct rtnl_request *req;
+ 
+ 	DBG("");
+ 
+-	hdr = g_malloc0(RTNL_REQUEST_SIZE);
+-
+-	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+-	hdr->nlmsg_type = RTM_GETLINK;
+-	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	hdr->nlmsg_pid = 0;
+-	hdr->nlmsg_seq = request_seq++;
++	req = g_try_malloc0(RTNL_REQUEST_SIZE);
++	if (!req)
++		return -ENOMEM;
+ 
+-	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+-	msg->rtgen_family = AF_INET;
++	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
++	req->hdr.nlmsg_type = RTM_GETLINK;
++	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	req->hdr.nlmsg_pid = 0;
++	req->hdr.nlmsg_seq = request_seq++;
++	req->msg.rtgen_family = AF_INET;
+ 
+-	return queue_request(hdr);
++	return queue_request(req);
+ }
+ 
+ static int send_getaddr(void)
+ {
+-	struct nlmsghdr *hdr;
+-	struct rtgenmsg *msg;
++	struct rtnl_request *req;
+ 
+ 	DBG("");
+ 
+-	hdr = g_malloc0(RTNL_REQUEST_SIZE);
++	req = g_try_malloc0(RTNL_REQUEST_SIZE);
++	if (!req)
++		return -ENOMEM;
+ 
+-	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+-	hdr->nlmsg_type = RTM_GETADDR;
+-	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	hdr->nlmsg_pid = 0;
+-	hdr->nlmsg_seq = request_seq++;
++	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
++	req->hdr.nlmsg_type = RTM_GETADDR;
++	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	req->hdr.nlmsg_pid = 0;
++	req->hdr.nlmsg_seq = request_seq++;
++	req->msg.rtgen_family = AF_INET;
+ 
+-	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+-	msg->rtgen_family = AF_INET;
+-
+-	return queue_request(hdr);
++	return queue_request(req);
+ }
+ 
+ static int send_getroute(void)
+ {
+-	struct nlmsghdr *hdr;
+-	struct rtgenmsg *msg;
++	struct rtnl_request *req;
+ 
+ 	DBG("");
+ 
+-	hdr = g_malloc0(RTNL_REQUEST_SIZE);
+-
+-	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+-	hdr->nlmsg_type = RTM_GETROUTE;
+-	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	hdr->nlmsg_pid = 0;
+-	hdr->nlmsg_seq = request_seq++;
++	req = g_try_malloc0(RTNL_REQUEST_SIZE);
++	if (!req)
++		return -ENOMEM;
+ 
+-	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+-	msg->rtgen_family = AF_INET;
++	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
++	req->hdr.nlmsg_type = RTM_GETROUTE;
++	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	req->hdr.nlmsg_pid = 0;
++	req->hdr.nlmsg_seq = request_seq++;
++	req->msg.rtgen_family = AF_INET;
+ 
+-	return queue_request(hdr);
++	return queue_request(req);
+ }
+ 
+ static gboolean update_timeout_cb(gpointer user_data)
+@@ -1672,14 +1673,14 @@ void __connman_rtnl_cleanup(void)
+ 	update_list = NULL;
+ 
+ 	for (list = request_list; list; list = list->next) {
+-		struct nlmsghdr *hdr= list->data;
++		struct rtnl_request *req = list->data;
+ 
+ 		DBG("%s len %d type %d flags 0x%04x seq %d",
+-				type2string(hdr->nlmsg_type),
+-				hdr->nlmsg_len, hdr->nlmsg_type,
+-				hdr->nlmsg_flags, hdr->nlmsg_seq);
++				type2string(req->hdr.nlmsg_type),
++				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
++				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+ 
+-		g_free(hdr);
++		g_free(req);
+ 		list->data = NULL;
+ 	}
+ 
+diff --git a/src/technology.c b/src/technology.c
+index 535a9040..ff54059f 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -1956,6 +1956,44 @@ void connman_technology_wps_failed_notify(struct connman_technology *technology)
+ 		CONNMAN_TECHNOLOGY_INTERFACE, "WPSFailed",
+ 		DBUS_TYPE_INVALID);
+ }
++
++static DBusMessage *start_wps(DBusConnection *conn, DBusMessage *msg, void *data)
++{
++	struct connman_technology *technology = data;
++	DBusMessageIter iter;
++	int err;
++	const char *pin;
++
++	DBG("technology %p request from %s", technology,
++		dbus_message_get_sender(msg));
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &pin);
++
++	err = __connman_device_request_start_wps(technology->type, pin);
++	if (err < 0)
++		return __connman_error_failed(msg, -err);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static DBusMessage *cancel_wps(DBusConnection *conn, DBusMessage *msg, void *data)
++{
++	struct connman_technology *technology = data;
++	int err;
++
++	err = __connman_device_request_cancel_wps(technology->type);
++	if (err < 0)
++		return __connman_error_failed(msg, -err);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
+ static DBusMessage *cancel_p2p(DBusConnection *conn, DBusMessage *msg, void *data)
+ {
+ 	struct connman_technology *technology = data;
+@@ -2064,6 +2102,10 @@ static const GDBusMethodTable technology_methods[] = {
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" }),
+ 			NULL, set_property) },
+ 	{ GDBUS_ASYNC_METHOD("Scan", NULL, NULL, scan) },
++	{ GDBUS_ASYNC_METHOD("StartWPS",
++			GDBUS_ARGS({ "pin", "s" }),
++			NULL, start_wps) },
++	{ GDBUS_METHOD("CancelWPS", NULL, NULL, cancel_wps) },
+ 	{ GDBUS_METHOD("CancelP2P", NULL, NULL, cancel_p2p) },
+ 	{ GDBUS_ASYNC_METHOD("GetInterfaceProperties",
+ 			GDBUS_ARGS({ "interface", "s" }),
+@@ -2075,6 +2117,7 @@ static const GDBusMethodTable technology_methods[] = {
+ static const GDBusSignalTable technology_signals[] = {
+ 	{ GDBUS_SIGNAL("PropertyChanged",
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" })) },
++	{ GDBUS_SIGNAL("WPSFailed", NULL) },
+ 	{ },
+ };
+ 
+diff --git a/src/wispr.c b/src/wispr.c
+index 90c7dc49..42f59e26 100644
+--- a/src/wispr.c
++++ b/src/wispr.c
+@@ -167,6 +167,11 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
+ static void free_connman_wispr_portal_context(
+ 		struct connman_wispr_portal_context *wp_context)
+ {
++	DBG("context %p", wp_context);
++
++	if (!wp_context)
++		return;
++
+ 	if (wp_context->wispr_portal) {
+ 		if (wp_context->wispr_portal->ipv4_context == wp_context)
+ 			wp_context->wispr_portal->ipv4_context = NULL;

--- a/meta-luneos/recipes-connectivity/connman/connman/0008-Revert-Fix-for-create-group-api-and-crash-issue.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0008-Revert-Fix-for-create-group-api-and-crash-issue.patch
@@ -1,0 +1,1272 @@
+From cc27375041a007e2eed387ce1f5690b6f8b747ae Mon Sep 17 00:00:00 2001
+From: "muralidhar.n" <muralidhar.n@lge.com>
+Date: Tue, 1 Nov 2022 22:09:28 +0900
+Subject: [PATCH] Revert "Fix for create group api and crash issue"
+
+This reverts commit 93374ace07c26124ded33a8d5e78c4b81de6939f.
+
+Reason for revert: <change needs to be added before submission>
+
+Change-Id: I9d68c04457798bab77ae954cf68e19d8747f59e0
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338219
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ client/commands.c         |  27 +++++---
+ gsupplicant/gsupplicant.h |  83 +-----------------------
+ gsupplicant/supplicant.c  | 132 +-------------------------------------
+ include/technology.h      |   9 ---
+ plugins/ethernet.c        |  12 ++--
+ plugins/wifi.c            |  21 ++----
+ src/connman.h             |   6 --
+ src/device.c              | 116 ---------------------------------
+ src/inet.c                |   7 --
+ src/network.c             |   8 ---
+ src/peer.c                |  72 ++-------------------
+ src/rtnl.c                | 125 ++++++++++++++++++------------------
+ src/technology.c          |  43 -------------
+ src/wispr.c               |   5 --
+ 14 files changed, 98 insertions(+), 568 deletions(-)
+
+diff --git a/client/commands.c b/client/commands.c
+index f8b43921..53cc14c8 100644
+--- a/client/commands.c
++++ b/client/commands.c
+@@ -557,14 +557,16 @@ static int tether_update(struct tether_properties *tether)
+ {
+ 	int ret;
+ 
+-	if (tether->ssid_result == 0 && tether->passphrase_result == 0) {
++	if (tether->ssid_result == 0 && tether->passphrase_result == 0 &&
++			tether->freq_result == 0) {
+ 		ret = tether_set("wifi", tether->set_tethering);
+ 		g_free(tether);
+ 		return ret;
+ 	}
+ 
+ 	if (tether->ssid_result != -EINPROGRESS &&
+-			tether->passphrase_result != -EINPROGRESS) {
++			tether->passphrase_result != -EINPROGRESS &&
++			tether->freq_result != -EINPROGRESS) {
+ 		g_free(tether);
+ 		return 0;
+ 	}
+@@ -620,9 +622,9 @@ static int tether_set_freq_return(DBusMessageIter *iter, int errnum,
+ 	return tether_update(tether);
+ }
+ 
+-static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering)
++static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering, int freq)
+ {
+-	struct tether_properties *tether = g_new(struct tether_properties, 1);
++	struct tether_properties *tether = g_new0(struct tether_properties, 1);
+ 
+ 	tether->set_tethering = set_tethering;
+ 
+@@ -638,9 +640,17 @@ static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering)
+ 			tether_set_passphrase_return, tether,
+ 			"TetheringPassphrase", DBUS_TYPE_STRING, &passphrase);
+ 
++	if (freq > 0) {
++		tether->freq_result =__connmanctl_dbus_set_property(connection,
++				"/net/connman/technology/wifi",
++				"net.connman.Technology",
++				tether_set_freq_return, tether,
++				"TetheringFreq", DBUS_TYPE_INT32, &freq);
++	}
+ 
+ 	if (tether->ssid_result != -EINPROGRESS &&
+-			tether->passphrase_result != -EINPROGRESS) {
++			tether->passphrase_result != -EINPROGRESS &&
++			tether->freq_result != -EINPROGRESS) {
+ 		g_free(tether);
+ 		return -ENXIO;
+ 	}
+@@ -656,9 +666,6 @@ static int cmd_tether(char *args[], int num, struct connman_option *options)
+ 	if (num < 3)
+ 		return -EINVAL;
+ 
+-	passphrase = args[num - 1];
+-	ssid = args[num - 2];
+-
+ 	set_tethering = parse_boolean(args[2]);
+ 
+ 	if (strcmp(args[1], "wifi") == 0) {
+@@ -682,7 +689,7 @@ static int cmd_tether(char *args[], int num, struct connman_option *options)
+ 		ssid = args[num - 2];
+ 
+ 		if (num > 3)
+-			return tether_set_ssid(ssid, passphrase, set_tethering);
++			return tether_set_ssid(ssid, passphrase, set_tethering, freq);
+ 	}
+ 
+ 	if (num > 3)
+@@ -2793,7 +2800,7 @@ static const struct {
+ 	  "Disables given technology or offline mode",
+ 	  lookup_technology_offline },
+ 	{ "tether", "<technology> on|off\n"
+-	            "            wifi [on|off] <ssid> <passphrase> ",
++	            "            wifi [on|off] <ssid> <passphrase> [<freq>] ",
+ 	                                  NULL,            cmd_tether,
+ 	  "Enable, disable tethering, set SSID and passphrase for wifi",
+ 	  lookup_tether },
+diff --git a/gsupplicant/gsupplicant.h b/gsupplicant/gsupplicant.h
+index b29a66d7..ba934c18 100644
+--- a/gsupplicant/gsupplicant.h
++++ b/gsupplicant/gsupplicant.h
+@@ -404,11 +404,6 @@ typedef void (*GSupplicantInterfaceCallback) (int result,
+ 					GSupplicantInterface *interface,
+ 							void *user_data);
+ 
+-typedef void (*GSupplicantInterfaceBcmCallback) (int result,
+-					GSupplicantInterface *interface,
+-						const char *cmd_response,
+-							void *user_data);
+-int dev_type_str2bin(const char *type, unsigned char dev_type[8]);
+ void g_supplicant_interface_cancel(GSupplicantInterface *interface);
+ 
+ int g_supplicant_interface_create(const char *ifname, const char *driver,
+@@ -468,56 +463,8 @@ int g_supplicant_interface_p2p_wps_start(GSupplicantInterface *interface,
+ 													GSupplicantP2PWPSParams *wps_data,
+ 													GSupplicantInterfaceCallback callback,
+ 													void *user_data);
+-
+-int g_supplicant_interface_p2p_remove_all_persistent_groups(GSupplicantInterface *interface);
+-int g_supplicant_interface_p2p_add_persistent_group(GSupplicantInterface *interface,
+-										GSupplicantSSID *ssid, void *user_data);
+-
+-int g_supplicant_interface_p2p_sd_request(GSupplicantInterface *interface,
+-				GSupplicantP2PSDParams *sd_data,
+-				GSupplicantInterfaceCallbackWithData callback,
+-				void *user_data);
+-
+-int g_supplicant_interface_p2p_sd_cancel_request(GSupplicantInterface *interface,
+-				dbus_uint64_t request_id,
+-				GSupplicantInterfaceCallback callback,
+-				void *user_data);
+-
+-int g_supplicant_interface_p2p_replace_service(GSupplicantInterface *interface,
+-				GSupplicantInterfaceCallback callback,
+-				GSupplicantP2PServiceParams *p2p_service_params,
+-				void *user_data);
+-
+-int g_supplicant_interface_p2p_asp_provision_request(GSupplicantInterface *interface,
+-										  GSupplicantP2PASPProvisionRequestParams *sd_data,
+-										  GSupplicantInterfaceCallback callback,
+-										  void *user_data);
+-
+-int g_supplicant_interface_p2p_asp_provision_response(GSupplicantInterface *interface,
+-                                                      GSupplicantP2PASPProvisionResponseParams *params,
+-                                                      GSupplicantInterfaceCallback callback,
+-                                                      void *user_data);
+-
+-int g_supplicant_interface_p2p_read_device_address(GSupplicantInterface *interface,
+-                                                   GSupplicantInterfaceCallback callback, void *user_data);
+-
+-const unsigned char *g_supplicant_interface_p2p_get_device_address(GSupplicantInterface *interface);
+-
+-
+ int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
+ 				GSupplicantP2PServiceParams *p2p_service_params);
+-
+-int g_supplicant_interface_p2p_reject(GSupplicantInterface *interface,
+-					GSupplicantPeerParams *peer_params, GSupplicantInterfaceCallback callback,
+-					void *user_data);
+-
+-int g_supplicant_interface_p2p_client_remove(GSupplicantInterface *interface,
+-					GSupplicantInterfaceCallback callback,
+-					char* peer_path);
+-
+-int g_supplicant_interface_p2p_cancel(GSupplicantInterface *interface,
+-				GSupplicantInterfaceCallback callback, void *user_data);
+-
+ int g_supplicant_interface_p2p_flush(GSupplicantInterface *interface,
+ 				GSupplicantInterfaceCallback callback, void *user_data);
+ int g_supplicant_interface_p2p_invite(GSupplicantInterface *interface,
+@@ -540,10 +487,6 @@ int g_supplicant_interface_disconnect(GSupplicantInterface *interface,
+ int g_supplicant_interface_set_bss_expiration_age(GSupplicantInterface *interface,
+ 					unsigned int bss_expiration_age);
+ 
+-int g_supplicant_interface_wps_cancel(GSupplicantInterface *interface,
+-					GSupplicantInterfaceCallback callback,
+-							void *user_data);
+-
+ int g_supplicant_interface_set_apscan(GSupplicantInterface *interface,
+ 							unsigned int ap_scan);
+ 
+@@ -629,18 +572,12 @@ dbus_uint16_t g_supplicant_bss_get_frequency(GSupplicantBss *bss);
+ 
+ GSupplicantInterface *g_supplicant_peer_get_interface(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_path(GSupplicantPeer *peer);
+-dbus_uint16_t g_supplicant_peer_get_config_methods(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_identifier(GSupplicantPeer *peer);
+ const void *g_supplicant_peer_get_device_address(GSupplicantPeer *peer);
+ const void *g_supplicant_peer_get_iface_address(GSupplicantPeer *peer);
+-const char *g_supplicant_peer_get_ip_address(GSupplicantPeer *peer);
+-
+ const char *g_supplicant_peer_get_name(GSupplicantPeer *peer);
+ const unsigned char *g_supplicant_peer_get_widi_ies(GSupplicantPeer *peer,
+ 								int *length);
+-dbus_int32_t g_supplicant_peer_get_level(GSupplicantPeer *peer);
+-const char *g_supplicant_peer_get_pri_dev_type(GSupplicantPeer *peer);
+-int g_supplicant_peer_get_failure_status(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_wps_pbc(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_wps_pin(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_in_a_group(GSupplicantPeer *peer);
+@@ -653,26 +590,8 @@ const char *g_supplicant_peer_identifier_from_intf_address(const char* pintf_add
+ const char *g_supplicant_peer_wfds_get_identifier(GSupplicantPeer *peer);
+ int g_supplicant_peer_wfds_get_asp_services(GSupplicantPeer *peer, GSupplicantP2PService** services);
+ const char *g_supplicant_peer_wfds_get_peer_name(GSupplicantPeer *peer);
+-
+-int g_supplicant_interface_bcm_private_cmd(GSupplicantInterface *interface,const char *driver_cmd,
+-			GSupplicantInterfaceBcmCallback callback,void *user_data);
+-
+-GSupplicantInterface *g_supplicant_group_get_interface(GSupplicantGroup *group);
+-GSupplicantInterface *g_supplicant_group_get_orig_interface(GSupplicantGroup *group);
+-char *g_supplicant_group_get_object_path(GSupplicantGroup *group);
+-char *g_supplicant_group_get_bssid_no_colon(GSupplicantGroup *group);
+-GSupplicantGroup *g_supplicant_get_group(const char *path);
+-GSupplicantP2PPersistentGroup* g_supplicant_interface_get_p2p_persistent_group(GSupplicantInterface *interface, GSupplicantGroup *group);
+-unsigned int g_supplicant_network_get_keymgmt(GSupplicantNetwork *network);
+-
+-int g_supplicant_group_get_role(GSupplicantGroup *group);
+ char *g_supplicant_group_get_ssid(GSupplicantGroup *group);
+-char *g_supplicant_group_get_passphrase(GSupplicantGroup *group);
+-int g_supplicant_group_get_frequency(GSupplicantGroup *group);
+-bool g_supplicant_group_get_persistent(GSupplicantGroup *group);
+-char *g_supplicant_group_get_ip_addr(GSupplicantGroup *group);
+-char *g_supplicant_group_get_ip_mask(GSupplicantGroup *group);
+-char *g_supplicant_group_get_go_ip_addr(GSupplicantGroup *group);
++unsigned int g_supplicant_network_get_keymgmt(GSupplicantNetwork *network);
+ 
+ struct _GSupplicantCallbacks {
+ 	void (*system_ready) (void);
+diff --git a/gsupplicant/supplicant.c b/gsupplicant/supplicant.c
+index cc0a16e9..353fe9d6 100644
+--- a/gsupplicant/supplicant.c
++++ b/gsupplicant/supplicant.c
+@@ -1115,16 +1115,6 @@ static void remove_group(gpointer data)
+ 	g_free(group);
+ }
+ 
+-static void callback_wps_state(GSupplicantInterface *interface)
+-{
+-	if (callbacks_pointer == NULL)
+-		return;
+-
+-	if (callbacks_pointer->wps_state == NULL)
+-		return;
+-
+-	callbacks_pointer->wps_state(interface);
+-}
+ 
+ static void remove_interface(gpointer data)
+ {
+@@ -3625,58 +3615,6 @@ static void signal_wps_event(const char *path, DBusMessageIter *iter)
+ 	dbus_message_iter_next(iter);
+ 
+ 	supplicant_dbus_property_foreach(iter, wps_event_args, interface);
+-
+-	callback_wps_state(interface);
+-}
+-
+-static void signal_station_connected(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-	const char *sta_mac = NULL;
+-
+-	SUPPLICANT_DBG("path %s %s", path, SUPPLICANT_PATH);
+-
+-	if (callbacks_pointer->station_added == NULL)
+-		return;
+-
+-	if (g_strcmp0(path, "/") == 0)
+-		return;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (interface == NULL)
+-		return;
+-
+-	dbus_message_iter_get_basic(iter, &sta_mac);
+-	if (sta_mac == NULL)
+-		return;
+-
+-	SUPPLICANT_DBG("New station %s connected", sta_mac);
+-	callbacks_pointer->station_added(sta_mac);
+-}
+-
+-static void signal_station_disconnected(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-	const char *sta_mac = NULL;
+-
+-	SUPPLICANT_DBG("path %s %s", path, SUPPLICANT_PATH);
+-
+-	if (callbacks_pointer->station_removed == NULL)
+-		return;
+-
+-	if (g_strcmp0(path, "/") == 0)
+-		return;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (interface == NULL)
+-		return;
+-
+-	dbus_message_iter_get_basic(iter, &sta_mac);
+-	if (sta_mac == NULL)
+-		return;
+-
+-	SUPPLICANT_DBG("Station %s disconnected", sta_mac);
+-	callbacks_pointer->station_removed(sta_mac);
+ }
+ 
+ static void create_peer_identifier(GSupplicantPeer *peer)
+@@ -5010,62 +4948,6 @@ static void interface_p2p_prov_disc_request_or_response(DBusMessageIter *iter,
+ 		                                     (void *)pin);
+ 	}
+ }
+-
+-static void signal_prov_disc_requested_pbc(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (!interface)
+-		return;
+-
+-	interface_p2p_prov_disc_request_or_response(iter, interface, true, "pbc");
+-}
+-
+-static void signal_prov_disc_requested_enter_pin(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (!interface)
+-		return;
+-
+-	interface_p2p_prov_disc_request_or_response(iter, interface, true, "enter_pin");
+-}
+-
+-static void signal_prov_disc_requested_disp_pin(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (!interface)
+-		return;
+-
+-	interface_p2p_prov_disc_request_or_response(iter, interface, true, "disp_pin");
+-}
+-
+-static void signal_prov_disc_response_enter_pin(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (!interface)
+-		return;
+-
+-	interface_p2p_prov_disc_request_or_response(iter, interface, false, "enter_pin");
+-}
+-
+-static void signal_prov_disc_response_disp_pin(const char *path, DBusMessageIter *iter)
+-{
+-	GSupplicantInterface *interface;
+-
+-	interface = g_hash_table_lookup(interface_table, path);
+-	if (!interface)
+-		return;
+-
+-	interface_p2p_prov_disc_request_or_response(iter, interface, false, "disp_pin");
+-}
+-
+ static void interface_p2p_prov_disc_fail(DBusMessageIter *iter, void *user_data)
+ {
+ 	GSupplicantInterface *interface = user_data;
+@@ -5907,9 +5789,6 @@ static struct {
+ 	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_sta_authorized    },
+ 	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_sta_deauthorized  },
+ 
+-	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_station_connected   },
+-	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_station_disconnected },
+-
+ 	{ SUPPLICANT_INTERFACE ".BSS", "PropertiesChanged", signal_bss_changed   },
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Credentials", signal_wps_credentials },
+@@ -5932,15 +5811,6 @@ static struct {
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionStart", signal_p2ps_prov_start	},
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionDone",	 signal_p2ps_prov_done	},
+-
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryPBCRequest",	signal_prov_disc_requested_pbc },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryRequestEnterPin",	signal_prov_disc_requested_enter_pin },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryRequestDisplayPin",	signal_prov_disc_requested_disp_pin },
+-
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryResponseEnterPin",	signal_prov_disc_response_enter_pin },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryResponseDisplayPin",	signal_prov_disc_response_disp_pin },
+-	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryFailure",	signal_prov_disc_fail },
+-
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationResult", signal_invitation_result },
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationReceived", signal_invitation_received	},
+ 	{ SUPPLICANT_INTERFACE ".Group", "PeerJoined", signal_group_peer_joined },
+@@ -6193,7 +6063,7 @@ static void p2p_device_config_result(const char *error,
+ 	dbus_free(config);
+ }
+ 
+-int dev_type_str2bin(const char *type, unsigned char dev_type[8])
++static int dev_type_str2bin(const char *type, unsigned char dev_type[8])
+ {
+ 	int length, pos, end;
+ 	char b[3] = {};
+diff --git a/include/technology.h b/include/technology.h
+index ffc951d2..6f721ee5 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -39,9 +39,6 @@ struct connman_technology;
+ 
+ int connman_technology_tethering_notify(struct connman_technology *technology,
+ 							bool enabled);
+-void connman_technology_interface_changed(struct connman_technology *technology);
+-int connman_technology_add_station(enum connman_service_type type, const char *mac);
+-int connman_technology_remove_station(char *mac);
+ int connman_technology_set_regdom(const char *alpha2);
+ void connman_technology_regdom_notify(struct connman_technology *technology,
+ 							const char *alpha2);
+@@ -61,16 +58,10 @@ bool connman_technology_get_enable_p2p_listen(struct connman_technology *technol
+ bool connman_technology_get_p2p_listen(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen(struct connman_technology *technology,
+ 							bool enabled);
+-void __connman_technology_p2p_invitation_result(struct connman_technology *technology,
+-							int status);
+-void connman_technology_set_p2p_listen_params(struct connman_technology *technology,
+-						int period, int interval);
+ unsigned int connman_technology_get_p2p_listen_channel(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen_channel(struct connman_technology *technology,
+ 									unsigned int listen_channel);
+ void connman_technology_wps_failed_notify(struct connman_technology *technology);
+-bool connman_technology_get_p2p_persistent(struct connman_technology *technology);
+-void connman_technology_set_p2p_persistent(struct connman_technology *technology, bool enabled);
+ 
+ struct connman_technology_driver {
+ 	const char *name;
+diff --git a/plugins/ethernet.c b/plugins/ethernet.c
+index 265a7b09..27a3dcf3 100644
+--- a/plugins/ethernet.c
++++ b/plugins/ethernet.c
+@@ -73,7 +73,7 @@ static int get_vlan_vid(const char *ifname)
+ 		return -errno;
+ 
+ 	vifr.cmd = GET_VLAN_VID_CMD;
+-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
++	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
+ 
+ 	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
+ 		vid = vifr.u.VID;
+@@ -99,14 +99,16 @@ static int get_dsa_port(const char *ifname)
+ 		return -errno;
+ 
+ 	memset(&ifr, 0, sizeof(ifr));
+-	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
++	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name) - 1);
+ 
+ 	/* check if it is a vlan and get physical interface name*/
+ 	vifr.cmd = GET_VLAN_REALDEV_NAME_CMD;
+-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
++	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
+ 
+-	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
+-		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name));
++	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0) {
++		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name) - 1);
++		ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
++	}
+ 
+ 	/* get driver info */
+ 	drvinfocmd.cmd =  ETHTOOL_GDRVINFO;
+diff --git a/plugins/wifi.c b/plugins/wifi.c
+index 051ba7dc..101c0e7a 100644
+--- a/plugins/wifi.c
++++ b/plugins/wifi.c
+@@ -750,10 +750,7 @@ static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technolo
+ 
+ 		info->wifi = wifi;
+ 		info->technology = technology;
+-		
+-		group_msg = dbus_message_ref(msg);
+-		DBG("piyush log connman group_msg :   %s", group_msg);
+-		
++
+ 		if (identifier || passphrase) {
+ 			snprintf(p2p_ssid, P2P_MAX_SSID, "%s%s", P2P_WILDCARD_SSID, identifier);
+ 			info->ssid = ssid_ap_init(p2p_ssid, passphrase);
+@@ -766,6 +763,7 @@ static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technolo
+ 					NULL, info);
+ 		}
+ 
++		group_msg = dbus_message_ref(msg);
+ 		create_group_flag = true;
+ 	}
+ 
+@@ -5509,7 +5507,6 @@ static void assoc_status_code(GSupplicantInterface *interface, int status_code)
+ 
+ static void p2p_group_started(GSupplicantGroup *group)
+ {
+-	DBG("piyush 1 log connman group_msg :  ");
+ 	struct wifi_data *wifi;
+ 	GSList *item;
+ 	GSupplicantP2PPersistentGroup *persistent_group;
+@@ -5523,7 +5520,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 	if (!wifi)
+ 		return;
+-	DBG("piyush 2 log connman group_msg :  ");
++
+ 	const char* bssid_no_colon = g_supplicant_group_get_bssid_no_colon(group);
+ 	const char *ssid = g_supplicant_group_get_ssid(group);
+ 	const char *passphrase = g_supplicant_group_get_passphrase(group);
+@@ -5536,7 +5533,6 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 	/* persistent check */
+ 	item = wifi->persistent_groups;
+-		DBG("piyush 3 log connman group_msg :  ");
+ 	while(item != NULL) {
+ 		persistent_group = item->data;
+ 
+@@ -5562,7 +5558,6 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 		item = g_slist_next(item);
+ 	}
+-		DBG("piyush 4 log connman group_msg :  ");
+ 	bool is_group_owner = false;
+ 	if (g_supplicant_group_get_role(group) == G_SUPPLICANT_GROUP_ROLE_GO) {
+ 		is_group_owner = true;
+@@ -5573,7 +5568,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 		if (create_group_flag)
+ 			__connman_p2p_go_set_enabled();
+ 	}
+-	DBG("piyush 5 log connman group_msg :  ");
++
+ 	int freq = g_supplicant_group_get_frequency(group);
+ 	bool persistent = g_supplicant_group_get_persistent(group);
+ 
+@@ -5581,7 +5576,7 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 					is_group_owner, persistent, go_path, create_group_flag, freq);
+ 
+ 	const char *connman_group_path = __connman_group_get_path(connman_group);
+-	DBG("piyush 6 log connman group_msg :  ");
++
+ 	if (is_group_owner) {
+ 		p2p_go_identifier = g_strdup(__connman_group_get_identifier(connman_group));
+ 	} else {
+@@ -5605,10 +5600,8 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 			peer_changed(supplicant_peer, G_SUPPLICANT_PEER_GROUP_JOINED);
+ 		}
+ 	}
+-		DBG("piyush 7 log connman group_msg :  ");
+-	DBG("piyush 1new log connman group_msg :   %c", group_msg);
++
+ 	if (is_group_owner && create_group_flag) {
+-		DBG("piyush 8 log connman group_msg :  ");
+ 		g_dbus_send_reply(connection, group_msg,
+ 						DBUS_TYPE_OBJECT_PATH, &connman_group_path,
+ 						DBUS_TYPE_INVALID);
+@@ -6327,8 +6320,6 @@ static int wifi_init(void)
+ {
+ 	int err;
+ 
+-	connection = connman_dbus_get_connection();
+-
+ 	err = connman_network_driver_register(&network_driver);
+ 	if (err < 0)
+ 		return err;
+diff --git a/src/connman.h b/src/connman.h
+index 8c8f2e4f..d4714122 100644
+--- a/src/connman.h
++++ b/src/connman.h
+@@ -471,7 +471,6 @@ typedef void (* dhcpv6_cb) (struct connman_network *network,
+ typedef void (* dhcp_cb) (struct connman_ipconfig *ipconfig,
+ 			struct connman_network *opt_network,
+ 			bool success, gpointer data);
+-char *__connman_dhcp_get_client_address(struct connman_ipconfig *ipconfig);
+ char *__connman_dhcp_get_server_address(struct connman_ipconfig *ipconfig);
+ int __connman_dhcp_start(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network, dhcp_cb callback,
+@@ -510,8 +509,6 @@ int __connman_connection_gateway_add(struct connman_service *service,
+ 					const char *peer);
+ void __connman_connection_gateway_remove(struct connman_service *service,
+ 					enum connman_ipconfig_type type);
+-char *find_service_gateway(struct connman_service *service);
+-
+ int __connman_connection_get_vpn_index(int phy_index);
+ int __connman_connection_get_vpn_phy_index(int vpn_index);
+ 
+@@ -580,8 +577,6 @@ enum connman_service_type __connman_device_get_service_type(struct connman_devic
+ struct connman_device *__connman_device_find_device(enum connman_service_type type);
+ int __connman_device_request_scan(enum connman_service_type type);
+ int __connman_device_request_scan_full(enum connman_service_type type);
+-int __connman_device_request_start_wps(enum connman_service_type type, const char *pin);
+-int __connman_device_request_cancel_wps(enum connman_service_type type);
+ int __connman_device_request_cancel_p2p(enum connman_service_type type);
+ int __connman_device_request_hidden_scan(struct connman_device *device,
+ 				const char *ssid, unsigned int ssid_len,
+@@ -775,7 +770,6 @@ int __connman_service_indicate_default(struct connman_service *service);
+ int __connman_service_connect(struct connman_service *service,
+ 			enum connman_service_connect_reason reason);
+ int __connman_service_disconnect(struct connman_service *service);
+-int __connman_service_disconnect_all(void);
+ void __connman_service_set_active_session(bool enable, GSList *list);
+ void __connman_service_auto_connect(enum connman_service_connect_reason reason);
+ bool __connman_service_remove(struct connman_service *service);
+diff --git a/src/device.c b/src/device.c
+index f1560b81..6d4feaad 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -1232,122 +1232,6 @@ void __connman_device_stop_scan(enum connman_service_type type)
+ 	}
+ }
+ 
+-static int device_start_wps(struct connman_device *device, const char *pin)
+-{
+-	if (!device->driver || !device->driver->start_wps)
+-		return -EOPNOTSUPP;
+-
+-	if (device->powered == FALSE)
+-	        return -ENOLINK;
+-
+-	__connman_device_disconnect(device);
+-
+-	return device->driver->start_wps(device, pin);
+-}
+-
+-int __connman_device_request_start_wps(enum connman_service_type type, const char *pin)
+-{
+-	bool success = FALSE;
+-	int last_err = -ENOSYS;
+-	GSList *list;
+-	int err;
+-
+-	switch (type) {
+-	case CONNMAN_SERVICE_TYPE_UNKNOWN:
+-	case CONNMAN_SERVICE_TYPE_SYSTEM:
+-	case CONNMAN_SERVICE_TYPE_ETHERNET:
+-	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
+-	case CONNMAN_SERVICE_TYPE_CELLULAR:
+-	case CONNMAN_SERVICE_TYPE_GPS:
+-	case CONNMAN_SERVICE_TYPE_VPN:
+-	case CONNMAN_SERVICE_TYPE_GADGET:
+-		return -EOPNOTSUPP;
+-	case CONNMAN_SERVICE_TYPE_WIFI:
+-		break;
+-	}
+-
+-	for (list = device_list; list != NULL; list = list->next) {
+-		struct connman_device *device = list->data;
+-		enum connman_service_type service_type =
+-			__connman_device_get_service_type(device);
+-
+-		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN &&
+-				service_type != type) {
+-			continue;
+-		}
+-
+-		err = device_start_wps(device, pin);
+-		if (err == 0) {
+-			success = TRUE;
+-		} else {
+-			last_err = err;
+-			DBG("device %p err %d", device, err);
+-		}
+-	}
+-
+-	if (success == TRUE)
+-		return 0;
+-
+-	return last_err;
+-}
+-
+-static int device_cancel_wps(struct connman_device *device)
+-{
+-	if (!device->driver || !device->driver->cancel_wps)
+-		return -EOPNOTSUPP;
+-
+-	if (device->powered == FALSE)
+-		return -ENOLINK;
+-
+-	return device->driver->cancel_wps(device);
+-}
+-
+-int __connman_device_request_cancel_wps(enum connman_service_type type)
+-{
+-	bool success = FALSE;
+-	int last_err = -ENOSYS;
+-	GSList *list;
+-	int err;
+-
+-	switch (type) {
+-	case CONNMAN_SERVICE_TYPE_UNKNOWN:
+-	case CONNMAN_SERVICE_TYPE_SYSTEM:
+-	case CONNMAN_SERVICE_TYPE_ETHERNET:
+-	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
+-	case CONNMAN_SERVICE_TYPE_CELLULAR:
+-	case CONNMAN_SERVICE_TYPE_GPS:
+-	case CONNMAN_SERVICE_TYPE_VPN:
+-	case CONNMAN_SERVICE_TYPE_GADGET:
+-		return -EOPNOTSUPP;
+-	case CONNMAN_SERVICE_TYPE_WIFI:
+-		break;
+-	}
+-
+-	for (list = device_list; list != NULL; list = list->next) {
+-		struct connman_device *device = list->data;
+-		enum connman_service_type service_type =
+-			__connman_device_get_service_type(device);
+-
+-		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN &&
+-			service_type != type) {
+-			continue;
+-		}
+-
+-		err = device_cancel_wps(device);
+-		if (err == 0) {
+-			success = TRUE;
+-		} else {
+-			last_err = err;
+-			DBG("device %p err %d", device, err);
+-		}
+-	}
+-
+-	if (success == TRUE)
+-		return 0;
+-
+-	return last_err;
+-}
+-
+ static int device_cancel_p2p(struct connman_device *device)
+ {
+ 	if (!device->driver || !device->driver->cancel_p2p)
+diff --git a/src/inet.c b/src/inet.c
+index df94d1ee..4039a73c 100644
+--- a/src/inet.c
++++ b/src/inet.c
+@@ -1836,13 +1836,6 @@ int __connman_inet_ipv6_send_rs(int index, int timeout,
+ 	return 0;
+ }
+ 
+-static inline void ipv6_addr_advert_mult(const struct in6_addr *addr,
+-					struct in6_addr *advert)
+-{
+-	ipv6_addr_set(advert, htonl(0xFF020000), 0, htonl(0x2),
+-			htonl(0xFF000000) | addr->s6_addr32[3]);
+-}
+-
+ #define MSG_SIZE_SEND 1452
+ 
+ static int inc_len(int len, int inc)
+diff --git a/src/network.c b/src/network.c
+index 123a5183..a46c763c 100644
+--- a/src/network.c
++++ b/src/network.c
+@@ -489,8 +489,6 @@ static void dhcp_callback(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network,
+ 			bool success, gpointer data)
+ {
+-	connman_info("DHCP success %d",success);
+-
+ 	network->connecting = false;
+ 
+ 	if (success)
+@@ -1248,7 +1246,6 @@ static void network_destruct(struct connman_network *network)
+ 	g_free(network->wifi.private_key_passphrase);
+ 	g_free(network->wifi.phase2_auth);
+ 	g_free(network->wifi.pin_wps);
+-	g_hash_table_destroy(network->wifi.bss);
+ 
+ 	g_free(network->path);
+ 	g_free(network->group);
+@@ -1256,11 +1253,9 @@ static void network_destruct(struct connman_network *network)
+ 	g_free(network->name);
+ 	g_free(network->identifier);
+ 	acd_host_free(network->acd_host);
+-	g_free(network->address);
+ 
+ 	network->device = NULL;
+ 
+-	network->wifi.bss = NULL;
+ 	g_free(network);
+ }
+ 
+@@ -1295,7 +1290,6 @@ struct connman_network *connman_network_create(const char *identifier,
+ 	network->identifier = ident;
+ 	network->acd_host = NULL;
+ 	network->ipv4ll_timeout = 0;
+-	network->wifi.bss   = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+ 
+ 	network_list = g_slist_prepend(network_list, network);
+ 
+@@ -1820,8 +1814,6 @@ int __connman_network_connect(struct connman_network *network)
+ 	if (!network->device)
+ 		return -ENODEV;
+ 
+-	__connman_device_disconnect(network->device);
+-
+ 	network->connecting = true;
+ 
+ 	err = network->driver->connect(network);
+diff --git a/src/peer.c b/src/peer.c
+index cc585bae..385ccd0e 100644
+--- a/src/peer.c
++++ b/src/peer.c
+@@ -111,7 +111,7 @@ static void stop_dhcp_server(struct connman_peer *peer)
+ 	peer->dhcp_server = NULL;
+ 
+ 	if (peer->ip_pool)
+-		__connman_ippool_unref(peer->ip_pool);
++		__connman_ippool_free(peer->ip_pool);
+ 	peer->ip_pool = NULL;
+ 	peer->lease_ip = 0;
+ }
+@@ -124,30 +124,13 @@ static void dhcp_server_debug(const char *str, void *data)
+ static void lease_added(unsigned char *mac, uint32_t ip)
+ {
+ 	GList *list, *start;
+-	char *mac_no_colon = __connman_util_mac_binary_to_string_no_colon(mac);
+-
+-	if (!mac_no_colon){
+-		connman_info("Failed to get mac");
+-		return;
+-	}
+-
+-	const char* identifier = g_supplicant_peer_identifier_from_intf_address(mac_no_colon);
+-	g_free(mac_no_colon);
+-
+-	if (!identifier)
+-		return;
+ 
+ 	start = list = g_hash_table_get_values(peers_table);
+ 	for (; list; list = list->next) {
+ 		struct connman_peer *temp = list->data;
+ 
+-		if (!g_strcmp0(temp->identifier, identifier)) {
++		if (!memcmp(temp->iface_address, mac, ETH_ALEN)) {
+ 			temp->lease_ip = ip;
+-			if (temp->is_static_ip) {
+-				temp->is_static_ip = false;
+-				if (temp->clientCb)
+-					temp->clientCb();
+-			}
+ 			settings_changed(temp);
+ 			break;
+ 		}
+@@ -186,8 +169,7 @@ static int start_dhcp_server(struct connman_peer *peer)
+ 	else
+ 		index = connman_device_get_index(peer->device);
+ 
+-	peer->ip_pool = __connman_ippool_create_with_block(index, 2, 252,
+-						P2P_DEFAULT_BLOCK, NULL, NULL);
++	peer->ip_pool = __connman_ippool_create(index, 2, 1, NULL, NULL);
+ 	if (!peer->ip_pool)
+ 		goto error;
+ 
+@@ -255,7 +237,6 @@ static void peer_free(gpointer data)
+ 	}
+ 
+ 	if (peer->ipconfig) {
+-		__connman_dhcp_stop(peer->ipconfig);
+ 		__connman_ipconfig_set_ops(peer->ipconfig, NULL);
+ 		__connman_ipconfig_set_data(peer->ipconfig, NULL);
+ 		__connman_ipconfig_unref(peer->ipconfig);
+@@ -274,7 +255,7 @@ static void peer_free(gpointer data)
+ 
+ 	g_free(peer->identifier);
+ 	g_free(peer->name);
+-	g_free(peer->device_address);
++
+ 	g_free(peer);
+ }
+ 
+@@ -368,10 +349,6 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 
+ 		local = __connman_ippool_get_gateway(peer->ip_pool);
+ 		remote = trans;
+-		if (peer->lease_ip == 0)
+-			peer->is_dhcp_ip = false;
+-		else
+-			peer->is_dhcp_ip = true;
+ 	} else if (peer->ipconfig) {
+ 		local = __connman_ipconfig_get_local(peer->ipconfig);
+ 
+@@ -388,10 +365,6 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 						DBUS_TYPE_STRING, &local);
+ 	connman_dbus_dict_append_basic(iter, "Remote",
+ 						DBUS_TYPE_STRING, &remote);
+-
+-	g_free(peer->dhcp_ip);
+-	peer->dhcp_ip = g_strdup(remote);
+-
+ 	if (dhcp)
+ 		g_free(dhcp);
+ }
+@@ -439,27 +412,6 @@ static void append_peer_services(DBusMessageIter *iter, void *user_data)
+ 	dbus_message_iter_close_container(iter, &container);
+ }
+ 
+-static void append_peer(DBusMessageIter *dict, void *user_data)
+-{
+-	dbus_bool_t val;
+-	struct connman_peer *peer = user_data;
+-
+-	connman_dbus_dict_append_basic(dict, "DeviceAddress", DBUS_TYPE_STRING,
+-					&peer->device_address);
+-
+-	val = peer->is_groupOwner;
+-	connman_dbus_dict_append_basic(dict, "GroupOwner", DBUS_TYPE_BOOLEAN,
+-					&val);
+-
+-	if (peer->config_methods)
+-		connman_dbus_dict_append_basic(dict, "ConfigMethod", DBUS_TYPE_UINT16,
+-					&peer->config_methods);
+-
+-	if (peer->pri_dev_type)
+-		connman_dbus_dict_append_basic(dict, "DeviceType", DBUS_TYPE_STRING,
+-					&peer->pri_dev_type);
+-}
+-
+ static void append_properties(DBusMessageIter *iter, struct connman_peer *peer)
+ {
+ 	const char *state = state2string(peer->state);
+@@ -467,30 +419,14 @@ static void append_properties(DBusMessageIter *iter, struct connman_peer *peer)
+ 
+ 	connman_dbus_dict_open(iter, &dict);
+ 
+-	connman_dbus_dict_append_basic(&dict, "Type",
+-					DBUS_TYPE_STRING, &peer->type);
+ 	connman_dbus_dict_append_basic(&dict, "State",
+ 					DBUS_TYPE_STRING, &state);
+ 	connman_dbus_dict_append_basic(&dict, "Name",
+ 					DBUS_TYPE_STRING, &peer->name);
+-	connman_dbus_dict_append_basic(&dict, "Strength",
+-					DBUS_TYPE_BYTE, &peer->strength);
+-	connman_dbus_dict_append_dict(&dict, "P2P", append_peer, peer);
+-
+ 	connman_dbus_dict_append_dict(&dict, "IPv4", append_ipv4, peer);
+ 	connman_dbus_dict_append_array(&dict, "Services",
+ 					DBUS_TYPE_DICT_ENTRY,
+ 					append_peer_services, peer);
+-
+-	if (is_connected(peer)) {
+-		if (peer->is_static_ip)
+-			connman_dbus_dict_append_basic(&dict, "IPAddress",
+-				DBUS_TYPE_STRING, &peer->static_ip);
+-		else if (peer->is_dhcp_ip)
+-			connman_dbus_dict_append_basic(&dict, "IPAddress",
+-				DBUS_TYPE_STRING, &peer->dhcp_ip);
+-	}
+-
+ 	connman_dbus_dict_close(iter, &dict);
+ }
+ 
+diff --git a/src/rtnl.c b/src/rtnl.c
+index c9e84dab..a87296ff 100644
+--- a/src/rtnl.c
++++ b/src/rtnl.c
+@@ -1308,75 +1308,71 @@ static const char *type2string(uint16_t type)
+ static GIOChannel *channel = NULL;
+ static guint channel_watch = 0;
+ 
+-struct rtnl_request {
+-	struct nlmsghdr hdr;
+-	struct rtgenmsg msg;
+-};
+-#define RTNL_REQUEST_SIZE  (sizeof(struct nlmsghdr) + sizeof(struct rtgenmsg))
++#define RTNL_REQUEST_SIZE (NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct rtgenmsg)))
+ 
+ static GSList *request_list = NULL;
+ static guint32 request_seq = 0;
+ 
+-static struct rtnl_request *find_request(guint32 seq)
++static struct nlmsghdr *find_request(guint32 seq)
+ {
+ 	GSList *list;
+ 
+ 	for (list = request_list; list; list = list->next) {
+-		struct rtnl_request *req = list->data;
++		struct nlmsghdr *hdr = list->data;
+ 
+-		if (req->hdr.nlmsg_seq == seq)
+-			return req;
++		if (hdr->nlmsg_seq == seq)
++			return hdr;
+ 	}
+ 
+ 	return NULL;
+ }
+ 
+-static int send_request(struct rtnl_request *req)
++static int send_request(struct nlmsghdr *hdr)
+ {
+ 	struct sockaddr_nl addr;
+ 	int sk;
+ 
+ 	DBG("%s len %d type %d flags 0x%04x seq %d",
+-				type2string(req->hdr.nlmsg_type),
+-				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
+-				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
++				type2string(hdr->nlmsg_type),
++				hdr->nlmsg_len, hdr->nlmsg_type,
++				hdr->nlmsg_flags, hdr->nlmsg_seq);
+ 
+ 	sk = g_io_channel_unix_get_fd(channel);
+ 
+ 	memset(&addr, 0, sizeof(addr));
+ 	addr.nl_family = AF_NETLINK;
+ 
+-	return sendto(sk, req, req->hdr.nlmsg_len, 0,
++	return sendto(sk, hdr, hdr->nlmsg_len, 0,
+ 				(struct sockaddr *) &addr, sizeof(addr));
+ }
+ 
+-static int queue_request(struct rtnl_request *req)
++static int queue_request(struct nlmsghdr *hdr)
+ {
+-	request_list = g_slist_append(request_list, req);
++	request_list = g_slist_append(request_list, hdr);
+ 
+ 	if (g_slist_length(request_list) > 1)
+ 		return 0;
+ 
+-	return send_request(req);
++	return send_request(hdr);
+ }
+ 
+ static int process_response(guint32 seq)
+ {
+-	struct rtnl_request *req;
++	struct nlmsghdr *hdr;
+ 
+ 	DBG("seq %d", seq);
+ 
+-	req = find_request(seq);
+-	if (req) {
+-		request_list = g_slist_remove(request_list, req);
+-		g_free(req);
++	hdr = find_request(seq);
++	if (hdr) {
++		request_list = g_slist_remove(request_list, hdr);
++		g_free(hdr);
+ 	}
+ 
+-	req = g_slist_nth_data(request_list, 0);
+-	if (!req)
++	hdr = g_slist_nth_data(request_list, 0);
++	if (!hdr)
+ 		return 0;
+ 
+-	return send_request(req);
++	return send_request(hdr);
+ }
+ 
+ static void rtnl_message(void *buf, size_t len)
+@@ -1474,62 +1470,65 @@ static gboolean netlink_event(GIOChannel *chan, GIOCondition cond, gpointer data
+ 
+ static int send_getlink(void)
+ {
+-	struct rtnl_request *req;
++	struct nlmsghdr *hdr;
++	struct rtgenmsg *msg;
+ 
+ 	DBG("");
+ 
+-	req = g_try_malloc0(RTNL_REQUEST_SIZE);
+-	if (!req)
+-		return -ENOMEM;
++	hdr = g_malloc0(RTNL_REQUEST_SIZE);
++
++	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
++	hdr->nlmsg_type = RTM_GETLINK;
++	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	hdr->nlmsg_pid = 0;
++	hdr->nlmsg_seq = request_seq++;
+ 
+-	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
+-	req->hdr.nlmsg_type = RTM_GETLINK;
+-	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	req->hdr.nlmsg_pid = 0;
+-	req->hdr.nlmsg_seq = request_seq++;
+-	req->msg.rtgen_family = AF_INET;
++	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
++	msg->rtgen_family = AF_INET;
+ 
+-	return queue_request(req);
++	return queue_request(hdr);
+ }
+ 
+ static int send_getaddr(void)
+ {
+-	struct rtnl_request *req;
++	struct nlmsghdr *hdr;
++	struct rtgenmsg *msg;
+ 
+ 	DBG("");
+ 
+-	req = g_try_malloc0(RTNL_REQUEST_SIZE);
+-	if (!req)
+-		return -ENOMEM;
++	hdr = g_malloc0(RTNL_REQUEST_SIZE);
+ 
+-	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
+-	req->hdr.nlmsg_type = RTM_GETADDR;
+-	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	req->hdr.nlmsg_pid = 0;
+-	req->hdr.nlmsg_seq = request_seq++;
+-	req->msg.rtgen_family = AF_INET;
++	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
++	hdr->nlmsg_type = RTM_GETADDR;
++	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	hdr->nlmsg_pid = 0;
++	hdr->nlmsg_seq = request_seq++;
+ 
+-	return queue_request(req);
++	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
++	msg->rtgen_family = AF_INET;
++
++	return queue_request(hdr);
+ }
+ 
+ static int send_getroute(void)
+ {
+-	struct rtnl_request *req;
++	struct nlmsghdr *hdr;
++	struct rtgenmsg *msg;
+ 
+ 	DBG("");
+ 
+-	req = g_try_malloc0(RTNL_REQUEST_SIZE);
+-	if (!req)
+-		return -ENOMEM;
++	hdr = g_malloc0(RTNL_REQUEST_SIZE);
++
++	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
++	hdr->nlmsg_type = RTM_GETROUTE;
++	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	hdr->nlmsg_pid = 0;
++	hdr->nlmsg_seq = request_seq++;
+ 
+-	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
+-	req->hdr.nlmsg_type = RTM_GETROUTE;
+-	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	req->hdr.nlmsg_pid = 0;
+-	req->hdr.nlmsg_seq = request_seq++;
+-	req->msg.rtgen_family = AF_INET;
++	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
++	msg->rtgen_family = AF_INET;
+ 
+-	return queue_request(req);
++	return queue_request(hdr);
+ }
+ 
+ static gboolean update_timeout_cb(gpointer user_data)
+@@ -1673,14 +1672,14 @@ void __connman_rtnl_cleanup(void)
+ 	update_list = NULL;
+ 
+ 	for (list = request_list; list; list = list->next) {
+-		struct rtnl_request *req = list->data;
++		struct nlmsghdr *hdr= list->data;
+ 
+ 		DBG("%s len %d type %d flags 0x%04x seq %d",
+-				type2string(req->hdr.nlmsg_type),
+-				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
+-				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
++				type2string(hdr->nlmsg_type),
++				hdr->nlmsg_len, hdr->nlmsg_type,
++				hdr->nlmsg_flags, hdr->nlmsg_seq);
+ 
+-		g_free(req);
++		g_free(hdr);
+ 		list->data = NULL;
+ 	}
+ 
+diff --git a/src/technology.c b/src/technology.c
+index ff54059f..535a9040 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -1956,44 +1956,6 @@ void connman_technology_wps_failed_notify(struct connman_technology *technology)
+ 		CONNMAN_TECHNOLOGY_INTERFACE, "WPSFailed",
+ 		DBUS_TYPE_INVALID);
+ }
+-
+-static DBusMessage *start_wps(DBusConnection *conn, DBusMessage *msg, void *data)
+-{
+-	struct connman_technology *technology = data;
+-	DBusMessageIter iter;
+-	int err;
+-	const char *pin;
+-
+-	DBG("technology %p request from %s", technology,
+-		dbus_message_get_sender(msg));
+-
+-	if (dbus_message_iter_init(msg, &iter) == FALSE)
+-		return __connman_error_invalid_arguments(msg);
+-
+-	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
+-		return __connman_error_invalid_arguments(msg);
+-
+-	dbus_message_iter_get_basic(&iter, &pin);
+-
+-	err = __connman_device_request_start_wps(technology->type, pin);
+-	if (err < 0)
+-		return __connman_error_failed(msg, -err);
+-
+-	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+-}
+-
+-static DBusMessage *cancel_wps(DBusConnection *conn, DBusMessage *msg, void *data)
+-{
+-	struct connman_technology *technology = data;
+-	int err;
+-
+-	err = __connman_device_request_cancel_wps(technology->type);
+-	if (err < 0)
+-		return __connman_error_failed(msg, -err);
+-
+-	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
+-}
+-
+ static DBusMessage *cancel_p2p(DBusConnection *conn, DBusMessage *msg, void *data)
+ {
+ 	struct connman_technology *technology = data;
+@@ -2102,10 +2064,6 @@ static const GDBusMethodTable technology_methods[] = {
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" }),
+ 			NULL, set_property) },
+ 	{ GDBUS_ASYNC_METHOD("Scan", NULL, NULL, scan) },
+-	{ GDBUS_ASYNC_METHOD("StartWPS",
+-			GDBUS_ARGS({ "pin", "s" }),
+-			NULL, start_wps) },
+-	{ GDBUS_METHOD("CancelWPS", NULL, NULL, cancel_wps) },
+ 	{ GDBUS_METHOD("CancelP2P", NULL, NULL, cancel_p2p) },
+ 	{ GDBUS_ASYNC_METHOD("GetInterfaceProperties",
+ 			GDBUS_ARGS({ "interface", "s" }),
+@@ -2117,7 +2075,6 @@ static const GDBusMethodTable technology_methods[] = {
+ static const GDBusSignalTable technology_signals[] = {
+ 	{ GDBUS_SIGNAL("PropertyChanged",
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" })) },
+-	{ GDBUS_SIGNAL("WPSFailed", NULL) },
+ 	{ },
+ };
+ 
+diff --git a/src/wispr.c b/src/wispr.c
+index 42f59e26..90c7dc49 100644
+--- a/src/wispr.c
++++ b/src/wispr.c
+@@ -167,11 +167,6 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
+ static void free_connman_wispr_portal_context(
+ 		struct connman_wispr_portal_context *wp_context)
+ {
+-	DBG("context %p", wp_context);
+-
+-	if (!wp_context)
+-		return;
+-
+ 	if (wp_context->wispr_portal) {
+ 		if (wp_context->wispr_portal->ipv4_context == wp_context)
+ 			wp_context->wispr_portal->ipv4_context = NULL;

--- a/meta-luneos/recipes-connectivity/connman/connman/0009-Fix-for-Create-Group-api-and-crash-issue.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0009-Fix-for-Create-Group-api-and-crash-issue.patch
@@ -1,0 +1,1235 @@
+From f9b4a2d9f2902f138de1e46d8df7fb82878e500c Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Tue, 1 Nov 2022 19:04:33 +0530
+Subject: [PATCH] Fix for Create Group api and crash issue
+
+:Release Notes:
+Fix for create group api and crash issue
+
+:Detailed Notes:
+Fix for create group api and crash issue
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-11079] - Fix for create group api and crash issue
+
+Change-Id: I8d9969094f10d9b880c5e5218497a0e64ad8e500
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338352
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ client/commands.c         |  27 +++-----
+ gsupplicant/gsupplicant.h |  83 +++++++++++++++++++++++-
+ gsupplicant/supplicant.c  | 132 +++++++++++++++++++++++++++++++++++++-
+ include/technology.h      |   9 +++
+ plugins/ethernet.c        |  12 ++--
+ plugins/wifi.c            |   7 +-
+ src/connman.h             |   6 ++
+ src/device.c              | 116 +++++++++++++++++++++++++++++++++
+ src/inet.c                |   7 ++
+ src/network.c             |   8 +++
+ src/peer.c                |  72 +++++++++++++++++++--
+ src/rtnl.c                | 125 ++++++++++++++++++------------------
+ src/technology.c          |  43 +++++++++++++
+ src/wispr.c               |   5 ++
+ 14 files changed, 556 insertions(+), 96 deletions(-)
+
+diff --git a/client/commands.c b/client/commands.c
+index 53cc14c8..f8b43921 100644
+--- a/client/commands.c
++++ b/client/commands.c
+@@ -557,16 +557,14 @@ static int tether_update(struct tether_properties *tether)
+ {
+ 	int ret;
+ 
+-	if (tether->ssid_result == 0 && tether->passphrase_result == 0 &&
+-			tether->freq_result == 0) {
++	if (tether->ssid_result == 0 && tether->passphrase_result == 0) {
+ 		ret = tether_set("wifi", tether->set_tethering);
+ 		g_free(tether);
+ 		return ret;
+ 	}
+ 
+ 	if (tether->ssid_result != -EINPROGRESS &&
+-			tether->passphrase_result != -EINPROGRESS &&
+-			tether->freq_result != -EINPROGRESS) {
++			tether->passphrase_result != -EINPROGRESS) {
+ 		g_free(tether);
+ 		return 0;
+ 	}
+@@ -622,9 +620,9 @@ static int tether_set_freq_return(DBusMessageIter *iter, int errnum,
+ 	return tether_update(tether);
+ }
+ 
+-static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering, int freq)
++static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering)
+ {
+-	struct tether_properties *tether = g_new0(struct tether_properties, 1);
++	struct tether_properties *tether = g_new(struct tether_properties, 1);
+ 
+ 	tether->set_tethering = set_tethering;
+ 
+@@ -640,17 +638,9 @@ static int tether_set_ssid(char *ssid, char *passphrase, int set_tethering, int
+ 			tether_set_passphrase_return, tether,
+ 			"TetheringPassphrase", DBUS_TYPE_STRING, &passphrase);
+ 
+-	if (freq > 0) {
+-		tether->freq_result =__connmanctl_dbus_set_property(connection,
+-				"/net/connman/technology/wifi",
+-				"net.connman.Technology",
+-				tether_set_freq_return, tether,
+-				"TetheringFreq", DBUS_TYPE_INT32, &freq);
+-	}
+ 
+ 	if (tether->ssid_result != -EINPROGRESS &&
+-			tether->passphrase_result != -EINPROGRESS &&
+-			tether->freq_result != -EINPROGRESS) {
++			tether->passphrase_result != -EINPROGRESS) {
+ 		g_free(tether);
+ 		return -ENXIO;
+ 	}
+@@ -666,6 +656,9 @@ static int cmd_tether(char *args[], int num, struct connman_option *options)
+ 	if (num < 3)
+ 		return -EINVAL;
+ 
++	passphrase = args[num - 1];
++	ssid = args[num - 2];
++
+ 	set_tethering = parse_boolean(args[2]);
+ 
+ 	if (strcmp(args[1], "wifi") == 0) {
+@@ -689,7 +682,7 @@ static int cmd_tether(char *args[], int num, struct connman_option *options)
+ 		ssid = args[num - 2];
+ 
+ 		if (num > 3)
+-			return tether_set_ssid(ssid, passphrase, set_tethering, freq);
++			return tether_set_ssid(ssid, passphrase, set_tethering);
+ 	}
+ 
+ 	if (num > 3)
+@@ -2800,7 +2793,7 @@ static const struct {
+ 	  "Disables given technology or offline mode",
+ 	  lookup_technology_offline },
+ 	{ "tether", "<technology> on|off\n"
+-	            "            wifi [on|off] <ssid> <passphrase> [<freq>] ",
++	            "            wifi [on|off] <ssid> <passphrase> ",
+ 	                                  NULL,            cmd_tether,
+ 	  "Enable, disable tethering, set SSID and passphrase for wifi",
+ 	  lookup_tether },
+diff --git a/gsupplicant/gsupplicant.h b/gsupplicant/gsupplicant.h
+index ba934c18..b29a66d7 100644
+--- a/gsupplicant/gsupplicant.h
++++ b/gsupplicant/gsupplicant.h
+@@ -404,6 +404,11 @@ typedef void (*GSupplicantInterfaceCallback) (int result,
+ 					GSupplicantInterface *interface,
+ 							void *user_data);
+ 
++typedef void (*GSupplicantInterfaceBcmCallback) (int result,
++					GSupplicantInterface *interface,
++						const char *cmd_response,
++							void *user_data);
++int dev_type_str2bin(const char *type, unsigned char dev_type[8]);
+ void g_supplicant_interface_cancel(GSupplicantInterface *interface);
+ 
+ int g_supplicant_interface_create(const char *ifname, const char *driver,
+@@ -463,8 +468,56 @@ int g_supplicant_interface_p2p_wps_start(GSupplicantInterface *interface,
+ 													GSupplicantP2PWPSParams *wps_data,
+ 													GSupplicantInterfaceCallback callback,
+ 													void *user_data);
++
++int g_supplicant_interface_p2p_remove_all_persistent_groups(GSupplicantInterface *interface);
++int g_supplicant_interface_p2p_add_persistent_group(GSupplicantInterface *interface,
++										GSupplicantSSID *ssid, void *user_data);
++
++int g_supplicant_interface_p2p_sd_request(GSupplicantInterface *interface,
++				GSupplicantP2PSDParams *sd_data,
++				GSupplicantInterfaceCallbackWithData callback,
++				void *user_data);
++
++int g_supplicant_interface_p2p_sd_cancel_request(GSupplicantInterface *interface,
++				dbus_uint64_t request_id,
++				GSupplicantInterfaceCallback callback,
++				void *user_data);
++
++int g_supplicant_interface_p2p_replace_service(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback,
++				GSupplicantP2PServiceParams *p2p_service_params,
++				void *user_data);
++
++int g_supplicant_interface_p2p_asp_provision_request(GSupplicantInterface *interface,
++										  GSupplicantP2PASPProvisionRequestParams *sd_data,
++										  GSupplicantInterfaceCallback callback,
++										  void *user_data);
++
++int g_supplicant_interface_p2p_asp_provision_response(GSupplicantInterface *interface,
++                                                      GSupplicantP2PASPProvisionResponseParams *params,
++                                                      GSupplicantInterfaceCallback callback,
++                                                      void *user_data);
++
++int g_supplicant_interface_p2p_read_device_address(GSupplicantInterface *interface,
++                                                   GSupplicantInterfaceCallback callback, void *user_data);
++
++const unsigned char *g_supplicant_interface_p2p_get_device_address(GSupplicantInterface *interface);
++
++
+ int g_supplicant_interface_p2p_del_service(GSupplicantInterface *interface,
+ 				GSupplicantP2PServiceParams *p2p_service_params);
++
++int g_supplicant_interface_p2p_reject(GSupplicantInterface *interface,
++					GSupplicantPeerParams *peer_params, GSupplicantInterfaceCallback callback,
++					void *user_data);
++
++int g_supplicant_interface_p2p_client_remove(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++					char* peer_path);
++
++int g_supplicant_interface_p2p_cancel(GSupplicantInterface *interface,
++				GSupplicantInterfaceCallback callback, void *user_data);
++
+ int g_supplicant_interface_p2p_flush(GSupplicantInterface *interface,
+ 				GSupplicantInterfaceCallback callback, void *user_data);
+ int g_supplicant_interface_p2p_invite(GSupplicantInterface *interface,
+@@ -487,6 +540,10 @@ int g_supplicant_interface_disconnect(GSupplicantInterface *interface,
+ int g_supplicant_interface_set_bss_expiration_age(GSupplicantInterface *interface,
+ 					unsigned int bss_expiration_age);
+ 
++int g_supplicant_interface_wps_cancel(GSupplicantInterface *interface,
++					GSupplicantInterfaceCallback callback,
++							void *user_data);
++
+ int g_supplicant_interface_set_apscan(GSupplicantInterface *interface,
+ 							unsigned int ap_scan);
+ 
+@@ -572,12 +629,18 @@ dbus_uint16_t g_supplicant_bss_get_frequency(GSupplicantBss *bss);
+ 
+ GSupplicantInterface *g_supplicant_peer_get_interface(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_path(GSupplicantPeer *peer);
++dbus_uint16_t g_supplicant_peer_get_config_methods(GSupplicantPeer *peer);
+ const char *g_supplicant_peer_get_identifier(GSupplicantPeer *peer);
+ const void *g_supplicant_peer_get_device_address(GSupplicantPeer *peer);
+ const void *g_supplicant_peer_get_iface_address(GSupplicantPeer *peer);
++const char *g_supplicant_peer_get_ip_address(GSupplicantPeer *peer);
++
+ const char *g_supplicant_peer_get_name(GSupplicantPeer *peer);
+ const unsigned char *g_supplicant_peer_get_widi_ies(GSupplicantPeer *peer,
+ 								int *length);
++dbus_int32_t g_supplicant_peer_get_level(GSupplicantPeer *peer);
++const char *g_supplicant_peer_get_pri_dev_type(GSupplicantPeer *peer);
++int g_supplicant_peer_get_failure_status(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_wps_pbc(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_wps_pin(GSupplicantPeer *peer);
+ bool g_supplicant_peer_is_in_a_group(GSupplicantPeer *peer);
+@@ -590,9 +653,27 @@ const char *g_supplicant_peer_identifier_from_intf_address(const char* pintf_add
+ const char *g_supplicant_peer_wfds_get_identifier(GSupplicantPeer *peer);
+ int g_supplicant_peer_wfds_get_asp_services(GSupplicantPeer *peer, GSupplicantP2PService** services);
+ const char *g_supplicant_peer_wfds_get_peer_name(GSupplicantPeer *peer);
+-char *g_supplicant_group_get_ssid(GSupplicantGroup *group);
++
++int g_supplicant_interface_bcm_private_cmd(GSupplicantInterface *interface,const char *driver_cmd,
++			GSupplicantInterfaceBcmCallback callback,void *user_data);
++
++GSupplicantInterface *g_supplicant_group_get_interface(GSupplicantGroup *group);
++GSupplicantInterface *g_supplicant_group_get_orig_interface(GSupplicantGroup *group);
++char *g_supplicant_group_get_object_path(GSupplicantGroup *group);
++char *g_supplicant_group_get_bssid_no_colon(GSupplicantGroup *group);
++GSupplicantGroup *g_supplicant_get_group(const char *path);
++GSupplicantP2PPersistentGroup* g_supplicant_interface_get_p2p_persistent_group(GSupplicantInterface *interface, GSupplicantGroup *group);
+ unsigned int g_supplicant_network_get_keymgmt(GSupplicantNetwork *network);
+ 
++int g_supplicant_group_get_role(GSupplicantGroup *group);
++char *g_supplicant_group_get_ssid(GSupplicantGroup *group);
++char *g_supplicant_group_get_passphrase(GSupplicantGroup *group);
++int g_supplicant_group_get_frequency(GSupplicantGroup *group);
++bool g_supplicant_group_get_persistent(GSupplicantGroup *group);
++char *g_supplicant_group_get_ip_addr(GSupplicantGroup *group);
++char *g_supplicant_group_get_ip_mask(GSupplicantGroup *group);
++char *g_supplicant_group_get_go_ip_addr(GSupplicantGroup *group);
++
+ struct _GSupplicantCallbacks {
+ 	void (*system_ready) (void);
+ 	void (*system_killed) (void);
+diff --git a/gsupplicant/supplicant.c b/gsupplicant/supplicant.c
+index 353fe9d6..cc0a16e9 100644
+--- a/gsupplicant/supplicant.c
++++ b/gsupplicant/supplicant.c
+@@ -1115,6 +1115,16 @@ static void remove_group(gpointer data)
+ 	g_free(group);
+ }
+ 
++static void callback_wps_state(GSupplicantInterface *interface)
++{
++	if (callbacks_pointer == NULL)
++		return;
++
++	if (callbacks_pointer->wps_state == NULL)
++		return;
++
++	callbacks_pointer->wps_state(interface);
++}
+ 
+ static void remove_interface(gpointer data)
+ {
+@@ -3615,6 +3625,58 @@ static void signal_wps_event(const char *path, DBusMessageIter *iter)
+ 	dbus_message_iter_next(iter);
+ 
+ 	supplicant_dbus_property_foreach(iter, wps_event_args, interface);
++
++	callback_wps_state(interface);
++}
++
++static void signal_station_connected(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++	const char *sta_mac = NULL;
++
++	SUPPLICANT_DBG("path %s %s", path, SUPPLICANT_PATH);
++
++	if (callbacks_pointer->station_added == NULL)
++		return;
++
++	if (g_strcmp0(path, "/") == 0)
++		return;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
++
++	dbus_message_iter_get_basic(iter, &sta_mac);
++	if (sta_mac == NULL)
++		return;
++
++	SUPPLICANT_DBG("New station %s connected", sta_mac);
++	callbacks_pointer->station_added(sta_mac);
++}
++
++static void signal_station_disconnected(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++	const char *sta_mac = NULL;
++
++	SUPPLICANT_DBG("path %s %s", path, SUPPLICANT_PATH);
++
++	if (callbacks_pointer->station_removed == NULL)
++		return;
++
++	if (g_strcmp0(path, "/") == 0)
++		return;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (interface == NULL)
++		return;
++
++	dbus_message_iter_get_basic(iter, &sta_mac);
++	if (sta_mac == NULL)
++		return;
++
++	SUPPLICANT_DBG("Station %s disconnected", sta_mac);
++	callbacks_pointer->station_removed(sta_mac);
+ }
+ 
+ static void create_peer_identifier(GSupplicantPeer *peer)
+@@ -4948,6 +5010,62 @@ static void interface_p2p_prov_disc_request_or_response(DBusMessageIter *iter,
+ 		                                     (void *)pin);
+ 	}
+ }
++
++static void signal_prov_disc_requested_pbc(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, true, "pbc");
++}
++
++static void signal_prov_disc_requested_enter_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, true, "enter_pin");
++}
++
++static void signal_prov_disc_requested_disp_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, true, "disp_pin");
++}
++
++static void signal_prov_disc_response_enter_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, false, "enter_pin");
++}
++
++static void signal_prov_disc_response_disp_pin(const char *path, DBusMessageIter *iter)
++{
++	GSupplicantInterface *interface;
++
++	interface = g_hash_table_lookup(interface_table, path);
++	if (!interface)
++		return;
++
++	interface_p2p_prov_disc_request_or_response(iter, interface, false, "disp_pin");
++}
++
+ static void interface_p2p_prov_disc_fail(DBusMessageIter *iter, void *user_data)
+ {
+ 	GSupplicantInterface *interface = user_data;
+@@ -5789,6 +5907,9 @@ static struct {
+ 	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_sta_authorized    },
+ 	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_sta_deauthorized  },
+ 
++	{ SUPPLICANT_INTERFACE ".Interface", "StaAuthorized",     signal_station_connected   },
++	{ SUPPLICANT_INTERFACE ".Interface", "StaDeauthorized",   signal_station_disconnected },
++
+ 	{ SUPPLICANT_INTERFACE ".BSS", "PropertiesChanged", signal_bss_changed   },
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.WPS", "Credentials", signal_wps_credentials },
+@@ -5811,6 +5932,15 @@ static struct {
+ 
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionStart", signal_p2ps_prov_start	},
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "P2PSProvisionDone",	 signal_p2ps_prov_done	},
++
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryPBCRequest",	signal_prov_disc_requested_pbc },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryRequestEnterPin",	signal_prov_disc_requested_enter_pin },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryRequestDisplayPin",	signal_prov_disc_requested_disp_pin },
++
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryResponseEnterPin",	signal_prov_disc_response_enter_pin },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryResponseDisplayPin",	signal_prov_disc_response_disp_pin },
++	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ProvisionDiscoveryFailure",	signal_prov_disc_fail },
++
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationResult", signal_invitation_result },
+ 	{ SUPPLICANT_INTERFACE ".Interface.P2PDevice", "InvitationReceived", signal_invitation_received	},
+ 	{ SUPPLICANT_INTERFACE ".Group", "PeerJoined", signal_group_peer_joined },
+@@ -6063,7 +6193,7 @@ static void p2p_device_config_result(const char *error,
+ 	dbus_free(config);
+ }
+ 
+-static int dev_type_str2bin(const char *type, unsigned char dev_type[8])
++int dev_type_str2bin(const char *type, unsigned char dev_type[8])
+ {
+ 	int length, pos, end;
+ 	char b[3] = {};
+diff --git a/include/technology.h b/include/technology.h
+index 6f721ee5..ffc951d2 100644
+--- a/include/technology.h
++++ b/include/technology.h
+@@ -39,6 +39,9 @@ struct connman_technology;
+ 
+ int connman_technology_tethering_notify(struct connman_technology *technology,
+ 							bool enabled);
++void connman_technology_interface_changed(struct connman_technology *technology);
++int connman_technology_add_station(enum connman_service_type type, const char *mac);
++int connman_technology_remove_station(char *mac);
+ int connman_technology_set_regdom(const char *alpha2);
+ void connman_technology_regdom_notify(struct connman_technology *technology,
+ 							const char *alpha2);
+@@ -58,10 +61,16 @@ bool connman_technology_get_enable_p2p_listen(struct connman_technology *technol
+ bool connman_technology_get_p2p_listen(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen(struct connman_technology *technology,
+ 							bool enabled);
++void __connman_technology_p2p_invitation_result(struct connman_technology *technology,
++							int status);
++void connman_technology_set_p2p_listen_params(struct connman_technology *technology,
++						int period, int interval);
+ unsigned int connman_technology_get_p2p_listen_channel(struct connman_technology *technology);
+ void connman_technology_set_p2p_listen_channel(struct connman_technology *technology,
+ 									unsigned int listen_channel);
+ void connman_technology_wps_failed_notify(struct connman_technology *technology);
++bool connman_technology_get_p2p_persistent(struct connman_technology *technology);
++void connman_technology_set_p2p_persistent(struct connman_technology *technology, bool enabled);
+ 
+ struct connman_technology_driver {
+ 	const char *name;
+diff --git a/plugins/ethernet.c b/plugins/ethernet.c
+index 27a3dcf3..265a7b09 100644
+--- a/plugins/ethernet.c
++++ b/plugins/ethernet.c
+@@ -73,7 +73,7 @@ static int get_vlan_vid(const char *ifname)
+ 		return -errno;
+ 
+ 	vifr.cmd = GET_VLAN_VID_CMD;
+-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
++	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
+ 
+ 	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
+ 		vid = vifr.u.VID;
+@@ -99,16 +99,14 @@ static int get_dsa_port(const char *ifname)
+ 		return -errno;
+ 
+ 	memset(&ifr, 0, sizeof(ifr));
+-	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name) - 1);
++	stpncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+ 
+ 	/* check if it is a vlan and get physical interface name*/
+ 	vifr.cmd = GET_VLAN_REALDEV_NAME_CMD;
+-	stpncpy(vifr.device1, ifname, sizeof(vifr.device1) - 1);
++	stpncpy(vifr.device1, ifname, sizeof(vifr.device1));
+ 
+-	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0) {
+-		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name) - 1);
+-		ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+-	}
++	if(ioctl(sk, SIOCSIFVLAN, &vifr) >= 0)
++		stpncpy(ifr.ifr_name, vifr.u.device2, sizeof(ifr.ifr_name));
+ 
+ 	/* get driver info */
+ 	drvinfocmd.cmd =  ETHTOOL_GDRVINFO;
+diff --git a/plugins/wifi.c b/plugins/wifi.c
+index 101c0e7a..bc390870 100644
+--- a/plugins/wifi.c
++++ b/plugins/wifi.c
+@@ -750,7 +750,7 @@ static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technolo
+ 
+ 		info->wifi = wifi;
+ 		info->technology = technology;
+-
++		
+ 		if (identifier || passphrase) {
+ 			snprintf(p2p_ssid, P2P_MAX_SSID, "%s%s", P2P_WILDCARD_SSID, identifier);
+ 			info->ssid = ssid_ap_init(p2p_ssid, passphrase);
+@@ -762,7 +762,6 @@ static int tech_set_p2p_go(DBusMessage *msg, struct connman_technology *technolo
+ 			err = g_supplicant_interface_p2p_group_add(iface, NULL,
+ 					NULL, info);
+ 		}
+-
+ 		group_msg = dbus_message_ref(msg);
+ 		create_group_flag = true;
+ 	}
+@@ -5520,7 +5519,6 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 
+ 	if (!wifi)
+ 		return;
+-
+ 	const char* bssid_no_colon = g_supplicant_group_get_bssid_no_colon(group);
+ 	const char *ssid = g_supplicant_group_get_ssid(group);
+ 	const char *passphrase = g_supplicant_group_get_passphrase(group);
+@@ -5568,7 +5566,6 @@ static void p2p_group_started(GSupplicantGroup *group)
+ 		if (create_group_flag)
+ 			__connman_p2p_go_set_enabled();
+ 	}
+-
+ 	int freq = g_supplicant_group_get_frequency(group);
+ 	bool persistent = g_supplicant_group_get_persistent(group);
+ 
+@@ -6320,6 +6317,8 @@ static int wifi_init(void)
+ {
+ 	int err;
+ 
++	connection = connman_dbus_get_connection();
++
+ 	err = connman_network_driver_register(&network_driver);
+ 	if (err < 0)
+ 		return err;
+diff --git a/src/connman.h b/src/connman.h
+index d4714122..8c8f2e4f 100644
+--- a/src/connman.h
++++ b/src/connman.h
+@@ -471,6 +471,7 @@ typedef void (* dhcpv6_cb) (struct connman_network *network,
+ typedef void (* dhcp_cb) (struct connman_ipconfig *ipconfig,
+ 			struct connman_network *opt_network,
+ 			bool success, gpointer data);
++char *__connman_dhcp_get_client_address(struct connman_ipconfig *ipconfig);
+ char *__connman_dhcp_get_server_address(struct connman_ipconfig *ipconfig);
+ int __connman_dhcp_start(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network, dhcp_cb callback,
+@@ -509,6 +510,8 @@ int __connman_connection_gateway_add(struct connman_service *service,
+ 					const char *peer);
+ void __connman_connection_gateway_remove(struct connman_service *service,
+ 					enum connman_ipconfig_type type);
++char *find_service_gateway(struct connman_service *service);
++
+ int __connman_connection_get_vpn_index(int phy_index);
+ int __connman_connection_get_vpn_phy_index(int vpn_index);
+ 
+@@ -577,6 +580,8 @@ enum connman_service_type __connman_device_get_service_type(struct connman_devic
+ struct connman_device *__connman_device_find_device(enum connman_service_type type);
+ int __connman_device_request_scan(enum connman_service_type type);
+ int __connman_device_request_scan_full(enum connman_service_type type);
++int __connman_device_request_start_wps(enum connman_service_type type, const char *pin);
++int __connman_device_request_cancel_wps(enum connman_service_type type);
+ int __connman_device_request_cancel_p2p(enum connman_service_type type);
+ int __connman_device_request_hidden_scan(struct connman_device *device,
+ 				const char *ssid, unsigned int ssid_len,
+@@ -770,6 +775,7 @@ int __connman_service_indicate_default(struct connman_service *service);
+ int __connman_service_connect(struct connman_service *service,
+ 			enum connman_service_connect_reason reason);
+ int __connman_service_disconnect(struct connman_service *service);
++int __connman_service_disconnect_all(void);
+ void __connman_service_set_active_session(bool enable, GSList *list);
+ void __connman_service_auto_connect(enum connman_service_connect_reason reason);
+ bool __connman_service_remove(struct connman_service *service);
+diff --git a/src/device.c b/src/device.c
+index 6d4feaad..f1560b81 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -1232,6 +1232,122 @@ void __connman_device_stop_scan(enum connman_service_type type)
+ 	}
+ }
+ 
++static int device_start_wps(struct connman_device *device, const char *pin)
++{
++	if (!device->driver || !device->driver->start_wps)
++		return -EOPNOTSUPP;
++
++	if (device->powered == FALSE)
++	        return -ENOLINK;
++
++	__connman_device_disconnect(device);
++
++	return device->driver->start_wps(device, pin);
++}
++
++int __connman_device_request_start_wps(enum connman_service_type type, const char *pin)
++{
++	bool success = FALSE;
++	int last_err = -ENOSYS;
++	GSList *list;
++	int err;
++
++	switch (type) {
++	case CONNMAN_SERVICE_TYPE_UNKNOWN:
++	case CONNMAN_SERVICE_TYPE_SYSTEM:
++	case CONNMAN_SERVICE_TYPE_ETHERNET:
++	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++	case CONNMAN_SERVICE_TYPE_CELLULAR:
++	case CONNMAN_SERVICE_TYPE_GPS:
++	case CONNMAN_SERVICE_TYPE_VPN:
++	case CONNMAN_SERVICE_TYPE_GADGET:
++		return -EOPNOTSUPP;
++	case CONNMAN_SERVICE_TYPE_WIFI:
++		break;
++	}
++
++	for (list = device_list; list != NULL; list = list->next) {
++		struct connman_device *device = list->data;
++		enum connman_service_type service_type =
++			__connman_device_get_service_type(device);
++
++		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN &&
++				service_type != type) {
++			continue;
++		}
++
++		err = device_start_wps(device, pin);
++		if (err == 0) {
++			success = TRUE;
++		} else {
++			last_err = err;
++			DBG("device %p err %d", device, err);
++		}
++	}
++
++	if (success == TRUE)
++		return 0;
++
++	return last_err;
++}
++
++static int device_cancel_wps(struct connman_device *device)
++{
++	if (!device->driver || !device->driver->cancel_wps)
++		return -EOPNOTSUPP;
++
++	if (device->powered == FALSE)
++		return -ENOLINK;
++
++	return device->driver->cancel_wps(device);
++}
++
++int __connman_device_request_cancel_wps(enum connman_service_type type)
++{
++	bool success = FALSE;
++	int last_err = -ENOSYS;
++	GSList *list;
++	int err;
++
++	switch (type) {
++	case CONNMAN_SERVICE_TYPE_UNKNOWN:
++	case CONNMAN_SERVICE_TYPE_SYSTEM:
++	case CONNMAN_SERVICE_TYPE_ETHERNET:
++	case CONNMAN_SERVICE_TYPE_BLUETOOTH:
++	case CONNMAN_SERVICE_TYPE_CELLULAR:
++	case CONNMAN_SERVICE_TYPE_GPS:
++	case CONNMAN_SERVICE_TYPE_VPN:
++	case CONNMAN_SERVICE_TYPE_GADGET:
++		return -EOPNOTSUPP;
++	case CONNMAN_SERVICE_TYPE_WIFI:
++		break;
++	}
++
++	for (list = device_list; list != NULL; list = list->next) {
++		struct connman_device *device = list->data;
++		enum connman_service_type service_type =
++			__connman_device_get_service_type(device);
++
++		if (service_type != CONNMAN_SERVICE_TYPE_UNKNOWN &&
++			service_type != type) {
++			continue;
++		}
++
++		err = device_cancel_wps(device);
++		if (err == 0) {
++			success = TRUE;
++		} else {
++			last_err = err;
++			DBG("device %p err %d", device, err);
++		}
++	}
++
++	if (success == TRUE)
++		return 0;
++
++	return last_err;
++}
++
+ static int device_cancel_p2p(struct connman_device *device)
+ {
+ 	if (!device->driver || !device->driver->cancel_p2p)
+diff --git a/src/inet.c b/src/inet.c
+index 4039a73c..df94d1ee 100644
+--- a/src/inet.c
++++ b/src/inet.c
+@@ -1836,6 +1836,13 @@ int __connman_inet_ipv6_send_rs(int index, int timeout,
+ 	return 0;
+ }
+ 
++static inline void ipv6_addr_advert_mult(const struct in6_addr *addr,
++					struct in6_addr *advert)
++{
++	ipv6_addr_set(advert, htonl(0xFF020000), 0, htonl(0x2),
++			htonl(0xFF000000) | addr->s6_addr32[3]);
++}
++
+ #define MSG_SIZE_SEND 1452
+ 
+ static int inc_len(int len, int inc)
+diff --git a/src/network.c b/src/network.c
+index a46c763c..123a5183 100644
+--- a/src/network.c
++++ b/src/network.c
+@@ -489,6 +489,8 @@ static void dhcp_callback(struct connman_ipconfig *ipconfig,
+ 			struct connman_network *network,
+ 			bool success, gpointer data)
+ {
++	connman_info("DHCP success %d",success);
++
+ 	network->connecting = false;
+ 
+ 	if (success)
+@@ -1246,6 +1248,7 @@ static void network_destruct(struct connman_network *network)
+ 	g_free(network->wifi.private_key_passphrase);
+ 	g_free(network->wifi.phase2_auth);
+ 	g_free(network->wifi.pin_wps);
++	g_hash_table_destroy(network->wifi.bss);
+ 
+ 	g_free(network->path);
+ 	g_free(network->group);
+@@ -1253,9 +1256,11 @@ static void network_destruct(struct connman_network *network)
+ 	g_free(network->name);
+ 	g_free(network->identifier);
+ 	acd_host_free(network->acd_host);
++	g_free(network->address);
+ 
+ 	network->device = NULL;
+ 
++	network->wifi.bss = NULL;
+ 	g_free(network);
+ }
+ 
+@@ -1290,6 +1295,7 @@ struct connman_network *connman_network_create(const char *identifier,
+ 	network->identifier = ident;
+ 	network->acd_host = NULL;
+ 	network->ipv4ll_timeout = 0;
++	network->wifi.bss   = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+ 
+ 	network_list = g_slist_prepend(network_list, network);
+ 
+@@ -1814,6 +1820,8 @@ int __connman_network_connect(struct connman_network *network)
+ 	if (!network->device)
+ 		return -ENODEV;
+ 
++	__connman_device_disconnect(network->device);
++
+ 	network->connecting = true;
+ 
+ 	err = network->driver->connect(network);
+diff --git a/src/peer.c b/src/peer.c
+index 385ccd0e..cc585bae 100644
+--- a/src/peer.c
++++ b/src/peer.c
+@@ -111,7 +111,7 @@ static void stop_dhcp_server(struct connman_peer *peer)
+ 	peer->dhcp_server = NULL;
+ 
+ 	if (peer->ip_pool)
+-		__connman_ippool_free(peer->ip_pool);
++		__connman_ippool_unref(peer->ip_pool);
+ 	peer->ip_pool = NULL;
+ 	peer->lease_ip = 0;
+ }
+@@ -124,13 +124,30 @@ static void dhcp_server_debug(const char *str, void *data)
+ static void lease_added(unsigned char *mac, uint32_t ip)
+ {
+ 	GList *list, *start;
++	char *mac_no_colon = __connman_util_mac_binary_to_string_no_colon(mac);
++
++	if (!mac_no_colon){
++		connman_info("Failed to get mac");
++		return;
++	}
++
++	const char* identifier = g_supplicant_peer_identifier_from_intf_address(mac_no_colon);
++	g_free(mac_no_colon);
++
++	if (!identifier)
++		return;
+ 
+ 	start = list = g_hash_table_get_values(peers_table);
+ 	for (; list; list = list->next) {
+ 		struct connman_peer *temp = list->data;
+ 
+-		if (!memcmp(temp->iface_address, mac, ETH_ALEN)) {
++		if (!g_strcmp0(temp->identifier, identifier)) {
+ 			temp->lease_ip = ip;
++			if (temp->is_static_ip) {
++				temp->is_static_ip = false;
++				if (temp->clientCb)
++					temp->clientCb();
++			}
+ 			settings_changed(temp);
+ 			break;
+ 		}
+@@ -169,7 +186,8 @@ static int start_dhcp_server(struct connman_peer *peer)
+ 	else
+ 		index = connman_device_get_index(peer->device);
+ 
+-	peer->ip_pool = __connman_ippool_create(index, 2, 1, NULL, NULL);
++	peer->ip_pool = __connman_ippool_create_with_block(index, 2, 252,
++						P2P_DEFAULT_BLOCK, NULL, NULL);
+ 	if (!peer->ip_pool)
+ 		goto error;
+ 
+@@ -237,6 +255,7 @@ static void peer_free(gpointer data)
+ 	}
+ 
+ 	if (peer->ipconfig) {
++		__connman_dhcp_stop(peer->ipconfig);
+ 		__connman_ipconfig_set_ops(peer->ipconfig, NULL);
+ 		__connman_ipconfig_set_data(peer->ipconfig, NULL);
+ 		__connman_ipconfig_unref(peer->ipconfig);
+@@ -255,7 +274,7 @@ static void peer_free(gpointer data)
+ 
+ 	g_free(peer->identifier);
+ 	g_free(peer->name);
+-
++	g_free(peer->device_address);
+ 	g_free(peer);
+ }
+ 
+@@ -349,6 +368,10 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 
+ 		local = __connman_ippool_get_gateway(peer->ip_pool);
+ 		remote = trans;
++		if (peer->lease_ip == 0)
++			peer->is_dhcp_ip = false;
++		else
++			peer->is_dhcp_ip = true;
+ 	} else if (peer->ipconfig) {
+ 		local = __connman_ipconfig_get_local(peer->ipconfig);
+ 
+@@ -365,6 +388,10 @@ static void append_ipv4(DBusMessageIter *iter, void *user_data)
+ 						DBUS_TYPE_STRING, &local);
+ 	connman_dbus_dict_append_basic(iter, "Remote",
+ 						DBUS_TYPE_STRING, &remote);
++
++	g_free(peer->dhcp_ip);
++	peer->dhcp_ip = g_strdup(remote);
++
+ 	if (dhcp)
+ 		g_free(dhcp);
+ }
+@@ -412,6 +439,27 @@ static void append_peer_services(DBusMessageIter *iter, void *user_data)
+ 	dbus_message_iter_close_container(iter, &container);
+ }
+ 
++static void append_peer(DBusMessageIter *dict, void *user_data)
++{
++	dbus_bool_t val;
++	struct connman_peer *peer = user_data;
++
++	connman_dbus_dict_append_basic(dict, "DeviceAddress", DBUS_TYPE_STRING,
++					&peer->device_address);
++
++	val = peer->is_groupOwner;
++	connman_dbus_dict_append_basic(dict, "GroupOwner", DBUS_TYPE_BOOLEAN,
++					&val);
++
++	if (peer->config_methods)
++		connman_dbus_dict_append_basic(dict, "ConfigMethod", DBUS_TYPE_UINT16,
++					&peer->config_methods);
++
++	if (peer->pri_dev_type)
++		connman_dbus_dict_append_basic(dict, "DeviceType", DBUS_TYPE_STRING,
++					&peer->pri_dev_type);
++}
++
+ static void append_properties(DBusMessageIter *iter, struct connman_peer *peer)
+ {
+ 	const char *state = state2string(peer->state);
+@@ -419,14 +467,30 @@ static void append_properties(DBusMessageIter *iter, struct connman_peer *peer)
+ 
+ 	connman_dbus_dict_open(iter, &dict);
+ 
++	connman_dbus_dict_append_basic(&dict, "Type",
++					DBUS_TYPE_STRING, &peer->type);
+ 	connman_dbus_dict_append_basic(&dict, "State",
+ 					DBUS_TYPE_STRING, &state);
+ 	connman_dbus_dict_append_basic(&dict, "Name",
+ 					DBUS_TYPE_STRING, &peer->name);
++	connman_dbus_dict_append_basic(&dict, "Strength",
++					DBUS_TYPE_BYTE, &peer->strength);
++	connman_dbus_dict_append_dict(&dict, "P2P", append_peer, peer);
++
+ 	connman_dbus_dict_append_dict(&dict, "IPv4", append_ipv4, peer);
+ 	connman_dbus_dict_append_array(&dict, "Services",
+ 					DBUS_TYPE_DICT_ENTRY,
+ 					append_peer_services, peer);
++
++	if (is_connected(peer)) {
++		if (peer->is_static_ip)
++			connman_dbus_dict_append_basic(&dict, "IPAddress",
++				DBUS_TYPE_STRING, &peer->static_ip);
++		else if (peer->is_dhcp_ip)
++			connman_dbus_dict_append_basic(&dict, "IPAddress",
++				DBUS_TYPE_STRING, &peer->dhcp_ip);
++	}
++
+ 	connman_dbus_dict_close(iter, &dict);
+ }
+ 
+diff --git a/src/rtnl.c b/src/rtnl.c
+index a87296ff..c9e84dab 100644
+--- a/src/rtnl.c
++++ b/src/rtnl.c
+@@ -1308,71 +1308,75 @@ static const char *type2string(uint16_t type)
+ static GIOChannel *channel = NULL;
+ static guint channel_watch = 0;
+ 
+-#define RTNL_REQUEST_SIZE (NLMSG_HDRLEN + NLMSG_ALIGN(sizeof(struct rtgenmsg)))
++struct rtnl_request {
++	struct nlmsghdr hdr;
++	struct rtgenmsg msg;
++};
++#define RTNL_REQUEST_SIZE  (sizeof(struct nlmsghdr) + sizeof(struct rtgenmsg))
+ 
+ static GSList *request_list = NULL;
+ static guint32 request_seq = 0;
+ 
+-static struct nlmsghdr *find_request(guint32 seq)
++static struct rtnl_request *find_request(guint32 seq)
+ {
+ 	GSList *list;
+ 
+ 	for (list = request_list; list; list = list->next) {
+-		struct nlmsghdr *hdr = list->data;
++		struct rtnl_request *req = list->data;
+ 
+-		if (hdr->nlmsg_seq == seq)
+-			return hdr;
++		if (req->hdr.nlmsg_seq == seq)
++			return req;
+ 	}
+ 
+ 	return NULL;
+ }
+ 
+-static int send_request(struct nlmsghdr *hdr)
++static int send_request(struct rtnl_request *req)
+ {
+ 	struct sockaddr_nl addr;
+ 	int sk;
+ 
+ 	DBG("%s len %d type %d flags 0x%04x seq %d",
+-				type2string(hdr->nlmsg_type),
+-				hdr->nlmsg_len, hdr->nlmsg_type,
+-				hdr->nlmsg_flags, hdr->nlmsg_seq);
++				type2string(req->hdr.nlmsg_type),
++				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
++				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+ 
+ 	sk = g_io_channel_unix_get_fd(channel);
+ 
+ 	memset(&addr, 0, sizeof(addr));
+ 	addr.nl_family = AF_NETLINK;
+ 
+-	return sendto(sk, hdr, hdr->nlmsg_len, 0,
++	return sendto(sk, req, req->hdr.nlmsg_len, 0,
+ 				(struct sockaddr *) &addr, sizeof(addr));
+ }
+ 
+-static int queue_request(struct nlmsghdr *hdr)
++static int queue_request(struct rtnl_request *req)
+ {
+-	request_list = g_slist_append(request_list, hdr);
++	request_list = g_slist_append(request_list, req);
+ 
+ 	if (g_slist_length(request_list) > 1)
+ 		return 0;
+ 
+-	return send_request(hdr);
++	return send_request(req);
+ }
+ 
+ static int process_response(guint32 seq)
+ {
+-	struct nlmsghdr *hdr;
++	struct rtnl_request *req;
+ 
+ 	DBG("seq %d", seq);
+ 
+-	hdr = find_request(seq);
+-	if (hdr) {
+-		request_list = g_slist_remove(request_list, hdr);
+-		g_free(hdr);
++	req = find_request(seq);
++	if (req) {
++		request_list = g_slist_remove(request_list, req);
++		g_free(req);
+ 	}
+ 
+-	hdr = g_slist_nth_data(request_list, 0);
+-	if (!hdr)
++	req = g_slist_nth_data(request_list, 0);
++	if (!req)
+ 		return 0;
+ 
+-	return send_request(hdr);
++	return send_request(req);
+ }
+ 
+ static void rtnl_message(void *buf, size_t len)
+@@ -1470,65 +1474,62 @@ static gboolean netlink_event(GIOChannel *chan, GIOCondition cond, gpointer data
+ 
+ static int send_getlink(void)
+ {
+-	struct nlmsghdr *hdr;
+-	struct rtgenmsg *msg;
++	struct rtnl_request *req;
+ 
+ 	DBG("");
+ 
+-	hdr = g_malloc0(RTNL_REQUEST_SIZE);
+-
+-	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+-	hdr->nlmsg_type = RTM_GETLINK;
+-	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	hdr->nlmsg_pid = 0;
+-	hdr->nlmsg_seq = request_seq++;
++	req = g_try_malloc0(RTNL_REQUEST_SIZE);
++	if (!req)
++		return -ENOMEM;
+ 
+-	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+-	msg->rtgen_family = AF_INET;
++	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
++	req->hdr.nlmsg_type = RTM_GETLINK;
++	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	req->hdr.nlmsg_pid = 0;
++	req->hdr.nlmsg_seq = request_seq++;
++	req->msg.rtgen_family = AF_INET;
+ 
+-	return queue_request(hdr);
++	return queue_request(req);
+ }
+ 
+ static int send_getaddr(void)
+ {
+-	struct nlmsghdr *hdr;
+-	struct rtgenmsg *msg;
++	struct rtnl_request *req;
+ 
+ 	DBG("");
+ 
+-	hdr = g_malloc0(RTNL_REQUEST_SIZE);
++	req = g_try_malloc0(RTNL_REQUEST_SIZE);
++	if (!req)
++		return -ENOMEM;
+ 
+-	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+-	hdr->nlmsg_type = RTM_GETADDR;
+-	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	hdr->nlmsg_pid = 0;
+-	hdr->nlmsg_seq = request_seq++;
++	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
++	req->hdr.nlmsg_type = RTM_GETADDR;
++	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	req->hdr.nlmsg_pid = 0;
++	req->hdr.nlmsg_seq = request_seq++;
++	req->msg.rtgen_family = AF_INET;
+ 
+-	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+-	msg->rtgen_family = AF_INET;
+-
+-	return queue_request(hdr);
++	return queue_request(req);
+ }
+ 
+ static int send_getroute(void)
+ {
+-	struct nlmsghdr *hdr;
+-	struct rtgenmsg *msg;
++	struct rtnl_request *req;
+ 
+ 	DBG("");
+ 
+-	hdr = g_malloc0(RTNL_REQUEST_SIZE);
+-
+-	hdr->nlmsg_len = RTNL_REQUEST_SIZE;
+-	hdr->nlmsg_type = RTM_GETROUTE;
+-	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+-	hdr->nlmsg_pid = 0;
+-	hdr->nlmsg_seq = request_seq++;
++	req = g_try_malloc0(RTNL_REQUEST_SIZE);
++	if (!req)
++		return -ENOMEM;
+ 
+-	msg = (struct rtgenmsg *) NLMSG_DATA(hdr);
+-	msg->rtgen_family = AF_INET;
++	req->hdr.nlmsg_len = RTNL_REQUEST_SIZE;
++	req->hdr.nlmsg_type = RTM_GETROUTE;
++	req->hdr.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
++	req->hdr.nlmsg_pid = 0;
++	req->hdr.nlmsg_seq = request_seq++;
++	req->msg.rtgen_family = AF_INET;
+ 
+-	return queue_request(hdr);
++	return queue_request(req);
+ }
+ 
+ static gboolean update_timeout_cb(gpointer user_data)
+@@ -1672,14 +1673,14 @@ void __connman_rtnl_cleanup(void)
+ 	update_list = NULL;
+ 
+ 	for (list = request_list; list; list = list->next) {
+-		struct nlmsghdr *hdr= list->data;
++		struct rtnl_request *req = list->data;
+ 
+ 		DBG("%s len %d type %d flags 0x%04x seq %d",
+-				type2string(hdr->nlmsg_type),
+-				hdr->nlmsg_len, hdr->nlmsg_type,
+-				hdr->nlmsg_flags, hdr->nlmsg_seq);
++				type2string(req->hdr.nlmsg_type),
++				req->hdr.nlmsg_len, req->hdr.nlmsg_type,
++				req->hdr.nlmsg_flags, req->hdr.nlmsg_seq);
+ 
+-		g_free(hdr);
++		g_free(req);
+ 		list->data = NULL;
+ 	}
+ 
+diff --git a/src/technology.c b/src/technology.c
+index 535a9040..ff54059f 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -1956,6 +1956,44 @@ void connman_technology_wps_failed_notify(struct connman_technology *technology)
+ 		CONNMAN_TECHNOLOGY_INTERFACE, "WPSFailed",
+ 		DBUS_TYPE_INVALID);
+ }
++
++static DBusMessage *start_wps(DBusConnection *conn, DBusMessage *msg, void *data)
++{
++	struct connman_technology *technology = data;
++	DBusMessageIter iter;
++	int err;
++	const char *pin;
++
++	DBG("technology %p request from %s", technology,
++		dbus_message_get_sender(msg));
++
++	if (dbus_message_iter_init(msg, &iter) == FALSE)
++		return __connman_error_invalid_arguments(msg);
++
++	if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
++		return __connman_error_invalid_arguments(msg);
++
++	dbus_message_iter_get_basic(&iter, &pin);
++
++	err = __connman_device_request_start_wps(technology->type, pin);
++	if (err < 0)
++		return __connman_error_failed(msg, -err);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
++static DBusMessage *cancel_wps(DBusConnection *conn, DBusMessage *msg, void *data)
++{
++	struct connman_technology *technology = data;
++	int err;
++
++	err = __connman_device_request_cancel_wps(technology->type);
++	if (err < 0)
++		return __connman_error_failed(msg, -err);
++
++	return g_dbus_create_reply(msg, DBUS_TYPE_INVALID);
++}
++
+ static DBusMessage *cancel_p2p(DBusConnection *conn, DBusMessage *msg, void *data)
+ {
+ 	struct connman_technology *technology = data;
+@@ -2064,6 +2102,10 @@ static const GDBusMethodTable technology_methods[] = {
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" }),
+ 			NULL, set_property) },
+ 	{ GDBUS_ASYNC_METHOD("Scan", NULL, NULL, scan) },
++	{ GDBUS_ASYNC_METHOD("StartWPS",
++			GDBUS_ARGS({ "pin", "s" }),
++			NULL, start_wps) },
++	{ GDBUS_METHOD("CancelWPS", NULL, NULL, cancel_wps) },
+ 	{ GDBUS_METHOD("CancelP2P", NULL, NULL, cancel_p2p) },
+ 	{ GDBUS_ASYNC_METHOD("GetInterfaceProperties",
+ 			GDBUS_ARGS({ "interface", "s" }),
+@@ -2075,6 +2117,7 @@ static const GDBusMethodTable technology_methods[] = {
+ static const GDBusSignalTable technology_signals[] = {
+ 	{ GDBUS_SIGNAL("PropertyChanged",
+ 			GDBUS_ARGS({ "name", "s" }, { "value", "v" })) },
++	{ GDBUS_SIGNAL("WPSFailed", NULL) },
+ 	{ },
+ };
+ 
+diff --git a/src/wispr.c b/src/wispr.c
+index 90c7dc49..42f59e26 100644
+--- a/src/wispr.c
++++ b/src/wispr.c
+@@ -167,6 +167,11 @@ static void free_wispr_routes(struct connman_wispr_portal_context *wp_context)
+ static void free_connman_wispr_portal_context(
+ 		struct connman_wispr_portal_context *wp_context)
+ {
++	DBG("context %p", wp_context);
++
++	if (!wp_context)
++		return;
++
+ 	if (wp_context->wispr_portal) {
+ 		if (wp_context->wispr_portal->ipv4_context == wp_context)
+ 			wp_context->wispr_portal->ipv4_context = NULL;

--- a/meta-luneos/recipes-connectivity/connman/connman/0010-Fix-for-peer-Device-List-Info-issue.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0010-Fix-for-peer-Device-List-Info-issue.patch
@@ -1,0 +1,341 @@
+From e77de090727f4efa1991579576300e08e7787434 Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Tue, 8 Nov 2022 17:59:24 +0530
+Subject: [PATCH] Fix for peer Device List Info issue
+
+:Release Notes:
+Fix for peer device list info issue
+
+:Detailed Notes:
+Fix for peer device list info issue
+
+:Testing Performed:
+Tested locally
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRO-15182] [OSE-RPi4] : peer device info is not listing in terminal
+
+Change-Id: Ibaac4172dd71007babf9165c7ebb122d27684bdd
+Reviewed-on: http://gpro.lge.com/c/webosose/connman-webos/+/338999
+Reviewed-by: Commit Msg Checker <commit_msg@lge.com>
+Reviewed-by: <muralidhar.n@lge.com>
+Tested-by: <muralidhar.n@lge.com>
+---
+ gsupplicant/supplicant.c | 102 +++++++++++++++++++++++++++++++++++++--
+ plugins/wifi.c           |  54 ++++++++++++---------
+ 2 files changed, 129 insertions(+), 27 deletions(-)
+
+diff --git a/gsupplicant/supplicant.c b/gsupplicant/supplicant.c
+index cc0a16e9..411cf5ae 100644
+--- a/gsupplicant/supplicant.c
++++ b/gsupplicant/supplicant.c
+@@ -2484,8 +2484,7 @@ static void bss_compute_security(struct g_supplicant_bss *bss)
+ 	if (bss->keymgmt &
+ 			(G_SUPPLICANT_KEYMGMT_WPA_PSK |
+ 				G_SUPPLICANT_KEYMGMT_WPA_FT_PSK |
+-				G_SUPPLICANT_KEYMGMT_WPA_PSK_256 |
+-				G_SUPPLICANT_KEYMGMT_SAE))
++				G_SUPPLICANT_KEYMGMT_WPA_PSK_256))
+ 		bss->psk = TRUE;
+ 
+ 	if (bss->ieee8021x)
+@@ -3090,6 +3089,12 @@ static GSupplicantInterface *interface_alloc(const char *path)
+ 	interface->bss_mapping = g_hash_table_new_full(g_str_hash, g_str_equal,
+ 								NULL, NULL);
+ 
++	interface->p2p_peer_path_to_network = g_hash_table_new_full(g_str_hash, g_str_equal,
++								NULL, NULL);
++
++	interface->p2p_group_path_to_group = g_hash_table_new_full(g_str_hash, g_str_equal,
++								NULL, NULL);
++
+ 	g_hash_table_replace(interface_table, interface->path, interface);
+ 
+ 	return interface;
+@@ -5532,7 +5537,7 @@ static void extract_peer_with_ip(const char *path, DBusMessageIter *iter, connma
+ 
+ static void signal_group_peer_joined(const char *path, DBusMessageIter *iter)
+ {
+-	const char *peer_path = NULL;
++	//const char *peer_path = NULL;
+ 	extract_peer_with_ip(path, iter, TRUE, false);
+ }
+ static gboolean peer_joined_with_ip(gpointer data)
+@@ -8648,6 +8653,46 @@ static void interface_p2p_reject_params(DBusMessageIter *iter, void *user_data)
+ 	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
+ 							&data->peer->path);
+ }
++
++int g_supplicant_interface_p2p_reject(GSupplicantInterface *interface,
++					GSupplicantPeerParams *peer_params,
++					GSupplicantInterfaceCallback callback,
++					void *user_data)
++{
++	struct interface_reject_data* data;
++	int ret;
++
++	SUPPLICANT_DBG("");
++
++	if (!interface || !peer_params || !peer_params->path)
++		return -EINVAL;
++
++	if (!interface->p2p_support)
++		return -ENOTSUP;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (!data)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->path = g_strdup(interface->path);
++	data->peer = peer_params;
++	data->callback = callback;
++	data->user_data = user_data;
++
++	ret = supplicant_dbus_method_call(interface->path,
++			SUPPLICANT_INTERFACE ".Interface.P2PDevice", "RejectPeer",
++			interface_p2p_reject_params, interface_p2p_reject_peer_result, data, NULL);
++
++	if (ret < 0) {
++		g_free(data->path);
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++
+ struct interface_p2p_sd_data {
+ 	GSupplicantInterface *interface;
+ 	GSupplicantInterfaceCallback callback;
+@@ -8778,6 +8823,42 @@ static void interface_p2p_sd_cancel_request_params(DBusMessageIter *iter, void *
+ 		dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT64, request_id);
+ 	}
+ }
++
++int g_supplicant_interface_p2p_sd_cancel_request(GSupplicantInterface *interface,
++				dbus_uint64_t request_id,
++				GSupplicantInterfaceCallback callback,
++				void *user_data)
++{
++	struct interface_p2p_sd_data *data;
++	int ret;
++
++	if (interface == NULL)
++		return -EINVAL;
++
++	if (system_available == FALSE)
++		return -EFAULT;
++
++	data = dbus_malloc0(sizeof(*data));
++	if (data == NULL)
++		return -ENOMEM;
++
++	data->interface = interface;
++	data->callback = callback;
++	data->user_data = user_data;
++	data->p2p_sd_params = (void*)&request_id;
++
++	ret = supplicant_dbus_method_call(interface->path,
++									  SUPPLICANT_INTERFACE ".Interface.P2PDevice", "ServiceDiscoveryCancelRequest",
++									  interface_p2p_sd_cancel_request_params, interface_p2p_sd_cancel_request_result, data, NULL);
++
++	if (ret < 0) {
++		dbus_free(data);
++		return ret;
++	}
++
++	return -EINPROGRESS;
++}
++
+ struct p2p_service_data {
+ 	bool registration;
+ 	GSupplicantInterface *interface;
+@@ -9945,6 +10026,12 @@ int g_supplicant_register(const GSupplicantCallbacks *callbacks)
+ 								NULL, NULL);
+ 	config_file_table = g_hash_table_new_full(g_str_hash, g_str_equal,
+ 								g_free, g_free);
++	intf_addr_mapping = g_hash_table_new_full(g_str_hash, g_str_equal,
++								g_free, NULL);
++	dev_addr_mapping = g_hash_table_new_full(g_str_hash, g_str_equal,
++								g_free, g_free);
++	p2p_peer_table = g_hash_table_new_full(g_str_hash, g_str_equal,
++								g_free, NULL);
+ 
+ 	supplicant_dbus_setup(connection);
+ 
+@@ -10048,6 +10135,15 @@ void g_supplicant_unregister(const GSupplicantCallbacks *callbacks)
+ 		connection = NULL;
+ 	}
+ 
++	if (intf_addr_mapping){
++		g_hash_table_destroy(intf_addr_mapping);
++		intf_addr_mapping = NULL;
++	}
++	if (p2p_peer_table != NULL){
++		g_hash_table_destroy(p2p_peer_table);
++		p2p_peer_table = NULL;
++	}
++
+ 	callbacks_pointer = NULL;
+ 	eap_methods = 0;
+ }
+diff --git a/plugins/wifi.c b/plugins/wifi.c
+index bc390870..80bdb60d 100644
+--- a/plugins/wifi.c
++++ b/plugins/wifi.c
+@@ -51,7 +51,7 @@
+ #include <connman/service.h>
+ #include <connman/peer.h>
+ #include <connman/log.h>
+-#include <include/option.h>
++#include <connman/option.h>
+ #include <connman/storage.h>
+ #include <include/setting.h>
+ #include <connman/provision.h>
+@@ -78,9 +78,9 @@
+ #define P2P_PERSISTENT_INFO		"P2PPersistentInfo"
+ 
+ #define P2P_FIND_TIMEOUT 30
+-#define P2P_CONNECTION_TIMEOUT 100
+-#define P2P_LISTEN_PERIOD 500
+-#define P2P_LISTEN_INTERVAL 2000
++#define P2P_CONNECTION_TIMEOUT 60
++#define P2P_LISTEN_PERIOD 450
++#define P2P_LISTEN_INTERVAL 500
+ #define P2P_PERSISTENT_MAX_COUNT 20
+ 
+ #define ASSOC_STATUS_AUTH_TIMEOUT 16
+@@ -1316,8 +1316,8 @@ static int peer_reject(struct connman_peer *peer)
+ 
+ 	peer_params.path = g_strdup(g_supplicant_peer_get_path(gs_peer));
+ 
+-	ret = g_supplicant_interface_p2p_disconnect(wifi->interface,
+-							&peer_params);
++	ret = g_supplicant_interface_p2p_reject(wifi->interface,
++							&peer_params, reject_peer_callback, peer);
+ 	g_free(peer_params.path);
+ 
+ 	if (ret == -EINPROGRESS) {
+@@ -2590,7 +2590,7 @@ static int wifi_enable(struct connman_device *device)
+ 	struct wifi_data *wifi = connman_device_get_data(device);
+ 	int index;
+ 	char *interface;
+-	const char *driver = connman_setting_get_string("wifi");
++	const char *driver = connman_option_get_string("wifi");
+ 	int ret;
+ 
+ 	DBG("device %p %p", device, wifi);
+@@ -3675,10 +3675,10 @@ static void disconnect_callback(int result, GSupplicantInterface *interface,
+ 		return;
+ 	}
+ 
+-	if (g_slist_find(wifi->networks, network))
++	//if (g_slist_find(wifi->networks, network))
+ 		connman_network_set_connected(network, false);
+ 
+-	wifi->disconnecting = false;
++	//wifi->disconnecting = false;
+ 
+ 	if (network != wifi->network) {
+ 		if (network == wifi->pending_network)
+@@ -3697,7 +3697,7 @@ static void disconnect_callback(int result, GSupplicantInterface *interface,
+ 		start_autoscan(wifi->device);
+ 	}
+ 
+-	start_autoscan(wifi->device);
++	//start_autoscan(wifi->device);
+ }
+ 
+ static int network_disconnect(struct connman_network *network)
+@@ -4448,8 +4448,7 @@ static int add_persistent_group_info(struct wifi_data *wifi)
+ }
+ static void p2p_support(GSupplicantInterface *interface)
+ {
+-	char dev_type[17] = {};
+-	const char *hostname;
++	struct wifi_data *wifi = NULL;
+ 
+ 	DBG("");
+ 
+@@ -4459,18 +4458,23 @@ static void p2p_support(GSupplicantInterface *interface)
+ 	if (!g_supplicant_interface_has_p2p(interface))
+ 		return;
+ 
++	wifi = g_supplicant_interface_get_data(interface);
++
++	if (!wifi)
++		return;
++
+ 	if (connman_technology_driver_register(&p2p_tech_driver) < 0) {
+ 		DBG("Could not register P2P technology driver");
+ 		return;
+ 	}
+ 
+-	hostname = connman_utsname_get_hostname();
++	/*hostname = connman_utsname_get_hostname();
+ 	if (!hostname)
+ 		hostname = "ConnMan";
+ 
+ 	set_device_type(connman_machine_get_type(), dev_type);
+ 	g_supplicant_interface_set_p2p_device_config(interface,
+-							hostname, dev_type);
++							hostname, dev_type);*/
+ 	connman_peer_driver_register(&peer_driver);
+ }
+ 
+@@ -4651,13 +4655,13 @@ static void network_added(GSupplicantNetwork *supplicant_network)
+ 
+ 		wifi->networks = g_slist_prepend(wifi->networks, network);
+ 
+-		network_data = g_new0(struct wifi_network, 1);
+-		connman_network_set_data(network, network_data);
++		//network_data = g_new0(struct wifi_network, 1);
++		//connman_network_set_data(network, network_data);
+ 	}
+ 
+-	network_data = connman_network_get_data(network);
+-	network_data->keymgmt =
+-		g_supplicant_network_get_keymgmt(supplicant_network);
++	//network_data = connman_network_get_data(network);
++	//network_data->keymgmt =
++	//	g_supplicant_network_get_keymgmt(supplicant_network);
+ 
+ 	if (name && name[0] != '\0')
+ 		connman_network_set_name(network, name);
+@@ -5300,8 +5304,8 @@ static void peer_changed(GSupplicantPeer *peer, GSupplicantPeerState state)
+ 	case G_SUPPLICANT_PEER_GROUP_CHANGED:
+ 		if (!g_supplicant_peer_is_in_a_group(peer))
+ 			p_state = CONNMAN_PEER_STATE_IDLE;
+-		else
+-			p_state = CONNMAN_PEER_STATE_CONFIGURATION;
++		//else
++		//	p_state = CONNMAN_PEER_STATE_CONFIGURATION;
+ 		break;
+ 	case G_SUPPLICANT_PEER_GROUP_STARTED:
+ 		break;
+@@ -5387,8 +5391,10 @@ static void peer_changed(GSupplicantPeer *peer, GSupplicantPeerState state)
+ 		if (wifi->p2p_connecting
+ 				&& connman_peer == wifi->pending_peer)
+ 			peer_cancel_timeout(wifi);
+-		else
+-			p_state = CONNMAN_PEER_STATE_UNKNOWN;
++/*		else {
++			if (!p2p_go_identifier)
++				p_state = CONNMAN_PEER_STATE_UNKNOWN;
++		}*/
+ 	}
+ 
+ 	if (p_state == CONNMAN_PEER_STATE_UNKNOWN)
+@@ -6099,7 +6105,7 @@ static void sta_remove_callback(int result,
+ 					void *user_data)
+ {
+ 	struct wifi_tethering_info *info = user_data;
+-	const char *driver = connman_setting_get_string("wifi");
++	const char *driver = connman_option_get_string("wifi");
+ 
+ 	DBG("ifname %s result %d ", info->ifname, result);
+ 

--- a/meta-luneos/recipes-connectivity/connman/connman/0011-Avoid-crash-if-no-interface-found.patch
+++ b/meta-luneos/recipes-connectivity/connman/connman/0011-Avoid-crash-if-no-interface-found.patch
@@ -1,0 +1,25 @@
+From ac02746ce18cd01ece4afc597b04d5a08af731ff Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 17 Dec 2022 17:34:37 +0000
+Subject: [PATCH] Avoid crash if no interface found
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/technology.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/technology.c b/src/technology.c
+index ff54059..600d8db 100644
+--- a/src/technology.c
++++ b/src/technology.c
+@@ -604,6 +604,10 @@ static void append_interfaces(DBusMessageIter *iter, void *user_data)
+ 	for (list = technology->device_list; list; list = list->next) {
+ 		struct connman_device *device = list->data;
+ 		const char *iface = connman_device_get_interface(device);
++		if (!iface) {
++			connman_error("Failed to get interface !!");
++			continue;
++		}
+ 
+ 		dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, &iface);
+ 	}

--- a/meta-luneos/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-luneos/recipes-connectivity/connman/connman_%.bbappend
@@ -18,7 +18,7 @@ SRC_URI += " \
     file://0007-Fix-for-create-group-api-and-crash-issue.patch \
     file://0008-Revert-Fix-for-create-group-api-and-crash-issue.patch \
     file://0009-Fix-for-Create-Group-api-and-crash-issue.patch \
-    file://0010-Fix-for-peer-Device-List-Info-issue-api.patch \
+    file://0010-Fix-for-peer-Device-List-Info-issue.patch \
 "
 
 

--- a/meta-luneos/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-luneos/recipes-connectivity/connman/connman_%.bbappend
@@ -7,6 +7,21 @@ SRC_URI:remove = "file://0001-connman.service-stop-systemd-networkd-when-using-c
 
 SRC_URI += "file://0001-connman.service.in-start-after-android-system.servic.patch"
 
+#Patches from connman-webos from webOS OSE
+SRC_URI += " \
+    file://0001-Add-Changes-for-p2p-setState-api.patch \
+    file://0002-Add-Changes-for-p2p-getDeviceName-api.patch \
+    file://0003-Add-Changes-for-p2p-addService-setwifidisplayinfo-fi.patch \
+    file://0004-Add-Changes-for-tethering-setState-api.patch \
+    file://0005-Add-Changes-for-p2p-create-group-api.patch \
+    file://0006-Add-Changes-for-No-Internet-issue-connman.patch \
+    file://0007-Fix-for-create-group-api-and-crash-issue.patch \
+    file://0008-Revert-Fix-for-create-group-api-and-crash-issue.patch \
+    file://0009-Fix-for-Create-Group-api-and-crash-issue.patch \
+    file://0010-Fix-for-peer-Device-List-Info-issue-api.patch \
+"
+
+
 RRECOMMENDS:${PN} += "neard connman-vpn connman-plugin-vpn-openvpn connman-plugin-vpn-vpnc connman-plugin-vpn-l2tp connman-plugin-vpn-pppt connman-tests connman-tools connman-wait-online"
 
 # needed for VPN support in ConnMan

--- a/meta-luneos/recipes-connectivity/connman/connman_%.bbappend
+++ b/meta-luneos/recipes-connectivity/connman/connman_%.bbappend
@@ -19,6 +19,7 @@ SRC_URI += " \
     file://0008-Revert-Fix-for-create-group-api-and-crash-issue.patch \
     file://0009-Fix-for-Create-Group-api-and-crash-issue.patch \
     file://0010-Fix-for-peer-Device-List-Info-issue.patch \
+    file://0011-Avoid-crash-if-no-interface-found.patch \
 "
 
 

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/0001-Add-p2p-changes.patch
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/0001-Add-p2p-changes.patch
@@ -1,0 +1,1683 @@
+From 4ea5d446e9725bbbccd3182fd4cd58f479f6865f Mon Sep 17 00:00:00 2001
+From: "penikelapati.kumar" <penikelapati.kumar@lge.com>
+Date: Wed, 27 Jan 2021 18:56:41 +0530
+Subject: [PATCH] Add p2p changes
+
+:Release Notes:
+Add new dbus methods related to p2p
+
+:Detailed Notes:
+Added code changes realted p2p joined with ip and generic mac address
+solution for p2p devices.
+
+:Testing Performed:
+Build successfully.
+Ethrenet/wifi connection successfully.
+
+:QA Notes:
+N/A
+
+:Issues Addressed:
+[PLAT-131728] Integrating and verification p2p/getstate, p2p/setstate
+              and p2p/setgointent Luna API
+
+Upstream-Status: Inappropriate[webos specific]
+
+---
+ src/ap/drv_callbacks.c                      |  11 ++
+ src/ap/hostapd.c                            |  23 ++++
+ src/ap/hostapd.h                            |   8 +-
+ src/ap/sta_info.c                           |  23 +++-
+ src/ap/wpa_auth.c                           |   2 +
+ src/common/ieee802_11_defs.h                |   1 +
+ src/p2p/p2p.c                               |  57 +++++++--
+ src/p2p/p2p.h                               |   5 +
+ src/p2p/p2p_build.c                         |  15 ++-
+ src/p2p/p2p_go_neg.c                        |  40 ++++---
+ src/p2p/p2p_group.c                         |  14 +++
+ src/p2p/p2p_invitation.c                    |  48 +++++++-
+ src/p2p/p2p_pd.c                            |   7 ++
+ src/wps/wps_attr_build.c                    | 116 ++++++++++++++++++
+ src/wps/wps_defs.h                          |  10 +-
+ src/wps/wps_i.h                             |   1 +
+ wpa_supplicant/ap.c                         |   4 +-
+ wpa_supplicant/dbus/dbus_new.c              | 123 +++++++++++++++++++-
+ wpa_supplicant/dbus/dbus_new.h              |  20 ++--
+ wpa_supplicant/dbus/dbus_new_handlers.c     |  56 +++++++++
+ wpa_supplicant/dbus/dbus_new_handlers.h     |   1 +
+ wpa_supplicant/dbus/dbus_new_handlers_p2p.c |  34 +++++-
+ wpa_supplicant/dbus/dbus_new_handlers_p2p.h |   2 +
+ wpa_supplicant/notify.c                     |  34 ++++--
+ wpa_supplicant/notify.h                     |   6 +-
+ wpa_supplicant/p2p_supplicant.c             |  47 +++++++-
+ wpa_supplicant/p2p_supplicant.h             |   1 +
+ wpa_supplicant/wpa_supplicant.c             |  17 ++-
+ 28 files changed, 655 insertions(+), 71 deletions(-)
+
+diff --git a/src/ap/drv_callbacks.c b/src/ap/drv_callbacks.c
+index 34ca379..dcbfb40 100644
+--- a/src/ap/drv_callbacks.c
++++ b/src/ap/drv_callbacks.c
+@@ -175,6 +175,17 @@ int hostapd_notif_assoc(struct hostapd_data *hapd, const u8 *addr,
+ 			   "STA did not include WPS/RSN/WPA IE in (Re)AssocReq");
+ 	}
+ 
++#ifdef CONFIG_P2P
++	if (hapd->rejected_peer && os_memcmp(hapd->rejected_peer, addr, ETH_ALEN) == 0) {
++		hostapd_drv_sta_disassoc(hapd, addr,
++					WLAN_STATUS_UNACCEPTABLE_LIFETIME);
++		eloop_cancel_timeout(clear_rejected_peer_timeout, hapd, NULL);
++		eloop_register_timeout(5, 0,
++					clear_rejected_peer_timeout, hapd, NULL);
++		return -1;
++	}
++#endif /* CONFIG_P2P */
++
+ 	sta = ap_get_sta(hapd, addr);
+ 	if (sta) {
+ 		ap_sta_no_session_timeout(hapd, sta);
+diff --git a/src/ap/hostapd.c b/src/ap/hostapd.c
+index bf1975f..65a0bb4 100644
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -352,6 +352,12 @@ static void hostapd_free_hapd_data(struct hostapd_data *hapd)
+ 	hapd->p2p_beacon_ie = NULL;
+ 	wpabuf_free(hapd->p2p_probe_resp_ie);
+ 	hapd->p2p_probe_resp_ie = NULL;
++
++	eloop_cancel_timeout(clear_rejected_peer_timeout, hapd, NULL);
++	if (hapd->rejected_peer) {
++		os_free(hapd->rejected_peer);
++		hapd->rejected_peer = NULL;
++	}
+ #endif /* CONFIG_P2P */
+ 
+ 	if (!hapd->started) {
+@@ -2229,6 +2235,11 @@ hostapd_alloc_bss_data(struct hostapd_iface *hapd_iface,
+ 	if (conf)
+ 		hapd->driver = conf->driver;
+ 	hapd->ctrl_sock = -1;
++
++#ifdef CONFIG_P2P
++	hapd->rejected_peer = NULL;
++#endif /* CONFIG_P2P */
++
+ 	dl_list_init(&hapd->ctrl_dst);
+ 	dl_list_init(&hapd->nr_db);
+ 	hapd->dhcp_sock = -1;
+@@ -3571,3 +3582,15 @@ void hostapd_periodic_iface(struct hostapd_iface *iface)
+ #endif /* CONFIG_NO_RADIUS */
+ 	}
+ }
++
++#ifdef CONFIG_P2P
++void clear_rejected_peer_timeout(void *eloop_ctx, void *timeout_ctx)
++{
++	struct hostapd_data *hapd = eloop_ctx;
++
++	if (hapd && hapd->rejected_peer) {
++		os_free(hapd->rejected_peer);
++		hapd->rejected_peer = NULL;
++	}
++}
++#endif /* CONFIG_P2P */
+diff --git a/src/ap/hostapd.h b/src/ap/hostapd.h
+index 518c7f1..d0603f0 100644
+--- a/src/ap/hostapd.h
++++ b/src/ap/hostapd.h
+@@ -263,7 +263,7 @@ struct hostapd_data {
+ 	void *wps_event_cb_ctx;
+ 
+ 	void (*sta_authorized_cb)(void *ctx, const u8 *mac_addr,
+-				  int authorized, const u8 *p2p_dev_addr);
++				  int authorized, const u8 *p2p_dev_addr, const char *ip_addr);
+ 	void *sta_authorized_cb_ctx;
+ 
+ 	void (*setup_complete_cb)(void *ctx);
+@@ -290,6 +290,8 @@ struct hostapd_data {
+ 	struct wpabuf *p2p_beacon_ie;
+ 	struct wpabuf *p2p_probe_resp_ie;
+ 
++	u8* rejected_peer;
++
+ 	/* Number of non-P2P association stations */
+ 	int num_sta_no_p2p;
+ 
+@@ -655,4 +657,8 @@ void fst_hostapd_fill_iface_obj(struct hostapd_data *hapd,
+ 				struct fst_wpa_obj *iface_obj);
+ #endif /* CONFIG_FST */
+ 
++#ifdef CONFIG_P2P
++void clear_rejected_peer_timeout(void *eloop_ctx, void *timeout_ctx);
++#endif /* CONFIG_P2P */
++
+ #endif /* HOSTAPD_H */
+diff --git a/src/ap/sta_info.c b/src/ap/sta_info.c
+index 51d7884..bc1ec32 100644
+--- a/src/ap/sta_info.c
++++ b/src/ap/sta_info.c
+@@ -1223,6 +1223,8 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+ #ifdef CONFIG_P2P
+ 	u8 addr[ETH_ALEN];
+ 	u8 ip_addr_buf[4];
++	char ip_info[100];
++	int is_ip_addr = -1;
+ #endif /* CONFIG_P2P */
+ 
+ 	if (!!authorized == !!(sta->flags & WLAN_STA_AUTHORIZED))
+@@ -1248,23 +1250,27 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+ #endif /* CONFIG_P2P */
+ 		os_snprintf(buf, sizeof(buf), MACSTR, MAC2STR(sta->addr));
+ 
+-	if (hapd->sta_authorized_cb)
+-		hapd->sta_authorized_cb(hapd->sta_authorized_cb_ctx,
+-					sta->addr, authorized, dev_addr);
+-
+ 	if (authorized) {
+ 		const char *keyid;
+ 		char keyid_buf[100];
+ 		char ip_addr[100];
+ 
+ 		keyid_buf[0] = '\0';
++		ip_info[0] = '\0';
+ 		ip_addr[0] = '\0';
+ #ifdef CONFIG_P2P
+ 		if (wpa_auth_get_ip_addr(sta->wpa_sm, ip_addr_buf) == 0) {
++			is_ip_addr = 1;
++
+ 			os_snprintf(ip_addr, sizeof(ip_addr),
+ 				    " ip_addr=%u.%u.%u.%u",
+ 				    ip_addr_buf[0], ip_addr_buf[1],
+ 				    ip_addr_buf[2], ip_addr_buf[3]);
++
++			os_snprintf(ip_info, sizeof(ip_info),
++								"%u.%u.%u.%u",
++								ip_addr_buf[0], ip_addr_buf[1],
++								ip_addr_buf[2], ip_addr_buf[3]);
+ 		}
+ #endif /* CONFIG_P2P */
+ 
+@@ -1291,6 +1297,15 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+ 					  AP_STA_DISCONNECTED "%s", buf);
+ 	}
+ 
++	if (hapd->sta_authorized_cb) {
++		if (is_ip_addr < 0)
++			hapd->sta_authorized_cb(hapd->sta_authorized_cb_ctx,
++								sta->addr, authorized, dev_addr, NULL);
++		else
++			hapd->sta_authorized_cb(hapd->sta_authorized_cb_ctx,
++								sta->addr, authorized, dev_addr, ip_info);
++	}
++
+ #ifdef CONFIG_FST
+ 	if (hapd->iface->fst) {
+ 		if (authorized)
+diff --git a/src/ap/wpa_auth.c b/src/ap/wpa_auth.c
+index c560770..72ff1f7 100644
+--- a/src/ap/wpa_auth.c
++++ b/src/ap/wpa_auth.c
+@@ -685,6 +685,7 @@ void wpa_auth_sta_no_wpa(struct wpa_state_machine *sm)
+ 
+ static void wpa_free_sta_sm(struct wpa_state_machine *sm)
+ {
++#if 0
+ #ifdef CONFIG_P2P
+ 	if (WPA_GET_BE32(sm->ip_addr)) {
+ 		u32 start;
+@@ -698,6 +699,7 @@ static void wpa_free_sta_sm(struct wpa_state_machine *sm)
+ 			       WPA_GET_BE32(sm->ip_addr) - start);
+ 	}
+ #endif /* CONFIG_P2P */
++#endif
+ 	if (sm->GUpdateStationKeys) {
+ 		sm->group->GKeyDoneStations--;
+ 		sm->GUpdateStationKeys = FALSE;
+diff --git a/src/common/ieee802_11_defs.h b/src/common/ieee802_11_defs.h
+index b0aa913..7446deb 100644
+--- a/src/common/ieee802_11_defs.h
++++ b/src/common/ieee802_11_defs.h
+@@ -1647,6 +1647,7 @@ enum p2p_role_indication {
+ 
+ #define P2P_WILDCARD_SSID "DIRECT-"
+ #define P2P_WILDCARD_SSID_LEN 7
++#define MAX_P2P_SSID_LEN 32
+ 
+ /* P2P action frames */
+ enum p2p_act_frame_type {
+diff --git a/src/p2p/p2p.c b/src/p2p/p2p.c
+index 079270f..3047220 100644
+--- a/src/p2p/p2p.c
++++ b/src/p2p/p2p.c
+@@ -1314,6 +1314,7 @@ void p2p_stop_find_for_freq(struct p2p_data *p2p, int freq)
+ 	p2p->go_neg_peer = NULL;
+ 	p2p->sd_peer = NULL;
+ 	p2p->invite_peer = NULL;
++	p2p->p2p_scan_running = 0;
+ 	p2p_stop_listen_for_freq(p2p, freq);
+ 	p2p->send_action_in_progress = 0;
+ }
+@@ -1321,6 +1322,10 @@ void p2p_stop_find_for_freq(struct p2p_data *p2p, int freq)
+ 
+ void p2p_stop_listen_for_freq(struct p2p_data *p2p, int freq)
+ {
++	if(!p2p) {
++		p2p_dbg(p2p, "p2p data is null");
++		return;
++	}
+ 	if (freq > 0 && p2p->drv_in_listen == freq && p2p->in_listen) {
+ 		p2p_dbg(p2p, "Skip stop_listen since we are on correct channel for response");
+ 		return;
+@@ -1626,15 +1631,26 @@ int p2p_connect(struct p2p_data *p2p, const u8 *peer_addr,
+ 	dev->go_neg_req_sent = 0;
+ 	dev->go_state = UNKNOWN_GO;
+ 	p2p_set_dev_persistent(dev, persistent_group);
+-	p2p->go_intent = go_intent;
+ 	os_memcpy(p2p->intended_addr, own_interface_addr, ETH_ALEN);
+ 
++	p2p_dbg(p2p, "Peer's go intent %d ", dev->info.go_intent);
++
++	/*If Peer's go intent value is 15, set p2p go intent to 1 for compatibility */
++	if (dev->info.go_intent == P2P_MAX_GO_INTENT) {
++		p2p->go_intent = 1;
++		p2p_dbg(p2p, "Peer's go intent value is 15, set to go intent %d", p2p->go_intent);
++	} else {
++		p2p->go_intent = go_intent;
++		p2p_dbg(p2p, "Set p2p go intent to %d", p2p->go_intent);
++	}
++
+ 	if (p2p->state != P2P_IDLE)
+ 		p2p_stop_find(p2p);
+ 
+ 	dev->wps_method = wps_method;
+ 	dev->oob_pw_id = oob_pw_id;
+-	dev->status = P2P_SC_SUCCESS;
++	if (dev->status != P2P_SC_FAIL_REJECTED_BY_USER)
++		dev->status = P2P_SC_SUCCESS;
+ 
+ 	if (p2p->p2p_scan_running) {
+ 		p2p_dbg(p2p, "p2p_scan running - delay connect send");
+@@ -1726,6 +1742,11 @@ void p2p_add_dev_info(struct p2p_data *p2p, const u8 *addr,
+ 		}
+ 	}
+ 
++	if(msg->go_intent) {
++		dev->info.go_intent = (*msg->go_intent >> 1);
++		p2p_dbg(p2p, "P2P: Peer's p2p go intent value is %d", dev->info.go_intent);
++	}
++
+ 	if (msg->wfd_subelems) {
+ 		wpabuf_free(dev->info.wfd_subelems);
+ 		dev->info.wfd_subelems = wpabuf_dup(msg->wfd_subelems);
+@@ -1760,9 +1781,12 @@ void p2p_build_ssid(struct p2p_data *p2p, u8 *ssid, size_t *ssid_len)
+ {
+ 	os_memcpy(ssid, P2P_WILDCARD_SSID, P2P_WILDCARD_SSID_LEN);
+ 	p2p_random((char *) &ssid[P2P_WILDCARD_SSID_LEN], 2);
+-	os_memcpy(&ssid[P2P_WILDCARD_SSID_LEN + 2],
+-		  p2p->cfg->ssid_postfix, p2p->cfg->ssid_postfix_len);
+ 	*ssid_len = P2P_WILDCARD_SSID_LEN + 2 + p2p->cfg->ssid_postfix_len;
++
++	if (*ssid_len < MAX_P2P_SSID_LEN)
++		os_memcpy(&ssid[P2P_WILDCARD_SSID_LEN + 2], p2p->cfg->ssid_postfix, p2p->cfg->ssid_postfix_len);
++	else if (*ssid_len == MAX_P2P_SSID_LEN)
++		*ssid_len = P2P_WILDCARD_SSID_LEN + 2;
+ }
+ 
+ 
+@@ -2957,7 +2981,8 @@ struct p2p_data * p2p_init(const struct p2p_config *cfg)
+ 	p2p->dev_capab |= P2P_DEV_CAPAB_INVITATION_PROCEDURE;
+ 	if (cfg->concurrent_operations)
+ 		p2p->dev_capab |= P2P_DEV_CAPAB_CONCURRENT_OPER;
+-	p2p->dev_capab |= P2P_DEV_CAPAB_CLIENT_DISCOVERABILITY;
++	/* Client discoverability disabled */
++	p2p->dev_capab &= ~P2P_DEV_CAPAB_CLIENT_DISCOVERABILITY;
+ 
+ 	dl_list_init(&p2p->devices);
+ 
+@@ -3231,6 +3256,9 @@ void p2p_continue_find(struct p2p_data *p2p)
+ 	struct p2p_device *dev;
+ 	int found, res;
+ 
++	if (p2p == NULL)
++		return;
++
+ 	p2p_set_state(p2p, P2P_SEARCH);
+ 
+ 	/* Continue from the device following the last iteration */
+@@ -4578,10 +4606,8 @@ static void p2p_ext_listen_timeout(void *eloop_ctx, void *timeout_ctx)
+ 				       p2p_ext_listen_timeout, p2p, NULL);
+ 	}
+ 
+-	if ((p2p->cfg->is_p2p_in_progress &&
+-	     p2p->cfg->is_p2p_in_progress(p2p->cfg->cb_ctx)) ||
+-	    (p2p->pending_action_state == P2P_PENDING_PD &&
+-	     p2p->pd_retries > 0)) {
++	if (p2p->pending_action_state == P2P_PENDING_PD &&
++	     p2p->pd_retries > 0) {
+ 		p2p_dbg(p2p, "Operation in progress - skip Extended Listen timeout (%s)",
+ 			p2p_state_txt(p2p->state));
+ 		return;
+@@ -4599,6 +4625,14 @@ static void p2p_ext_listen_timeout(void *eloop_ctx, void *timeout_ctx)
+ 		p2p_set_state(p2p, P2P_IDLE);
+ 	}
+ 
++	if (p2p->cfg->is_p2p_in_progress &&
++	     p2p->cfg->is_p2p_in_progress(p2p->cfg->cb_ctx)) {
++		p2p_dbg(p2p, "Connection in progress - skip Extended Listen timeout (%s)",
++			p2p_state_txt(p2p->state));
++		return;
++	}
++
++
+ 	if (p2p->state != P2P_IDLE) {
+ 		p2p_dbg(p2p, "Skip Extended Listen timeout in active state (%s)", p2p_state_txt(p2p->state));
+ 		return;
+@@ -4626,13 +4660,13 @@ int p2p_ext_listen(struct p2p_data *p2p, unsigned int period,
+ 	eloop_cancel_timeout(p2p_ext_listen_timeout, p2p, NULL);
+ 
+ 	if (interval == 0) {
+-		p2p_dbg(p2p, "Disabling Extended Listen Timing");
++		p2p_info(p2p, "Disabling Extended Listen Timing");
+ 		p2p->ext_listen_period = 0;
+ 		p2p->ext_listen_interval = 0;
+ 		return 0;
+ 	}
+ 
+-	p2p_dbg(p2p, "Enabling Extended Listen Timing: period %u msec, interval %u msec",
++	p2p_info(p2p, "Enabling Extended Listen Timing: period %u msec, interval %u msec",
+ 		period, interval);
+ 	p2p->ext_listen_period = period;
+ 	p2p->ext_listen_interval = interval;
+@@ -4737,6 +4771,7 @@ int p2p_set_listen_channel(struct p2p_data *p2p, u8 reg_class, u8 channel,
+ 		reg_class, channel);
+ 
+ 	if (p2p->state == P2P_IDLE) {
++		p2p->pending_listen_freq = 0;
+ 		p2p->cfg->reg_class = reg_class;
+ 		p2p->cfg->channel = channel;
+ 		p2p->cfg->channel_forced = forced;
+diff --git a/src/p2p/p2p.h b/src/p2p/p2p.h
+index 425b037..6816174 100644
+--- a/src/p2p/p2p.h
++++ b/src/p2p/p2p.h
+@@ -375,6 +375,11 @@ struct p2p_peer_info {
+ 	 */
+ 	u8 group_capab;
+ 
++	/**
++	 * go_intent - p2p go intent value
++	 */
++	u8 go_intent;
++
+ 	/**
+ 	 * wps_sec_dev_type_list - WPS secondary device type list
+ 	 *
+diff --git a/src/p2p/p2p_build.c b/src/p2p/p2p_build.c
+index 63eb2e8..0274ec2 100644
+--- a/src/p2p/p2p_build.c
++++ b/src/p2p/p2p_build.c
+@@ -223,10 +223,14 @@ void p2p_buf_add_device_info(struct wpabuf *buf, struct p2p_data *p2p,
+ 			sizeof(p2p->cfg->pri_dev_type));
+ 
+ 	/* Number of Secondary Device Types */
+-	wpabuf_put_u8(buf, p2p->cfg->num_sec_dev_types);
++	wpabuf_put_u8(buf, p2p->cfg->num_sec_dev_types + 1);
++
++	/* Prepend Intel OUI (see Gen4 WiDi Sink Technical Specification, chapter 3.2) */
++	u8 intel_oui[8] = { 00, 07, 00, 23, 53, 32, 00, 02 };
++	wpabuf_put_data(buf, intel_oui, WPS_DEV_TYPE_LEN);
+ 
+ 	/* Secondary Device Type List */
+-	for (i = 0; i < p2p->cfg->num_sec_dev_types; i++)
++	for (i = 1; i < p2p->cfg->num_sec_dev_types; i++)
+ 		wpabuf_put_data(buf, p2p->cfg->sec_dev_type[i],
+ 				WPS_DEV_TYPE_LEN);
+ 
+@@ -805,13 +809,20 @@ int p2p_build_wps_ie(struct p2p_data *p2p, struct wpabuf *buf, int pw_id,
+ 	if (wps_build_wfa_ext(buf, 0, NULL, 0, 0) < 0)
+ 		return -1;
+ 
++	if (wps_build_wfa_ext_ms(buf, p2p->cfg->dev_name, p2p->cfg->dev_addr) < 0)
++		wpa_printf(MSG_DEBUG, "WPS: *MS failed to build wps_build_wfa_ext_ms");
++
+ 	if (all_attr && p2p->cfg->num_sec_dev_types) {
+ 		if (wpabuf_tailroom(buf) <
+ 		    4 + WPS_DEV_TYPE_LEN * p2p->cfg->num_sec_dev_types)
+ 			return -1;
++		/* Prepend Intel OUI (see Gen4 WiDi Sink Technical Specification, chapter 3.2) */
++		u8 intel_oui[8] = { 00, 07, 00, 23, 53, 32, 00, 02 };
+ 		wpabuf_put_be16(buf, ATTR_SECONDARY_DEV_TYPE_LIST);
++		wpabuf_put_be16(buf, WPS_DEV_TYPE_LEN);
+ 		wpabuf_put_be16(buf, WPS_DEV_TYPE_LEN *
+ 				p2p->cfg->num_sec_dev_types);
++		wpabuf_put_data(buf, intel_oui, WPS_DEV_TYPE_LEN);
+ 		wpabuf_put_data(buf, p2p->cfg->sec_dev_type,
+ 				WPS_DEV_TYPE_LEN *
+ 				p2p->cfg->num_sec_dev_types);
+diff --git a/src/p2p/p2p_go_neg.c b/src/p2p/p2p_go_neg.c
+index c94bf41..d34c417 100644
+--- a/src/p2p/p2p_go_neg.c
++++ b/src/p2p/p2p_go_neg.c
+@@ -171,6 +171,18 @@ static struct wpabuf * p2p_build_go_neg_req(struct p2p_data *p2p,
+ 	p2p_buf_add_capability(buf, p2p->dev_capab &
+ 			       ~P2P_DEV_CAPAB_CLIENT_DISCOVERABILITY,
+ 			       group_capab);
++	/*
++	 * This statement provided MC should be added to indicate the
++	 * rejection of GO Negotiation to remote device when we combinate the
++	 * rejectPeer() and connect() APIs.
++	 *
++	 * FIXME: The setting of P2P_SC_FAIL_REJECTED_BY_USER is against the spec.
++	 * But apparently still being used in practice. We need to find a better
++	 * solution for this issue.
++	 */
++	if (peer->status == P2P_SC_FAIL_REJECTED_BY_USER)
++		p2p_buf_add_status(buf, P2P_SC_FAIL_INVALID_PARAMS);
++
+ 	p2p_buf_add_go_intent(buf, (p2p->go_intent << 1) | peer->tie_breaker);
+ 	p2p_buf_add_config_timeout(buf, p2p->go_timeout, p2p->client_timeout);
+ 	p2p_buf_add_listen_channel(buf, p2p->cfg->country, p2p->cfg->reg_class,
+@@ -454,6 +466,18 @@ void p2p_reselect_channel(struct p2p_data *p2p,
+ 		}
+ 	}
+ 
++	/*
++         * Try to see if the original channel is in the intersection. If
++         * so, no need to change anything, as it already contains some
++         * randomness.
++         */
++	if (p2p_channels_includes(intersection, p2p->op_reg_class,
++				  p2p->op_channel)) {
++		p2p_dbg(p2p, "Using original operating class and channel (op_class %u channel %u) from intersection",
++			p2p->op_reg_class, p2p->op_channel);
++		return;
++	}
++
+ 	/* Try a channel where we might be able to use VHT */
+ 	if (p2p_channel_select(intersection, op_classes_vht,
+ 			       &p2p->op_reg_class, &p2p->op_channel) == 0) {
+@@ -478,18 +502,6 @@ void p2p_reselect_channel(struct p2p_data *p2p,
+ 		return;
+ 	}
+ 
+-	/*
+-	 * Try to see if the original channel is in the intersection. If
+-	 * so, no need to change anything, as it already contains some
+-	 * randomness.
+-	 */
+-	if (p2p_channels_includes(intersection, p2p->op_reg_class,
+-				  p2p->op_channel)) {
+-		p2p_dbg(p2p, "Using original operating class and channel (op_class %u channel %u) from intersection",
+-			p2p->op_reg_class, p2p->op_channel);
+-		return;
+-	}
+-
+ 	/*
+ 	 * Fall back to whatever is included in the channel intersection since
+ 	 * no better options seems to be available.
+@@ -831,14 +843,14 @@ void p2p_process_go_neg_req(struct p2p_data *p2p, const u8 *sa,
+ 	else if ((dev->flags & P2P_DEV_PROBE_REQ_ONLY) ||
+ 		  !(dev->flags & P2P_DEV_REPORTED))
+ 		p2p_add_dev_info(p2p, sa, dev, &msg);
+-	else if (!dev->listen_freq && !dev->oper_freq) {
++	else if ((!dev->listen_freq && !dev->oper_freq) || dev->info.go_intent == 0) {
+ 		/*
+ 		 * This may happen if the peer entry was added based on PD
+ 		 * Request and no Probe Request/Response frame has been received
+ 		 * from this peer (or that information has timed out).
+ 		 */
+ 		p2p_dbg(p2p, "Update peer " MACSTR
+-			" based on GO Neg Req since listen/oper freq not known",
++			" based on GO Neg Req since listen/oper freq or go intent not known",
+ 			MAC2STR(dev->info.p2p_device_addr));
+ 		p2p_add_dev_info(p2p, sa, dev, &msg);
+ 	}
+diff --git a/src/p2p/p2p_group.c b/src/p2p/p2p_group.c
+index aa18af6..4e42601 100644
+--- a/src/p2p/p2p_group.c
++++ b/src/p2p/p2p_group.c
+@@ -349,6 +349,13 @@ static int wifi_display_add_dev_info_descr(struct wpabuf *buf,
+ 	return 1;
+ }
+ 
++static void wifi_display_set_alternative_mac(struct wpabuf *e, const u8 *addr)
++{
++	wpabuf_put_u8(e, WFD_SUBELEM_MAC_INFO);
++	wpabuf_put_be16(e, ETH_ALEN);
++	wpabuf_put_data(e, addr, ETH_ALEN);
++}
++
+ 
+ static struct wpabuf *
+ wifi_display_build_go_ie(struct p2p_group *group)
+@@ -396,6 +403,10 @@ wifi_display_build_go_ie(struct p2p_group *group)
+ 			count);
+ 	}
+ 
++	/* Build alternative MAC address*/
++	if (os_memcmp(group->p2p->cfg->dev_addr, group->p2p->intended_addr, ETH_ALEN) !=0)
++		wifi_display_set_alternative_mac(wfd_subelems, group->p2p->intended_addr);
++
+ 	wfd_ie = wifi_display_encaps(wfd_subelems);
+ 	wpabuf_free(wfd_subelems);
+ 
+@@ -760,6 +771,9 @@ int p2p_group_match_dev_type(struct p2p_group *group, struct wpabuf *wps)
+ {
+ 	struct p2p_group_member *m;
+ 
++	if (group == NULL)
++		return 0;
++
+ 	if (p2p_match_dev_type(group->p2p, wps))
+ 		return 1; /* Match with own device type */
+ 
+diff --git a/src/p2p/p2p_invitation.c b/src/p2p/p2p_invitation.c
+index 77d662a..51b8582 100644
+--- a/src/p2p/p2p_invitation.c
++++ b/src/p2p/p2p_invitation.c
+@@ -170,6 +170,43 @@ static struct wpabuf * p2p_build_invitation_resp(struct p2p_data *p2p,
+ 	return buf;
+ }
+ 
++static void p2p_select_default_channel(struct p2p_data *p2p,
++			  struct p2p_channels *intersection)
++{
++	const int op_classes_5ghz[] = { 124, 125, 115, 0 };
++	const int op_classes_ht40[] = { 126, 127, 116, 117, 0 };
++	const int op_classes_vht[] = { 128, 129, 130, 0 };
++
++	/* Try a channel where we might be able to use VHT */
++	if (p2p_channel_select(intersection, op_classes_vht,
++			       &p2p->op_reg_class, &p2p->op_channel) == 0) {
++		p2p_dbg(p2p, "Pick possible VHT channel (op_class %u channel %u) from intersection",
++			p2p->op_reg_class, p2p->op_channel);
++		return;
++	}
++
++	/* Try a channel where we might be able to use HT40 */
++	if (p2p_channel_select(intersection, op_classes_ht40,
++			       &p2p->op_reg_class, &p2p->op_channel) == 0) {
++		p2p_dbg(p2p, "Pick possible HT40 channel (op_class %u channel %u) from intersection",
++			p2p->op_reg_class, p2p->op_channel);
++		return;
++	}
++
++	/* Prefer a 5 GHz channel */
++	if (p2p_channel_select(intersection, op_classes_5ghz,
++			       &p2p->op_reg_class, &p2p->op_channel) == 0) {
++		p2p_dbg(p2p, "Pick possible 5 GHz channel (op_class %u channel %u) from intersection",
++			p2p->op_reg_class, p2p->op_channel);
++		return;
++	}
++
++	/* Default to own configuration as a starting point */
++	p2p->op_reg_class = p2p->cfg->op_reg_class;
++	p2p->op_channel = p2p->cfg->op_channel;
++	p2p_dbg(p2p, "Pick operating class and channel (op_class %u channel %u) from configuration",
++			p2p->op_reg_class, p2p->op_channel);
++}
+ 
+ void p2p_process_invitation_req(struct p2p_data *p2p, const u8 *sa,
+ 				const u8 *data, size_t len, int rx_freq)
+@@ -213,7 +250,15 @@ void p2p_process_invitation_req(struct p2p_data *p2p, const u8 *sa,
+ 				MACSTR, MAC2STR(sa));
+ 			status = P2P_SC_FAIL_INFO_CURRENTLY_UNAVAILABLE;
+ 			goto fail;
++		} else {
++			p2p_add_dev_info(p2p, sa, dev, &msg);
++			p2p_dbg(p2p, "Update peer info from Invitation Request "
++				"peer " MACSTR, MAC2STR(sa));
+ 		}
++	} else {
++		p2p_add_dev_info(p2p, sa, dev, &msg);
++		p2p_dbg(p2p, "Update peer info from Invitation Request "
++			"peer " MACSTR, MAC2STR(sa));
+ 	}
+ 
+ 	if (!msg.group_id || !msg.channel_list) {
+@@ -296,8 +341,7 @@ void p2p_process_invitation_req(struct p2p_data *p2p, const u8 *sa,
+ 		p2p_dbg(p2p, "No forced channel from invitation processing - figure out best one to use");
+ 
+ 		/* Default to own configuration as a starting point */
+-		p2p->op_reg_class = p2p->cfg->op_reg_class;
+-		p2p->op_channel = p2p->cfg->op_channel;
++		p2p_select_default_channel(p2p, &intersection);
+ 		p2p_dbg(p2p, "Own default op_class %d channel %d",
+ 			p2p->op_reg_class, p2p->op_channel);
+ 
+diff --git a/src/p2p/p2p_pd.c b/src/p2p/p2p_pd.c
+index 05fd593..027cdfc 100644
+--- a/src/p2p/p2p_pd.c
++++ b/src/p2p/p2p_pd.c
+@@ -602,6 +602,13 @@ void p2p_process_prov_disc_req(struct p2p_data *p2p, const u8 *sa,
+ 				MACSTR, MAC2STR(sa));
+ 			goto out;
+ 		}
++
++		dev = p2p_get_device(p2p, sa);
++		if (dev != NULL) {
++			p2p_add_dev_info(p2p, sa, dev, &msg);
++			p2p_dbg(p2p, "Update peer info from Provision Discovery Request "
++				"peer " MACSTR, MAC2STR(sa));
++		}
+ 	} else if (msg.wfd_subelems) {
+ 		wpabuf_free(dev->info.wfd_subelems);
+ 		dev->info.wfd_subelems = wpabuf_dup(msg.wfd_subelems);
+diff --git a/src/wps/wps_attr_build.c b/src/wps/wps_attr_build.c
+index 4e872f3..d25aa53 100644
+--- a/src/wps/wps_attr_build.c
++++ b/src/wps/wps_attr_build.c
+@@ -9,6 +9,11 @@
+ #include "includes.h"
+ 
+ #include "common.h"
++#include <net/if.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include <sys/ioctl.h>
++#include <linux/wireless.h>
+ #include "crypto/aes_wrap.h"
+ #include "crypto/crypto.h"
+ #include "crypto/dh_group5.h"
+@@ -202,6 +207,117 @@ int wps_build_version(struct wpabuf *msg)
+ 	return 0;
+ }
+ 
++int wps_build_wfa_ext_ms(struct wpabuf *msg, char *host_name, const u8 *mac)
++{
++	u8 *len;
++	char mdns_name[30] = "LGWEBOS";
++
++	int s, ret, freq = 0, wifi2_4 = 0, wifi5 = 0, eth = 0;
++	struct ifreq ifr;
++	struct iwreq wrq;
++	struct sockaddr_in *saddr;
++	char wlan0_address[16] = {0,};
++	char eth0_address[16] = {0,};
++	char mac_addr[13] = {0,};
++
++	// convert mac string "%02x%02x%02x%02x%02x%02x"
++	os_snprintf(mac_addr, sizeof(mac_addr), COMPACT_MACSTR, MAC2STR(mac));
++
++	if (os_strlen(mac_addr) < 12) {
++		return -1;
++	}
++
++	s = socket(PF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
++	if (s < 0) {
++		wpa_printf(MSG_ERROR, "%s: socket: %s",
++			   __func__, strerror(errno));
++		return -1;
++	} else {
++		for(int i = 0 ; i < 10 ; i++) {
++			os_memset(&ifr, 0, sizeof(struct ifreq));
++			os_memset(&wrq, 0, sizeof(struct iwreq));
++			ifr.ifr_ifindex = i;
++			ret = ioctl(s, SIOCGIFNAME, &ifr);
++			if(ret >= 0)
++			{
++				if (!os_memcmp(ifr.ifr_name, "eth0", 4)) {
++					if (ioctl(s, SIOCGIFADDR, &ifr) < 0) {
++						if (errno != EADDRNOTAVAIL)
++							wpa_printf(MSG_ERROR, "%s: ioctl[SIOCGIFADDR]: %s",
++									__func__, strerror(errno));
++					} else {
++						saddr = (struct sockaddr_in *)&ifr.ifr_addr;
++						inet_ntop(AF_INET, &saddr->sin_addr, eth0_address, sizeof(eth0_address));
++						eth = 1;
++					}
++				} else if (!os_memcmp(ifr.ifr_name, "wlan0", 5)) {
++					os_memcpy(wrq.ifr_name, ifr.ifr_name, sizeof(wrq.ifr_name));
++					if (ioctl(s, SIOCGIWFREQ, &wrq) >= 0) {
++						freq = wrq.u.freq.m / 1000;
++					}
++					if (freq > 2484) {
++						if (ioctl(s, SIOCGIFADDR, &ifr) < 0) {
++							if (errno != EADDRNOTAVAIL)
++								wpa_printf(MSG_ERROR, "%s: ioctl[SIOCGIFADDR]: %s",
++										__func__, strerror(errno));
++						} else {
++							saddr = (struct sockaddr_in *)&ifr.ifr_addr;
++							inet_ntop(AF_INET, &saddr->sin_addr, wlan0_address, sizeof(wlan0_address));
++							wifi5 = 1;
++						}
++					} else if (freq > 2411 && freq < 2485) {
++						wifi2_4 = 1;
++					}
++				}
++			}
++		}
++		close(s);
++	}
++
++	for(int i=3 ; i<6 ; i++) {
++		char temp[10];
++		os_snprintf(temp, sizeof(temp), "%02x",mac[i]);
++		strncat(mdns_name, temp, sizeof(temp));
++	}
++
++	if (wpabuf_tailroom(msg) < 7 + 5 + 36)
++		return -1;
++	wpabuf_put_be16(msg, ATTR_VENDOR_EXT);
++	len = wpabuf_put(msg, 2); /* to be filled */
++	wpabuf_put_be24(msg, WPS_VENDOR_ID_MS);
++
++	if (eth && (wifi2_4 || wifi5)) {
++		wpa_printf(MSG_DEBUG, "WPS:  * MS Infra eth wlan Dual Connection");
++	} else if (eth || wifi5) {
++		/* For MS Infrastructure Mode */
++		wpabuf_put_be16(msg, WFA_ELEM_MS_CAPABILITY);
++		wpabuf_put_be16(msg, 1);
++		wpabuf_put_u8(msg, 0x05);	//for support infrastructure
++
++		wpabuf_put_be16(msg, WFA_ELEM_MS_HOST_NAME);
++		wpabuf_put_be16(msg, os_strlen(mdns_name));
++		wpabuf_put_data(msg, mdns_name, os_strlen(mdns_name));
++
++		if (eth) {
++			wpa_printf(MSG_DEBUG, "WPS:  * MS Infra eth ip capa : %s, Host Name : %s",
++								eth0_address, mdns_name);
++			wpabuf_put_be16(msg, WFA_ELEM_MS_IP_ADDRESS);
++			wpabuf_put_be16(msg, os_strlen(eth0_address));
++			wpabuf_put_data(msg, eth0_address, os_strlen(eth0_address));
++		} else if (wifi5) {
++			wpa_printf(MSG_DEBUG, "WPS:  * MS Infra wlan ip capa : %s, freq : %d, Host Name : %s",
++								wlan0_address, freq, mdns_name);
++			wpabuf_put_be16(msg, WFA_ELEM_MS_IP_ADDRESS);
++			wpabuf_put_be16(msg, os_strlen(wlan0_address));
++			wpabuf_put_data(msg, wlan0_address, os_strlen(wlan0_address));
++		}
++	}
++
++	WPA_PUT_BE16(len, (u8 *) wpabuf_put(msg, 0) - len - 2);
++
++	return 0;
++}
++
+ 
+ int wps_build_wfa_ext(struct wpabuf *msg, int req_to_enroll,
+ 		      const u8 *auth_macs, size_t auth_macs_count,
+diff --git a/src/wps/wps_defs.h b/src/wps/wps_defs.h
+index 9fccb4e..374ae96 100644
+--- a/src/wps/wps_defs.h
++++ b/src/wps/wps_defs.h
+@@ -144,6 +144,7 @@ enum wps_attribute {
+ };
+ 
+ #define WPS_VENDOR_ID_WFA 14122
++#define WPS_VENDOR_ID_MS 311		//0x000137
+ 
+ /* WFA Vendor Extension subelements */
+ enum {
+@@ -153,7 +154,14 @@ enum {
+ 	WFA_ELEM_REQUEST_TO_ENROLL = 0x03,
+ 	WFA_ELEM_SETTINGS_DELAY_TIME = 0x04,
+ 	WFA_ELEM_REGISTRAR_CONFIGURATION_METHODS = 0x05,
+-	WFA_ELEM_MULTI_AP = 0x06
++	WFA_ELEM_MULTI_AP = 0x06,
++
++	/* For Microsoft Infrastructure mode */
++	WFA_ELEM_MS_CAPABILITY = 0x2001,
++	WFA_ELEM_MS_HOST_NAME = 0x2002,
++	WFA_ELEM_MS_BSSID = 0x2003,
++	WFA_ELEM_MS_CONNECTION_PREFERENCE = 0x2004,
++	WFA_ELEM_MS_IP_ADDRESS = 0x2005
+ };
+ 
+ /* Device Password ID */
+diff --git a/src/wps/wps_i.h b/src/wps/wps_i.h
+index 2cf22d4..423f577 100644
+--- a/src/wps/wps_i.h
++++ b/src/wps/wps_i.h
+@@ -167,6 +167,7 @@ int wps_build_version(struct wpabuf *msg);
+ int wps_build_wfa_ext(struct wpabuf *msg, int req_to_enroll,
+ 		      const u8 *auth_macs, size_t auth_macs_count,
+ 		      u8 multi_ap_subelem);
++int wps_build_wfa_ext_ms(struct wpabuf *msg, char *host_name, const u8 *mac);
+ int wps_build_msg_type(struct wpabuf *msg, enum wps_msg_type msg_type);
+ int wps_build_enrollee_nonce(struct wps_data *wps, struct wpabuf *msg);
+ int wps_build_registrar_nonce(struct wps_data *wps, struct wpabuf *msg);
+diff --git a/wpa_supplicant/ap.c b/wpa_supplicant/ap.c
+index 4e3c281..ce6acfc 100644
+--- a/wpa_supplicant/ap.c
++++ b/wpa_supplicant/ap.c
+@@ -627,9 +627,9 @@ static void ap_wps_event_cb(void *ctx, enum wps_event event,
+ 
+ 
+ static void ap_sta_authorized_cb(void *ctx, const u8 *mac_addr,
+-				 int authorized, const u8 *p2p_dev_addr)
++				 int authorized, const u8 *p2p_dev_addr, const char *ip_addr)
+ {
+-	wpas_notify_sta_authorized(ctx, mac_addr, authorized, p2p_dev_addr);
++	wpas_notify_sta_authorized(ctx, mac_addr, authorized, p2p_dev_addr, ip_addr);
+ }
+ 
+ 
+diff --git a/wpa_supplicant/dbus/dbus_new.c b/wpa_supplicant/dbus/dbus_new.c
+index fc2fc2e..ce520ed 100644
+--- a/wpa_supplicant/dbus/dbus_new.c
++++ b/wpa_supplicant/dbus/dbus_new.c
+@@ -27,6 +27,8 @@
+ #include "p2p/p2p.h"
+ #include "../p2p_supplicant.h"
+ 
++#define COMPACT_MACSTR_LEN	12
++
+ #ifdef CONFIG_AP /* until needed by something else */
+ 
+ /*
+@@ -1471,10 +1473,12 @@ static void peer_groups_changed(struct wpa_supplicant *wpa_s)
+  * @persistent: 0 - non persistent group, 1 - persistent group
+  * @ip: When group role is client, it contains local IP address, netmask, and
+  *	GO's IP address, if assigned; otherwise, NULL
++ * @go_dev_addr: GO 's device address'
++ * @freq: connected p2p channel
+  */
+ void wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
+ 					int client, int persistent,
+-					const u8 *ip)
++					const u8 *ip, const u8 *go_dev_addr, int freq)
+ {
+ 	DBusMessage *msg;
+ 	DBusMessageIter iter, dict_iter;
+@@ -1514,6 +1518,10 @@ void wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
+ 	    !wpa_dbus_dict_append_string(&dict_iter, "role",
+ 					 client ? "client" : "GO") ||
+ 	    !wpa_dbus_dict_append_bool(&dict_iter, "persistent", persistent) ||
++	    (go_dev_addr &&
++	     !wpa_dbus_dict_append_byte_array(&dict_iter, "go_dev_addr",
++					      (const char *) go_dev_addr, ETH_ALEN)) ||
++		!wpa_dbus_dict_append_uint32(&dict_iter, "freq", freq) ||
+ 	    !wpa_dbus_dict_append_object_path(&dict_iter, "group_object",
+ 					      wpa_s->dbus_groupobj_path) ||
+ 	    (ip &&
+@@ -1705,13 +1713,14 @@ void wpas_dbus_signal_p2p_invitation_result(struct wpa_supplicant *wpa_s,
+  * @peer_addr: P2P Device Address of the peer joining the group
+  */
+ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+-				      const u8 *peer_addr)
++				      const u8 *peer_addr, const u8 *p2p_dev_addr)
+ {
+ 	struct wpas_dbus_priv *iface;
+ 	DBusMessage *msg;
+ 	DBusMessageIter iter;
+ 	char peer_obj_path[WPAS_DBUS_OBJECT_PATH_MAX], *path;
+ 	struct wpa_supplicant *parent;
++	char dev_address[COMPACT_MACSTR_LEN + 1], *dev_addr;
+ 
+ 	iface = wpa_s->global->dbus;
+ 
+@@ -1733,6 +1742,9 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+ 			COMPACT_MACSTR,
+ 			parent->dbus_new_path, MAC2STR(peer_addr));
+ 
++	os_memset(dev_address, 0, sizeof(dev_address));
++	os_snprintf(dev_address, sizeof(dev_address), COMPACT_MACSTR, MAC2STR(p2p_dev_addr));
++
+ 	msg = dbus_message_new_signal(wpa_s->dbus_groupobj_path,
+ 				      WPAS_DBUS_NEW_IFACE_P2P_GROUP,
+ 				      "PeerJoined");
+@@ -1741,9 +1753,78 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+ 
+ 	dbus_message_iter_init_append(msg, &iter);
+ 	path = peer_obj_path;
++	dev_addr = dev_address;
+ 	if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_OBJECT_PATH,
+ 					    &path)) {
+ 		wpa_printf(MSG_ERROR, "dbus: Failed to construct signal");
++	} else if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &dev_addr)) {
++		wpa_printf(MSG_ERROR, "dbus: Failed to construct signal");
++	} else {
++		dbus_connection_send(iface->con, msg, NULL);
++		wpas_dbus_signal_peer_groups_changed(parent, peer_addr);
++	}
++	dbus_message_unref(msg);
++}
++
++
++/**
++ *
++ * Method to emit a signal for a peer joining the group.
++ * The signal will carry path to the group member object
++ * constructed using p2p i/f addr used for connecting.
++ *
++ * @wpa_s: %wpa_supplicant network interface data
++ * @peer_addr: P2P Device Address of the peer joining the group
++ */
++void wpas_dbus_signal_p2p_peer_joined_with_ip(struct wpa_supplicant *wpa_s,
++				      const u8 *peer_addr, const char *ip_addr, const u8 *p2p_dev_addr)
++{
++	struct wpas_dbus_priv *iface;
++	DBusMessage *msg;
++	DBusMessageIter iter;
++	char peer_obj_path[WPAS_DBUS_OBJECT_PATH_MAX], *path;
++	struct wpa_supplicant *parent;
++	char dev_address[COMPACT_MACSTR_LEN + 1], *dev_addr;
++
++	iface = wpa_s->global->dbus;
++
++	/* Do nothing if the control interface is not turned on */
++	if (iface == NULL)
++		return;
++
++	if (!wpa_s->dbus_groupobj_path)
++		return;
++
++	parent = wpa_s->parent;
++	if (parent->p2p_mgmt)
++		parent = parent->parent;
++	if (!parent->dbus_new_path)
++		return;
++
++	os_snprintf(peer_obj_path, WPAS_DBUS_OBJECT_PATH_MAX,
++			"%s/" WPAS_DBUS_NEW_P2P_PEERS_PART "/"
++			COMPACT_MACSTR,
++			parent->dbus_new_path, MAC2STR(peer_addr));
++
++	os_memset(dev_address, 0, sizeof(dev_address));
++	os_snprintf(dev_address, sizeof(dev_address), COMPACT_MACSTR, MAC2STR(p2p_dev_addr));
++
++	msg = dbus_message_new_signal(wpa_s->dbus_groupobj_path,
++				      WPAS_DBUS_NEW_IFACE_P2P_GROUP,
++				      "PeerJoinedWithIP");
++	if (msg == NULL)
++		return;
++
++	dbus_message_iter_init_append(msg, &iter);
++	path = peer_obj_path;
++	dev_addr = dev_address;
++	if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_OBJECT_PATH,
++					    &path)) {
++		wpa_printf(MSG_ERROR, "dbus: Failed to construct signal");
++	} else if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &ip_addr)) {
++		wpa_printf(MSG_ERROR, "dbus: Failed to construct signal");
++	} else if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &dev_addr)) {
++		wpa_printf(MSG_ERROR, "dbus: Failed to construct signal");
+ 	} else {
+ 		dbus_connection_send(iface->con, msg, NULL);
+ 		wpas_dbus_signal_peer_groups_changed(parent, peer_addr);
+@@ -1762,13 +1843,14 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+  * @peer_addr: P2P Device Address of the peer joining the group
+  */
+ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+-					    const u8 *peer_addr)
++					    const u8 *peer_addr, const u8 *p2p_dev_addr)
+ {
+ 	struct wpas_dbus_priv *iface;
+ 	DBusMessage *msg;
+ 	DBusMessageIter iter;
+ 	char peer_obj_path[WPAS_DBUS_OBJECT_PATH_MAX], *path;
+ 	struct wpa_supplicant *parent;
++	char dev_address[COMPACT_MACSTR_LEN + 1], *dev_addr;
+ 
+ 	iface = wpa_s->global->dbus;
+ 
+@@ -1790,6 +1872,9 @@ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+ 			COMPACT_MACSTR,
+ 			parent->dbus_new_path, MAC2STR(peer_addr));
+ 
++	os_memset(dev_address, 0, sizeof(dev_address));
++	os_snprintf(dev_address, sizeof(dev_address), COMPACT_MACSTR, MAC2STR(p2p_dev_addr));
++
+ 	msg = dbus_message_new_signal(wpa_s->dbus_groupobj_path,
+ 				      WPAS_DBUS_NEW_IFACE_P2P_GROUP,
+ 				      "PeerDisconnected");
+@@ -1798,10 +1883,13 @@ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+ 
+ 	dbus_message_iter_init_append(msg, &iter);
+ 	path = peer_obj_path;
++	dev_addr = dev_address;
+ 	if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_OBJECT_PATH,
+ 					    &path)) {
+ 		wpa_printf(MSG_ERROR,
+ 			   "dbus: Failed to construct PeerDisconnected signal");
++	} else if (!dbus_message_iter_append_basic(&iter, DBUS_TYPE_STRING, &dev_addr)) {
++		wpa_printf(MSG_ERROR, "dbus: Failed to construct signal");
+ 	} else {
+ 		dbus_connection_send(iface->con, msg, NULL);
+ 		wpas_dbus_signal_peer_groups_changed(parent, peer_addr);
+@@ -2105,6 +2193,9 @@ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
+ 	if (wpa_s->p2p_mgmt)
+ 		wpa_s = wpa_s->parent;
+ 
++	if (!wpa_s->dbus_new_path)
++		return;
++
+ 	msg = dbus_message_new_signal(wpa_s->dbus_new_path,
+ 				      WPAS_DBUS_NEW_IFACE_P2PDEVICE,
+ 				      "GroupFormationFailure");
+@@ -2129,12 +2220,13 @@ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
+  * @bssid: P2P Group BSSID or %NULL if not received
+  * @id: Persistent group id or %0 if not persistent group
+  * @op_freq: Operating frequency for the group
++ * @status : staus of our Invitation Response
+  */
+ 
+ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 					      const u8 *sa, const u8 *dev_addr,
+ 					      const u8 *bssid, int id,
+-					      int op_freq)
++					      int op_freq, int status)
+ {
+ 	DBusMessage *msg;
+ 	DBusMessageIter iter, dict_iter;
+@@ -2149,6 +2241,9 @@ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 	if (wpa_s->p2p_mgmt)
+ 		wpa_s = wpa_s->parent;
+ 
++	if (!wpa_s->dbus_new_path)
++		return;
++
+ 	msg = dbus_message_new_signal(wpa_s->dbus_new_path,
+ 				      WPAS_DBUS_NEW_IFACE_P2PDEVICE,
+ 				      "InvitationReceived");
+@@ -2157,6 +2252,7 @@ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 
+ 	dbus_message_iter_init_append(msg, &iter);
+ 	if (!wpa_dbus_dict_open_write(&iter, &dict_iter) ||
++	    !wpa_dbus_dict_append_int32(&dict_iter, "status", status) ||
+ 	    (sa &&
+ 	     !wpa_dbus_dict_append_byte_array(&dict_iter, "sa",
+ 					      (const char *) sa, ETH_ALEN)) ||
+@@ -3745,6 +3841,10 @@ static const struct wpa_dbus_property_desc wpas_dbus_interface_properties[] = {
+ 	  wpas_dbus_setter_p2p_device_config,
+ 	  NULL
+ 	},
++	{ "P2PDisabled", WPAS_DBUS_NEW_IFACE_P2PDEVICE, "b",
++	  wpas_dbus_getter_p2p_disabled,
++	  wpas_dbus_setter_p2p_disabled
++	},
+ 	{ "Peers", WPAS_DBUS_NEW_IFACE_P2PDEVICE, "ao",
+ 	  wpas_dbus_getter_p2p_peers,
+ 	  NULL,
+@@ -3803,6 +3903,11 @@ static const struct wpa_dbus_property_desc wpas_dbus_interface_properties[] = {
+ 	  NULL,
+ 	  NULL
+ 	},
++	{ "SignalInfo", WPAS_DBUS_NEW_IFACE_INTERFACE, "a{sv}",
++	  wpas_dbus_getter_signal_info,
++	  NULL,
++	  NULL
++	},
+ 	{ NULL, NULL, NULL, NULL, NULL, NULL }
+ };
+ 
+@@ -4692,12 +4797,22 @@ static const struct wpa_dbus_signal_desc wpas_dbus_p2p_group_signals[] = {
+ 	{ "PeerJoined", WPAS_DBUS_NEW_IFACE_P2P_GROUP,
+ 	  {
+ 		  { "peer", "o", ARG_OUT },
++		  { "dev_addr", "s", ARG_OUT },
+ 		  END_ARGS
+ 	  }
+ 	},
+ 	{ "PeerDisconnected", WPAS_DBUS_NEW_IFACE_P2P_GROUP,
+ 	  {
+ 		  { "peer", "o", ARG_OUT },
++		  { "dev_addr", "s", ARG_OUT },
++		  END_ARGS
++	  }
++	},
++	{ "PeerJoinedWithIP", WPAS_DBUS_NEW_IFACE_P2P_GROUP,
++	  {
++		  { "peer", "o", ARG_OUT },
++		  { "ip_addr", "s", ARG_OUT },
++		  { "dev_addr", "s", ARG_OUT },
+ 		  END_ARGS
+ 	  }
+ 	},
+diff --git a/wpa_supplicant/dbus/dbus_new.h b/wpa_supplicant/dbus/dbus_new.h
+index 42db389..0f6b847 100644
+--- a/wpa_supplicant/dbus/dbus_new.h
++++ b/wpa_supplicant/dbus/dbus_new.h
+@@ -208,7 +208,7 @@ void wpas_dbus_signal_p2p_go_neg_req(struct wpa_supplicant *wpa_s,
+ 				     u8 go_intent);
+ void wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
+ 					int client, int persistent,
+-					const u8 *ip);
++					const u8 *ip, const u8 *go_dev_addr, int freq);
+ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
+ 						  const char *reason);
+ void wpas_dbus_register_p2p_group(struct wpa_supplicant *wpa_s,
+@@ -224,7 +224,7 @@ int wpas_dbus_unregister_persistent_group(struct wpa_supplicant *wpa_s,
+ void wpas_dbus_signal_p2p_invitation_result(struct wpa_supplicant *wpa_s,
+ 					    int status, const u8 *bssid);
+ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+-					    const u8 *member);
++					    const u8 *member, const u8 *p2p_dev_addr);
+ void wpas_dbus_signal_p2p_sd_request(struct wpa_supplicant *wpa_s,
+ 				     int freq, const u8 *sa, u8 dialog_token,
+ 				     u16 update_indic, const u8 *tlvs,
+@@ -233,7 +233,7 @@ void wpas_dbus_signal_p2p_sd_response(struct wpa_supplicant *wpa_s,
+ 				      const u8 *sa, u16 update_indic,
+ 				      const u8 *tlvs, size_t tlvs_len);
+ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+-				const u8 *member);
++				const u8 *member, const u8 *p2p_dev_addr);
+ void wpas_dbus_signal_p2p_wps_failed(struct wpa_supplicant *wpa_s,
+ 				     struct wps_event_fail *fail);
+ void wpas_dbus_signal_certification(struct wpa_supplicant *wpa_s,
+@@ -254,7 +254,7 @@ void wpas_dbus_signal_sta_deauthorized(struct wpa_supplicant *wpa_s,
+ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 					      const u8 *sa, const u8 *dev_addr,
+ 					      const u8 *bssid, int id,
+-					      int op_freq);
++					      int op_freq, int status);
+ void wpas_dbus_signal_mesh_group_started(struct wpa_supplicant *wpa_s,
+ 					 struct wpa_ssid *ssid);
+ void wpas_dbus_signal_mesh_group_removed(struct wpa_supplicant *wpa_s,
+@@ -440,7 +440,7 @@ static inline void wpas_dbus_signal_p2p_go_neg_req(struct wpa_supplicant *wpa_s,
+ static inline void
+ wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
+ 				   int client, int persistent,
+-				   const u8 *ip)
++				   const u8 *ip, const u8 *go_dev_addr, int freq)
+ {
+ }
+ 
+@@ -514,7 +514,13 @@ wpas_dbus_unregister_p2p_groupmember(struct wpa_supplicant *wpa_s,
+ 
+ static inline void
+ wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+-				 const u8 *member)
++				 const u8 *member, const u8 *p2p_dev_addr)
++{
++}
++
++static inline void
++wpas_dbus_signal_p2p_peer_joined_with_ip(struct wpa_supplicant *wpa_s,
++				 const u8 *member, const u8 *p2p_dev_addr)
+ {
+ }
+ 
+@@ -537,7 +543,7 @@ wpas_dbus_signal_peer_device_lost(struct wpa_supplicant *wpa_s,
+ 
+ static inline void
+ wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+-				       const u8 *member)
++				       const u8 *member, const u8 *p2p_dev_addr)
+ {
+ }
+ 
+diff --git a/wpa_supplicant/dbus/dbus_new_handlers.c b/wpa_supplicant/dbus/dbus_new_handlers.c
+index 6c36d91..938cad6 100644
+--- a/wpa_supplicant/dbus/dbus_new_handlers.c
++++ b/wpa_supplicant/dbus/dbus_new_handlers.c
+@@ -3091,6 +3091,56 @@ dbus_bool_t wpas_dbus_getter_disconnect_reason(
+ 						&reason, error);
+ }
+ 
++/**
++ * wpas_dbus_getter_signal_info - Get most recent signal information
++ * @iter: Pointer to incoming dbus message iter
++ * @error: Location to store error on failure
++ * @user_data: Function specific data
++ * Returns: TRUE on success, FALSE on failure
++ *
++ * Getter for "SignalInfo" property.
++ */
++dbus_bool_t wpas_dbus_getter_signal_info(
++	const struct wpa_dbus_property_desc *property_desc,
++	DBusMessageIter *iter, DBusError *error, void *user_data)
++{
++	struct wpa_supplicant *wpa_s = user_data;
++	struct wpa_signal_info si;
++	int ret;
++	DBusMessageIter variant_iter, dict_iter;
++
++	memset(&si, 0, sizeof(struct wpa_signal_info));
++
++	ret = wpa_drv_signal_poll(wpa_s, &si);
++	if (ret)
++		wpa_printf(MSG_DEBUG, "dbus: Failed to retrieve signal info from driver");
++
++	if (!dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, "a{sv}", &variant_iter) ||
++	    !wpa_dbus_dict_open_write(&variant_iter, &dict_iter))
++		goto err_no_mem;
++
++	if (!wpa_dbus_dict_append_uint32(&dict_iter, "RSSI", si.current_signal))
++		goto err_no_mem;
++
++	if (!wpa_dbus_dict_append_uint32(&dict_iter, "LinkSpeed", si.current_txrate / 1000))
++		goto err_no_mem;
++
++	if (!wpa_dbus_dict_append_uint32(&dict_iter, "Noise", si.current_noise))
++		goto err_no_mem;
++
++	if (!wpa_dbus_dict_append_uint32(&dict_iter, "Frequency", si.frequency))
++		goto err_no_mem;
++
++	if (!wpa_dbus_dict_close_write(&variant_iter, &dict_iter) ||
++	    !dbus_message_iter_close_container(iter, &variant_iter))
++		goto err_no_mem;
++
++	return TRUE;
++
++err_no_mem:
++	dbus_set_error_const(error, DBUS_ERROR_NO_MEMORY, "no memory");
++	return FALSE;
++}
+ 
+ /**
+  * wpas_dbus_getter_auth_status_code - Get most recent auth status code
+@@ -4904,6 +4954,12 @@ dbus_bool_t wpas_dbus_getter_network_properties(
+ 
+ 	iterator = props;
+ 	while (*iterator) {
++		if (!os_strcmp("ssid", *iterator))
++		{
++			wpa_dbus_dict_append_byte_array(&dict_iter, "binary-ssid",
++				net->ssid->ssid, net->ssid->ssid_len);
++		}
++
+ 		if (!wpa_dbus_dict_append_string(&dict_iter, *iterator,
+ 						 *(iterator + 1))) {
+ 			dbus_set_error_const(error, DBUS_ERROR_NO_MEMORY,
+diff --git a/wpa_supplicant/dbus/dbus_new_handlers.h b/wpa_supplicant/dbus/dbus_new_handlers.h
+index d922ce1..5afcba2 100644
+--- a/wpa_supplicant/dbus/dbus_new_handlers.h
++++ b/wpa_supplicant/dbus/dbus_new_handlers.h
+@@ -152,6 +152,7 @@ DECLARE_ACCESSOR(wpas_dbus_getter_disconnect_reason);
+ DECLARE_ACCESSOR(wpas_dbus_getter_disassociate_reason);
+ DECLARE_ACCESSOR(wpas_dbus_getter_auth_status_code);
+ DECLARE_ACCESSOR(wpas_dbus_getter_assoc_status_code);
++DECLARE_ACCESSOR(wpas_dbus_getter_signal_info);
+ DECLARE_ACCESSOR(wpas_dbus_getter_roam_time);
+ DECLARE_ACCESSOR(wpas_dbus_getter_roam_complete);
+ DECLARE_ACCESSOR(wpas_dbus_getter_session_length);
+diff --git a/wpa_supplicant/dbus/dbus_new_handlers_p2p.c b/wpa_supplicant/dbus/dbus_new_handlers_p2p.c
+index 8cdd885..1d39f0d 100644
+--- a/wpa_supplicant/dbus/dbus_new_handlers_p2p.c
++++ b/wpa_supplicant/dbus/dbus_new_handlers_p2p.c
+@@ -1166,6 +1166,34 @@ dbus_bool_t wpas_dbus_setter_p2p_device_config(
+ }
+ 
+ 
++dbus_bool_t wpas_dbus_getter_p2p_disabled(
++	const struct wpa_dbus_property_desc *property_desc,
++	DBusMessageIter *iter, DBusError *error, void *user_data)
++{
++	struct wpa_supplicant *wpa_s = user_data;
++	dbus_bool_t disabled = wpa_s->global->p2p_disabled ? TRUE : FALSE;
++
++	return wpas_dbus_simple_property_getter(iter, DBUS_TYPE_BOOLEAN,
++						&disabled, error);
++}
++
++dbus_bool_t wpas_dbus_setter_p2p_disabled(
++	const struct wpa_dbus_property_desc *property_desc,
++	DBusMessageIter *iter, DBusError *error, void *user_data)
++{
++	struct wpa_supplicant *wpa_s = user_data;
++	dbus_bool_t disabled;
++
++	if (!wpas_dbus_simple_property_setter(iter, error, DBUS_TYPE_BOOLEAN,
++					      &disabled))
++		return FALSE;
++
++	wpas_p2p_set_disabled(wpa_s, disabled ? 1 : 0);
++
++	return TRUE;
++}
++
++
+ dbus_bool_t wpas_dbus_getter_p2p_peers(
+ 	const struct wpa_dbus_property_desc *property_desc,
+ 	DBusMessageIter *iter, DBusError *error, void *user_data)
+@@ -1849,8 +1877,10 @@ static int match_group_where_peer_is_client(struct p2p_group *group,
+ 		goto out_of_memory;
+ 
+ 	data->paths = paths;
+-	data->paths[data->nb_paths] = wpa_s_go->dbus_groupobj_path;
+-	data->nb_paths++;
++	if (wpa_s_go->dbus_groupobj_path != NULL){
++		data->paths[data->nb_paths] = wpa_s_go->dbus_groupobj_path;
++		data->nb_paths++;
++	}
+ 
+ 	return 1;
+ 
+diff --git a/wpa_supplicant/dbus/dbus_new_handlers_p2p.h b/wpa_supplicant/dbus/dbus_new_handlers_p2p.h
+index b3c45c1..4cb7013 100644
+--- a/wpa_supplicant/dbus/dbus_new_handlers_p2p.h
++++ b/wpa_supplicant/dbus/dbus_new_handlers_p2p.h
+@@ -91,6 +91,8 @@ DBusMessage *wpas_dbus_handler_p2p_serv_disc_external(
+  */
+ DECLARE_ACCESSOR(wpas_dbus_setter_p2p_device_config);
+ DECLARE_ACCESSOR(wpas_dbus_getter_p2p_device_config);
++DECLARE_ACCESSOR(wpas_dbus_getter_p2p_disabled);
++DECLARE_ACCESSOR(wpas_dbus_setter_p2p_disabled);
+ DECLARE_ACCESSOR(wpas_dbus_getter_p2p_peers);
+ DECLARE_ACCESSOR(wpas_dbus_getter_p2p_role);
+ DECLARE_ACCESSOR(wpas_dbus_getter_p2p_group);
+diff --git a/wpa_supplicant/notify.c b/wpa_supplicant/notify.c
+index e41d7c4..dc9b432 100644
+--- a/wpa_supplicant/notify.c
++++ b/wpa_supplicant/notify.c
+@@ -604,6 +604,9 @@ void wpas_notify_p2p_device_found(struct wpa_supplicant *wpa_s,
+ 		wpas_dbus_register_peer(wpa_s, dev_addr);
+ 	}
+ 
++	if (wpa_s->global->p2p_disabled || wpa_s->global->p2p == NULL)
++		return;
++
+ 	/* Notify a new peer has been detected*/
+ 	wpas_dbus_signal_peer_device_found(wpa_s, dev_addr);
+ }
+@@ -696,12 +699,13 @@ void wpas_notify_p2p_provision_discovery(struct wpa_supplicant *wpa_s,
+ 
+ void wpas_notify_p2p_group_started(struct wpa_supplicant *wpa_s,
+ 				   struct wpa_ssid *ssid, int persistent,
+-				   int client, const u8 *ip)
++				   int client, const u8 *ip, const u8 *go_dev_addr, int freq)
+ {
+ 	/* Notify a group has been started */
+ 	wpas_dbus_register_p2p_group(wpa_s, ssid);
+ 
+-	wpas_dbus_signal_p2p_group_started(wpa_s, client, persistent, ip);
++	wpa_printf(MSG_INFO, "wpas_notify_p2p_group_started freq %d", freq);
++	wpas_dbus_signal_p2p_group_started(wpa_s, client, persistent, ip, go_dev_addr, freq);
+ }
+ 
+ 
+@@ -722,11 +726,11 @@ void wpas_notify_p2p_wps_failed(struct wpa_supplicant *wpa_s,
+ 
+ void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 					 const u8 *sa, const u8 *go_dev_addr,
+-					 const u8 *bssid, int id, int op_freq)
++					 const u8 *bssid, int id, int op_freq, int status)
+ {
+ 	/* Notify a P2P Invitation Request */
+ 	wpas_dbus_signal_p2p_invitation_received(wpa_s, sa, go_dev_addr, bssid,
+-						 id, op_freq);
++						 id, op_freq, status);
+ }
+ 
+ #endif /* CONFIG_P2P */
+@@ -734,8 +738,11 @@ void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 
+ static void wpas_notify_ap_sta_authorized(struct wpa_supplicant *wpa_s,
+ 					  const u8 *sta,
+-					  const u8 *p2p_dev_addr)
++					  const u8 *p2p_dev_addr, const char *ip_addr)
+ {
++//	if (!p2p_dev_addr)
++//		wpas_dbus_signal_ap_authorized(wpa_s);
++
+ #ifdef CONFIG_P2P
+ 	wpas_p2p_notify_ap_sta_authorized(wpa_s, p2p_dev_addr);
+ 
+@@ -743,8 +750,12 @@ static void wpas_notify_ap_sta_authorized(struct wpa_supplicant *wpa_s,
+ 	 * Create 'peer-joined' signal on group object -- will also
+ 	 * check P2P itself.
+ 	 */
+-	if (p2p_dev_addr)
+-		wpas_dbus_signal_p2p_peer_joined(wpa_s, p2p_dev_addr);
++	if (p2p_dev_addr) {
++		if (ip_addr == NULL)
++			wpas_dbus_signal_p2p_peer_joined(wpa_s, sta, p2p_dev_addr);
++		else
++			wpas_dbus_signal_p2p_peer_joined_with_ip(wpa_s, sta, ip_addr, p2p_dev_addr);
++	}
+ #endif /* CONFIG_P2P */
+ 
+ 	/* Register the station */
+@@ -764,8 +775,8 @@ static void wpas_notify_ap_sta_deauthorized(struct wpa_supplicant *wpa_s,
+ 	 * Create 'peer-disconnected' signal on group object if this
+ 	 * is a P2P group.
+ 	 */
+-	if (p2p_dev_addr)
+-		wpas_dbus_signal_p2p_peer_disconnected(wpa_s, p2p_dev_addr);
++	if(p2p_dev_addr)
++		wpas_dbus_signal_p2p_peer_disconnected(wpa_s, sta, p2p_dev_addr);
+ #endif /* CONFIG_P2P */
+ 
+ 	/* Notify listeners a station has been deauthorized */
+@@ -778,10 +789,10 @@ static void wpas_notify_ap_sta_deauthorized(struct wpa_supplicant *wpa_s,
+ 
+ void wpas_notify_sta_authorized(struct wpa_supplicant *wpa_s,
+ 				const u8 *mac_addr, int authorized,
+-				const u8 *p2p_dev_addr)
++				const u8 *p2p_dev_addr, const char *ip_addr)
+ {
+ 	if (authorized)
+-		wpas_notify_ap_sta_authorized(wpa_s, mac_addr, p2p_dev_addr);
++		wpas_notify_ap_sta_authorized(wpa_s, mac_addr, p2p_dev_addr, ip_addr);
+ 	else
+ 		wpas_notify_ap_sta_deauthorized(wpa_s, mac_addr, p2p_dev_addr);
+ }
+@@ -886,7 +897,6 @@ void wpas_notify_network_type_changed(struct wpa_supplicant *wpa_s,
+ #endif /* CONFIG_P2P */
+ }
+ 
+-
+ #ifdef CONFIG_MESH
+ 
+ void wpas_notify_mesh_group_started(struct wpa_supplicant *wpa_s,
+diff --git a/wpa_supplicant/notify.h b/wpa_supplicant/notify.h
+index e843aa1..042a3c4 100644
+--- a/wpa_supplicant/notify.h
++++ b/wpa_supplicant/notify.h
+@@ -91,7 +91,7 @@ void wpas_notify_resume(struct wpa_global *global);
+ 
+ void wpas_notify_sta_authorized(struct wpa_supplicant *wpa_s,
+ 				const u8 *mac_addr, int authorized,
+-				const u8 *p2p_dev_addr);
++				const u8 *p2p_dev_addr, const char *ip_addr);
+ void wpas_notify_p2p_find_stopped(struct wpa_supplicant *wpa_s);
+ void wpas_notify_p2p_device_found(struct wpa_supplicant *wpa_s,
+ 				  const u8 *dev_addr, int new_device);
+@@ -120,7 +120,7 @@ void wpas_notify_p2p_provision_discovery(struct wpa_supplicant *wpa_s,
+ 					 unsigned int generated_pin);
+ void wpas_notify_p2p_group_started(struct wpa_supplicant *wpa_s,
+ 				   struct wpa_ssid *ssid, int persistent,
+-				   int client, const u8 *ip);
++				   int client, const u8 *ip, const u8 *go_dev_addr, int freq);
+ void wpas_notify_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
+ 					     const char *reason);
+ void wpas_notify_persistent_group_added(struct wpa_supplicant *wpa_s,
+@@ -146,7 +146,7 @@ void wpas_notify_network_type_changed(struct wpa_supplicant *wpa_s,
+ 				      struct wpa_ssid *ssid);
+ void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+ 					 const u8 *sa, const u8 *go_dev_addr,
+-					 const u8 *bssid, int id, int op_freq);
++					 const u8 *bssid, int id, int op_freq, int status);
+ void wpas_notify_mesh_group_started(struct wpa_supplicant *wpa_s,
+ 				    struct wpa_ssid *ssid);
+ void wpas_notify_mesh_group_removed(struct wpa_supplicant *wpa_s,
+diff --git a/wpa_supplicant/p2p_supplicant.c b/wpa_supplicant/p2p_supplicant.c
+index 55b3b08..72c02b0 100644
+--- a/wpa_supplicant/p2p_supplicant.c
++++ b/wpa_supplicant/p2p_supplicant.c
+@@ -1397,7 +1397,7 @@ static void wpas_group_formation_completed(struct wpa_supplicant *wpa_s,
+ 	}
+ 
+ 	if (!client) {
+-		wpas_notify_p2p_group_started(wpa_s, ssid, persistent, 0, NULL);
++		wpas_notify_p2p_group_started(wpa_s, ssid, persistent, 0, NULL, go_dev_addr, ssid ? ssid->frequency : 0);
+ 		os_get_reltime(&wpa_s->global->p2p_go_wait_client);
+ 	}
+ }
+@@ -1832,7 +1832,7 @@ static void p2p_go_configured(void *ctx, void *data)
+ 
+ 		wpas_notify_p2p_group_started(wpa_s, ssid,
+ 					      params->persistent_group, 0,
+-					      NULL);
++					      NULL, wpa_s->global->p2p_dev_addr, ssid->frequency);
+ 		wpas_p2p_cross_connect_setup(wpa_s);
+ 		wpas_p2p_set_group_idle_timeout(wpa_s);
+ 
+@@ -1965,6 +1965,8 @@ static void wpas_start_wps_go(struct wpa_supplicant *wpa_s,
+ 	wpa_s->connect_without_scan = ssid;
+ 	wpa_s->reassociate = 1;
+ 	wpa_s->disconnected = 0;
++	wpa_dbg(wpa_s, MSG_DEBUG, "P2P: Disabling Extended Listen to start GO");
++	p2p_ext_listen(wpa_s->global->p2p, 0, 0);
+ 	wpa_dbg(wpa_s, MSG_DEBUG, "P2P: Request scan (that will be skipped) to "
+ 		"start GO)");
+ 	wpa_supplicant_req_scan(wpa_s, 0, 0);
+@@ -3088,6 +3090,8 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+ 					       " persistent=%d",
+ 					       MAC2STR(sa), s->id);
+ 			}
++			wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr, bssid,
++					    s->id, op_freq, status);
+ 			wpas_p2p_group_add_persistent(
+ 				wpa_s, s, go, 0, op_freq, 0, 0, 0, 0, 0, NULL,
+ 				go ? P2P_MAX_INITIAL_CONN_WAIT_GO_REINVOKE : 0,
+@@ -3100,6 +3104,8 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+ 				       " bssid=" MACSTR " unknown-network",
+ 				       MAC2STR(sa), MAC2STR(go_dev_addr),
+ 				       MAC2STR(bssid));
++			wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr,
++						    bssid, 0, op_freq, status);
+ 			wpas_p2p_join(wpa_s, bssid, go_dev_addr,
+ 				      wpa_s->p2p_wps_method, 0, op_freq,
+ 				      ssid, ssid_len);
+@@ -3129,7 +3135,7 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+ 				       MAC2STR(sa), MAC2STR(go_dev_addr));
+ 		}
+ 		wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr,
+-						    bssid, 0, op_freq);
++						    bssid, 0, op_freq, status);
+ 		return;
+ 	}
+ 
+@@ -3143,7 +3149,7 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+ 			       MAC2STR(sa), s->id);
+ 	}
+ 	wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr, bssid,
+-					    s->id, op_freq);
++					    s->id, op_freq, status);
+ }
+ 
+ 
+@@ -6413,6 +6419,8 @@ static int wpas_start_p2p_client(struct wpa_supplicant *wpa_s,
+ 	wpa_s->p2p_invite_go_freq = freq;
+ 	wpa_s->p2p_go_group_formation_completed = 0;
+ 	wpa_s->global->p2p_group_formation = wpa_s;
++	wpa_printf(MSG_DEBUG, "P2P: Diable Listen when start wps client");
++	p2p_ext_listen(wpa_s->global->p2p, 0, 0);
+ 
+ 	eloop_cancel_timeout(wpas_p2p_group_formation_timeout, wpa_s->p2pdev,
+ 			     NULL);
+@@ -6887,6 +6895,10 @@ static void wpas_p2p_stop_find_oper(struct wpa_supplicant *wpa_s)
+ 
+ void wpas_p2p_stop_find(struct wpa_supplicant *wpa_s)
+ {
++
++	if (wpa_s == NULL)
++		return;
++
+ 	wpas_p2p_stop_find_oper(wpa_s);
+ 	if (!wpa_s->global->pending_group_iface_for_p2ps)
+ 		wpas_p2p_remove_pending_group_interface(wpa_s);
+@@ -7282,7 +7294,7 @@ void wpas_p2p_completed(struct wpa_supplicant *wpa_s)
+ 		wpas_p2p_store_persistent_group(wpa_s->p2pdev,
+ 						ssid, go_dev_addr);
+ 
+-	wpas_notify_p2p_group_started(wpa_s, ssid, persistent, 1, ip_ptr);
++	wpas_notify_p2p_group_started(wpa_s, ssid, persistent, 1, ip_ptr, go_dev_addr, freq);
+ }
+ 
+ 
+@@ -8328,13 +8340,19 @@ static void wpas_p2p_remove_client_go(struct wpa_supplicant *wpa_s,
+ 		sta = ap_get_sta(hapd, peer);
+ 	else
+ 		sta = ap_get_sta_p2p(hapd, peer);
++
+ 	if (sta) {
++		hapd->rejected_peer = os_malloc(ETH_ALEN);
++		os_memcpy(hapd->rejected_peer, sta->addr, ETH_ALEN);
+ 		wpa_dbg(wpa_s, MSG_DEBUG, "P2P: Disconnect peer " MACSTR
+ 			" (iface_addr=%d) from group",
+ 			MAC2STR(peer), iface_addr);
+ 		hostapd_drv_sta_deauth(hapd, sta->addr,
+ 				       WLAN_REASON_DEAUTH_LEAVING);
+ 		ap_sta_deauthenticate(hapd, sta, WLAN_REASON_DEAUTH_LEAVING);
++		eloop_cancel_timeout(clear_rejected_peer_timeout, hapd, NULL);
++		eloop_register_timeout(5, 0,
++					clear_rejected_peer_timeout, hapd, NULL);
+ 	}
+ }
+ 
+@@ -9578,3 +9596,22 @@ int wpas_p2p_lo_stop(struct wpa_supplicant *wpa_s)
+ 	wpa_s->p2p_lo_started = 0;
+ 	return ret;
+ }
++
++
++int wpas_p2p_set_disabled(struct wpa_supplicant *wpa_s, int disable)
++{
++	wpa_s->global->p2p_disabled = disable;
++
++	wpa_printf(MSG_DEBUG, "P2P functionality %s",
++			   wpa_s->global->p2p_disabled ? "disabled" : "enabled");
++
++	if (wpa_s->global->p2p_disabled) {
++		wpas_p2p_stop_find(wpa_s);
++		os_memset(wpa_s->p2p_auth_invite, 0, ETH_ALEN);
++
++		if (wpa_s->global->p2p)
++			p2p_flush(wpa_s->global->p2p);
++	}
++
++	return 0;
++}
+diff --git a/wpa_supplicant/p2p_supplicant.h b/wpa_supplicant/p2p_supplicant.h
+index 24ec2ca..d6c9431 100644
+--- a/wpa_supplicant/p2p_supplicant.h
++++ b/wpa_supplicant/p2p_supplicant.h
+@@ -212,6 +212,7 @@ int wpas_p2p_lo_start(struct wpa_supplicant *wpa_s, unsigned int freq,
+ 		      unsigned int count);
+ int wpas_p2p_lo_stop(struct wpa_supplicant *wpa_s);
+ int wpas_p2p_mac_setup(struct wpa_supplicant *wpa_s);
++int wpas_p2p_set_disabled(struct wpa_supplicant *wpa_s, int disable);
+ 
+ #else /* CONFIG_P2P */
+ 
+diff --git a/wpa_supplicant/wpa_supplicant.c b/wpa_supplicant/wpa_supplicant.c
+index 911d79d..7323d58 100644
+--- a/wpa_supplicant/wpa_supplicant.c
++++ b/wpa_supplicant/wpa_supplicant.c
+@@ -126,6 +126,7 @@ static void wpa_bss_tmp_disallow_timeout(void *eloop_ctx, void *timeout_ctx);
+ static void wpas_update_fils_connect_params(struct wpa_supplicant *wpa_s);
+ #endif /* CONFIG_FILS && IEEE8021X_EAPOL */
+ 
++static int prefer_channel = 0;
+ 
+ /* Configure default/group WEP keys for static WEP */
+ int wpa_set_wep_keys(struct wpa_supplicant *wpa_s, struct wpa_ssid *ssid)
+@@ -7225,8 +7226,12 @@ int get_shared_radio_freqs_data(struct wpa_supplicant *wpa_s,
+ 		if (idx == len)
+ 			break;
+ 
+-		if (ifs->current_ssid == NULL || ifs->assoc_freq == 0)
++		if (ifs->current_ssid == NULL || ifs->assoc_freq == 0) {
++			if(os_strcmp(ifs->ifname, "wlan0") == 0) {
++				prefer_channel = 0;
++			}
+ 			continue;
++		}
+ 
+ 		if (ifs->current_ssid->mode == WPAS_MODE_AP ||
+ 		    ifs->current_ssid->mode == WPAS_MODE_P2P_GO ||
+@@ -7249,9 +7254,19 @@ int get_shared_radio_freqs_data(struct wpa_supplicant *wpa_s,
+ 			freqs_data[i].flags |= ifs->current_ssid->p2p_group ?
+ 				WPA_FREQ_USED_BY_P2P_CLIENT :
+ 				WPA_FREQ_USED_BY_INFRA_STATION;
++			if(!ifs->current_ssid->p2p_group) {
++				prefer_channel = freqs_data[i].freq;
++			}
+ 		}
+ 	}
+ 
++	if(prefer_channel) {
++		freqs_data[0].freq = prefer_channel;
++		freqs_data[0].flags |= WPA_FREQ_USED_BY_INFRA_STATION;
++		if(idx < len)
++			idx = 1;
++	}
++
+ 	dump_freq_data(wpa_s, "completed iteration", freqs_data, idx);
+ 	return idx;
+ }

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/0001-Add-p2p-changes.patch
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/0001-Add-p2p-changes.patch
@@ -1,4 +1,4 @@
-From 4ea5d446e9725bbbccd3182fd4cd58f479f6865f Mon Sep 17 00:00:00 2001
+From ddaf58852e2b0bc7176e3132940fcf3a1cf22687 Mon Sep 17 00:00:00 2001
 From: "penikelapati.kumar" <penikelapati.kumar@lge.com>
 Date: Wed, 27 Jan 2021 18:56:41 +0530
 Subject: [PATCH] Add p2p changes
@@ -22,7 +22,6 @@ N/A
               and p2p/setgointent Luna API
 
 Upstream-Status: Inappropriate[webos specific]
-
 ---
  src/ap/drv_callbacks.c                      |  11 ++
  src/ap/hostapd.c                            |  23 ++++
@@ -55,10 +54,10 @@ Upstream-Status: Inappropriate[webos specific]
  28 files changed, 655 insertions(+), 71 deletions(-)
 
 diff --git a/src/ap/drv_callbacks.c b/src/ap/drv_callbacks.c
-index 34ca379..dcbfb40 100644
+index a50e6f2af..13737dcd8 100644
 --- a/src/ap/drv_callbacks.c
 +++ b/src/ap/drv_callbacks.c
-@@ -175,6 +175,17 @@ int hostapd_notif_assoc(struct hostapd_data *hapd, const u8 *addr,
+@@ -202,6 +202,17 @@ int hostapd_notif_assoc(struct hostapd_data *hapd, const u8 *addr,
  			   "STA did not include WPS/RSN/WPA IE in (Re)AssocReq");
  	}
  
@@ -77,10 +76,10 @@ index 34ca379..dcbfb40 100644
  	if (sta) {
  		ap_sta_no_session_timeout(hapd, sta);
 diff --git a/src/ap/hostapd.c b/src/ap/hostapd.c
-index bf1975f..65a0bb4 100644
+index 4b88641a2..b537fe9e7 100644
 --- a/src/ap/hostapd.c
 +++ b/src/ap/hostapd.c
-@@ -352,6 +352,12 @@ static void hostapd_free_hapd_data(struct hostapd_data *hapd)
+@@ -366,6 +366,12 @@ void hostapd_free_hapd_data(struct hostapd_data *hapd)
  	hapd->p2p_beacon_ie = NULL;
  	wpabuf_free(hapd->p2p_probe_resp_ie);
  	hapd->p2p_probe_resp_ie = NULL;
@@ -93,7 +92,7 @@ index bf1975f..65a0bb4 100644
  #endif /* CONFIG_P2P */
  
  	if (!hapd->started) {
-@@ -2229,6 +2235,11 @@ hostapd_alloc_bss_data(struct hostapd_iface *hapd_iface,
+@@ -2376,6 +2382,11 @@ hostapd_alloc_bss_data(struct hostapd_iface *hapd_iface,
  	if (conf)
  		hapd->driver = conf->driver;
  	hapd->ctrl_sock = -1;
@@ -105,10 +104,10 @@ index bf1975f..65a0bb4 100644
  	dl_list_init(&hapd->ctrl_dst);
  	dl_list_init(&hapd->nr_db);
  	hapd->dhcp_sock = -1;
-@@ -3571,3 +3582,15 @@ void hostapd_periodic_iface(struct hostapd_iface *iface)
- #endif /* CONFIG_NO_RADIUS */
+@@ -3768,3 +3779,15 @@ void hostapd_ocv_check_csa_sa_query(void *eloop_ctx, void *timeout_ctx)
  	}
  }
+ #endif /* CONFIG_OCV */
 +
 +#ifdef CONFIG_P2P
 +void clear_rejected_peer_timeout(void *eloop_ctx, void *timeout_ctx)
@@ -122,10 +121,10 @@ index bf1975f..65a0bb4 100644
 +}
 +#endif /* CONFIG_P2P */
 diff --git a/src/ap/hostapd.h b/src/ap/hostapd.h
-index 518c7f1..d0603f0 100644
+index f3ca7529a..dc40c6a88 100644
 --- a/src/ap/hostapd.h
 +++ b/src/ap/hostapd.h
-@@ -263,7 +263,7 @@ struct hostapd_data {
+@@ -273,7 +273,7 @@ struct hostapd_data {
  	void *wps_event_cb_ctx;
  
  	void (*sta_authorized_cb)(void *ctx, const u8 *mac_addr,
@@ -134,7 +133,7 @@ index 518c7f1..d0603f0 100644
  	void *sta_authorized_cb_ctx;
  
  	void (*setup_complete_cb)(void *ctx);
-@@ -290,6 +290,8 @@ struct hostapd_data {
+@@ -300,6 +300,8 @@ struct hostapd_data {
  	struct wpabuf *p2p_beacon_ie;
  	struct wpabuf *p2p_probe_resp_ie;
  
@@ -143,7 +142,7 @@ index 518c7f1..d0603f0 100644
  	/* Number of non-P2P association stations */
  	int num_sta_no_p2p;
  
-@@ -655,4 +657,8 @@ void fst_hostapd_fill_iface_obj(struct hostapd_data *hapd,
+@@ -692,4 +694,8 @@ void fst_hostapd_fill_iface_obj(struct hostapd_data *hapd,
  				struct fst_wpa_obj *iface_obj);
  #endif /* CONFIG_FST */
  
@@ -153,10 +152,10 @@ index 518c7f1..d0603f0 100644
 +
  #endif /* HOSTAPD_H */
 diff --git a/src/ap/sta_info.c b/src/ap/sta_info.c
-index 51d7884..bc1ec32 100644
+index ccd1ed931..7402731a3 100644
 --- a/src/ap/sta_info.c
 +++ b/src/ap/sta_info.c
-@@ -1223,6 +1223,8 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+@@ -1268,6 +1268,8 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
  #ifdef CONFIG_P2P
  	u8 addr[ETH_ALEN];
  	u8 ip_addr_buf[4];
@@ -165,7 +164,7 @@ index 51d7884..bc1ec32 100644
  #endif /* CONFIG_P2P */
  
  	if (!!authorized == !!(sta->flags & WLAN_STA_AUTHORIZED))
-@@ -1248,23 +1250,27 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+@@ -1293,23 +1295,27 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
  #endif /* CONFIG_P2P */
  		os_snprintf(buf, sizeof(buf), MACSTR, MAC2STR(sta->addr));
  
@@ -197,7 +196,7 @@ index 51d7884..bc1ec32 100644
  		}
  #endif /* CONFIG_P2P */
  
-@@ -1291,6 +1297,15 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+@@ -1336,6 +1342,15 @@ void ap_sta_set_authorized(struct hostapd_data *hapd, struct sta_info *sta,
  					  AP_STA_DISCONNECTED "%s", buf);
  	}
  
@@ -214,10 +213,10 @@ index 51d7884..bc1ec32 100644
  	if (hapd->iface->fst) {
  		if (authorized)
 diff --git a/src/ap/wpa_auth.c b/src/ap/wpa_auth.c
-index c560770..72ff1f7 100644
+index 6d60f2629..824c3b195 100644
 --- a/src/ap/wpa_auth.c
 +++ b/src/ap/wpa_auth.c
-@@ -685,6 +685,7 @@ void wpa_auth_sta_no_wpa(struct wpa_state_machine *sm)
+@@ -729,6 +729,7 @@ void wpa_auth_sta_no_wpa(struct wpa_state_machine *sm)
  
  static void wpa_free_sta_sm(struct wpa_state_machine *sm)
  {
@@ -225,19 +224,19 @@ index c560770..72ff1f7 100644
  #ifdef CONFIG_P2P
  	if (WPA_GET_BE32(sm->ip_addr)) {
  		u32 start;
-@@ -698,6 +699,7 @@ static void wpa_free_sta_sm(struct wpa_state_machine *sm)
+@@ -743,6 +744,7 @@ static void wpa_free_sta_sm(struct wpa_state_machine *sm)
  			       WPA_GET_BE32(sm->ip_addr) - start);
  	}
  #endif /* CONFIG_P2P */
 +#endif
  	if (sm->GUpdateStationKeys) {
  		sm->group->GKeyDoneStations--;
- 		sm->GUpdateStationKeys = FALSE;
+ 		sm->GUpdateStationKeys = false;
 diff --git a/src/common/ieee802_11_defs.h b/src/common/ieee802_11_defs.h
-index b0aa913..7446deb 100644
+index 928b53500..6f1e824bc 100644
 --- a/src/common/ieee802_11_defs.h
 +++ b/src/common/ieee802_11_defs.h
-@@ -1647,6 +1647,7 @@ enum p2p_role_indication {
+@@ -1715,6 +1715,7 @@ enum p2p_role_indication {
  
  #define P2P_WILDCARD_SSID "DIRECT-"
  #define P2P_WILDCARD_SSID_LEN 7
@@ -246,10 +245,10 @@ index b0aa913..7446deb 100644
  /* P2P action frames */
  enum p2p_act_frame_type {
 diff --git a/src/p2p/p2p.c b/src/p2p/p2p.c
-index 079270f..3047220 100644
+index 598a449c1..a045f4aa7 100644
 --- a/src/p2p/p2p.c
 +++ b/src/p2p/p2p.c
-@@ -1314,6 +1314,7 @@ void p2p_stop_find_for_freq(struct p2p_data *p2p, int freq)
+@@ -1319,6 +1319,7 @@ void p2p_stop_find_for_freq(struct p2p_data *p2p, int freq)
  	p2p->go_neg_peer = NULL;
  	p2p->sd_peer = NULL;
  	p2p->invite_peer = NULL;
@@ -257,7 +256,7 @@ index 079270f..3047220 100644
  	p2p_stop_listen_for_freq(p2p, freq);
  	p2p->send_action_in_progress = 0;
  }
-@@ -1321,6 +1322,10 @@ void p2p_stop_find_for_freq(struct p2p_data *p2p, int freq)
+@@ -1326,6 +1327,10 @@ void p2p_stop_find_for_freq(struct p2p_data *p2p, int freq)
  
  void p2p_stop_listen_for_freq(struct p2p_data *p2p, int freq)
  {
@@ -265,10 +264,10 @@ index 079270f..3047220 100644
 +		p2p_dbg(p2p, "p2p data is null");
 +		return;
 +	}
- 	if (freq > 0 && p2p->drv_in_listen == freq && p2p->in_listen) {
- 		p2p_dbg(p2p, "Skip stop_listen since we are on correct channel for response");
- 		return;
-@@ -1626,15 +1631,26 @@ int p2p_connect(struct p2p_data *p2p, const u8 *peer_addr,
+ 	if (freq > 0 &&
+ 	    ((p2p->drv_in_listen == freq && p2p->in_listen) ||
+ 	     p2p->pending_listen_freq == (unsigned int) freq)) {
+@@ -1646,15 +1651,26 @@ int p2p_connect(struct p2p_data *p2p, const u8 *peer_addr,
  	dev->go_neg_req_sent = 0;
  	dev->go_state = UNKNOWN_GO;
  	p2p_set_dev_persistent(dev, persistent_group);
@@ -297,7 +296,7 @@ index 079270f..3047220 100644
  
  	if (p2p->p2p_scan_running) {
  		p2p_dbg(p2p, "p2p_scan running - delay connect send");
-@@ -1726,6 +1742,11 @@ void p2p_add_dev_info(struct p2p_data *p2p, const u8 *addr,
+@@ -1746,6 +1762,11 @@ void p2p_add_dev_info(struct p2p_data *p2p, const u8 *addr,
  		}
  	}
  
@@ -309,7 +308,7 @@ index 079270f..3047220 100644
  	if (msg->wfd_subelems) {
  		wpabuf_free(dev->info.wfd_subelems);
  		dev->info.wfd_subelems = wpabuf_dup(msg->wfd_subelems);
-@@ -1760,9 +1781,12 @@ void p2p_build_ssid(struct p2p_data *p2p, u8 *ssid, size_t *ssid_len)
+@@ -1780,9 +1801,12 @@ void p2p_build_ssid(struct p2p_data *p2p, u8 *ssid, size_t *ssid_len)
  {
  	os_memcpy(ssid, P2P_WILDCARD_SSID, P2P_WILDCARD_SSID_LEN);
  	p2p_random((char *) &ssid[P2P_WILDCARD_SSID_LEN], 2);
@@ -324,7 +323,7 @@ index 079270f..3047220 100644
  }
  
  
-@@ -2957,7 +2981,8 @@ struct p2p_data * p2p_init(const struct p2p_config *cfg)
+@@ -2985,7 +3009,8 @@ struct p2p_data * p2p_init(const struct p2p_config *cfg)
  	p2p->dev_capab |= P2P_DEV_CAPAB_INVITATION_PROCEDURE;
  	if (cfg->concurrent_operations)
  		p2p->dev_capab |= P2P_DEV_CAPAB_CONCURRENT_OPER;
@@ -334,7 +333,7 @@ index 079270f..3047220 100644
  
  	dl_list_init(&p2p->devices);
  
-@@ -3231,6 +3256,9 @@ void p2p_continue_find(struct p2p_data *p2p)
+@@ -3259,6 +3284,9 @@ void p2p_continue_find(struct p2p_data *p2p)
  	struct p2p_device *dev;
  	int found, res;
  
@@ -344,7 +343,7 @@ index 079270f..3047220 100644
  	p2p_set_state(p2p, P2P_SEARCH);
  
  	/* Continue from the device following the last iteration */
-@@ -4578,10 +4606,8 @@ static void p2p_ext_listen_timeout(void *eloop_ctx, void *timeout_ctx)
+@@ -4622,10 +4650,8 @@ static void p2p_ext_listen_timeout(void *eloop_ctx, void *timeout_ctx)
  				       p2p_ext_listen_timeout, p2p, NULL);
  	}
  
@@ -357,7 +356,7 @@ index 079270f..3047220 100644
  		p2p_dbg(p2p, "Operation in progress - skip Extended Listen timeout (%s)",
  			p2p_state_txt(p2p->state));
  		return;
-@@ -4599,6 +4625,14 @@ static void p2p_ext_listen_timeout(void *eloop_ctx, void *timeout_ctx)
+@@ -4643,6 +4669,14 @@ static void p2p_ext_listen_timeout(void *eloop_ctx, void *timeout_ctx)
  		p2p_set_state(p2p, P2P_IDLE);
  	}
  
@@ -372,7 +371,7 @@ index 079270f..3047220 100644
  	if (p2p->state != P2P_IDLE) {
  		p2p_dbg(p2p, "Skip Extended Listen timeout in active state (%s)", p2p_state_txt(p2p->state));
  		return;
-@@ -4626,13 +4660,13 @@ int p2p_ext_listen(struct p2p_data *p2p, unsigned int period,
+@@ -4670,13 +4704,13 @@ int p2p_ext_listen(struct p2p_data *p2p, unsigned int period,
  	eloop_cancel_timeout(p2p_ext_listen_timeout, p2p, NULL);
  
  	if (interval == 0) {
@@ -388,7 +387,7 @@ index 079270f..3047220 100644
  		period, interval);
  	p2p->ext_listen_period = period;
  	p2p->ext_listen_interval = interval;
-@@ -4737,6 +4771,7 @@ int p2p_set_listen_channel(struct p2p_data *p2p, u8 reg_class, u8 channel,
+@@ -4781,6 +4815,7 @@ int p2p_set_listen_channel(struct p2p_data *p2p, u8 reg_class, u8 channel,
  		reg_class, channel);
  
  	if (p2p->state == P2P_IDLE) {
@@ -397,10 +396,10 @@ index 079270f..3047220 100644
  		p2p->cfg->channel = channel;
  		p2p->cfg->channel_forced = forced;
 diff --git a/src/p2p/p2p.h b/src/p2p/p2p.h
-index 425b037..6816174 100644
+index f606fbb14..6b934bfd9 100644
 --- a/src/p2p/p2p.h
 +++ b/src/p2p/p2p.h
-@@ -375,6 +375,11 @@ struct p2p_peer_info {
+@@ -377,6 +377,11 @@ struct p2p_peer_info {
  	 */
  	u8 group_capab;
  
@@ -413,7 +412,7 @@ index 425b037..6816174 100644
  	 * wps_sec_dev_type_list - WPS secondary device type list
  	 *
 diff --git a/src/p2p/p2p_build.c b/src/p2p/p2p_build.c
-index 63eb2e8..0274ec2 100644
+index 4229d9b34..5f23caa2b 100644
 --- a/src/p2p/p2p_build.c
 +++ b/src/p2p/p2p_build.c
 @@ -223,10 +223,14 @@ void p2p_buf_add_device_info(struct wpabuf *buf, struct p2p_data *p2p,
@@ -455,7 +454,7 @@ index 63eb2e8..0274ec2 100644
  				WPS_DEV_TYPE_LEN *
  				p2p->cfg->num_sec_dev_types);
 diff --git a/src/p2p/p2p_go_neg.c b/src/p2p/p2p_go_neg.c
-index c94bf41..d34c417 100644
+index 1d53d52f1..a69b4f5e9 100644
 --- a/src/p2p/p2p_go_neg.c
 +++ b/src/p2p/p2p_go_neg.c
 @@ -171,6 +171,18 @@ static struct wpabuf * p2p_build_go_neg_req(struct p2p_data *p2p,
@@ -477,8 +476,8 @@ index c94bf41..d34c417 100644
  	p2p_buf_add_go_intent(buf, (p2p->go_intent << 1) | peer->tie_breaker);
  	p2p_buf_add_config_timeout(buf, p2p->go_timeout, p2p->client_timeout);
  	p2p_buf_add_listen_channel(buf, p2p->cfg->country, p2p->cfg->reg_class,
-@@ -454,6 +466,18 @@ void p2p_reselect_channel(struct p2p_data *p2p,
- 		}
+@@ -463,6 +475,18 @@ void p2p_reselect_channel(struct p2p_data *p2p,
+ 		return;
  	}
  
 +	/*
@@ -496,7 +495,7 @@ index c94bf41..d34c417 100644
  	/* Try a channel where we might be able to use VHT */
  	if (p2p_channel_select(intersection, op_classes_vht,
  			       &p2p->op_reg_class, &p2p->op_channel) == 0) {
-@@ -478,18 +502,6 @@ void p2p_reselect_channel(struct p2p_data *p2p,
+@@ -487,18 +511,6 @@ void p2p_reselect_channel(struct p2p_data *p2p,
  		return;
  	}
  
@@ -515,7 +514,7 @@ index c94bf41..d34c417 100644
  	/*
  	 * Fall back to whatever is included in the channel intersection since
  	 * no better options seems to be available.
-@@ -831,14 +843,14 @@ void p2p_process_go_neg_req(struct p2p_data *p2p, const u8 *sa,
+@@ -840,14 +852,14 @@ void p2p_process_go_neg_req(struct p2p_data *p2p, const u8 *sa,
  	else if ((dev->flags & P2P_DEV_PROBE_REQ_ONLY) ||
  		  !(dev->flags & P2P_DEV_REPORTED))
  		p2p_add_dev_info(p2p, sa, dev, &msg);
@@ -533,7 +532,7 @@ index c94bf41..d34c417 100644
  		p2p_add_dev_info(p2p, sa, dev, &msg);
  	}
 diff --git a/src/p2p/p2p_group.c b/src/p2p/p2p_group.c
-index aa18af6..4e42601 100644
+index aa18af6c1..4e4260125 100644
 --- a/src/p2p/p2p_group.c
 +++ b/src/p2p/p2p_group.c
 @@ -349,6 +349,13 @@ static int wifi_display_add_dev_info_descr(struct wpabuf *buf,
@@ -572,7 +571,7 @@ index aa18af6..4e42601 100644
  		return 1; /* Match with own device type */
  
 diff --git a/src/p2p/p2p_invitation.c b/src/p2p/p2p_invitation.c
-index 77d662a..51b8582 100644
+index ab0072219..8ac71026f 100644
 --- a/src/p2p/p2p_invitation.c
 +++ b/src/p2p/p2p_invitation.c
 @@ -170,6 +170,43 @@ static struct wpabuf * p2p_build_invitation_resp(struct p2p_data *p2p,
@@ -646,7 +645,7 @@ index 77d662a..51b8582 100644
  			p2p->op_reg_class, p2p->op_channel);
  
 diff --git a/src/p2p/p2p_pd.c b/src/p2p/p2p_pd.c
-index 05fd593..027cdfc 100644
+index 338b47e4e..f7a84f344 100644
 --- a/src/p2p/p2p_pd.c
 +++ b/src/p2p/p2p_pd.c
 @@ -602,6 +602,13 @@ void p2p_process_prov_disc_req(struct p2p_data *p2p, const u8 *sa,
@@ -664,7 +663,7 @@ index 05fd593..027cdfc 100644
  		wpabuf_free(dev->info.wfd_subelems);
  		dev->info.wfd_subelems = wpabuf_dup(msg.wfd_subelems);
 diff --git a/src/wps/wps_attr_build.c b/src/wps/wps_attr_build.c
-index 4e872f3..d25aa53 100644
+index f37225676..6459f20fc 100644
 --- a/src/wps/wps_attr_build.c
 +++ b/src/wps/wps_attr_build.c
 @@ -9,6 +9,11 @@
@@ -679,7 +678,7 @@ index 4e872f3..d25aa53 100644
  #include "crypto/aes_wrap.h"
  #include "crypto/crypto.h"
  #include "crypto/dh_group5.h"
-@@ -202,6 +207,117 @@ int wps_build_version(struct wpabuf *msg)
+@@ -204,6 +209,117 @@ int wps_build_version(struct wpabuf *msg)
  	return 0;
  }
  
@@ -798,7 +797,7 @@ index 4e872f3..d25aa53 100644
  int wps_build_wfa_ext(struct wpabuf *msg, int req_to_enroll,
  		      const u8 *auth_macs, size_t auth_macs_count,
 diff --git a/src/wps/wps_defs.h b/src/wps/wps_defs.h
-index 9fccb4e..374ae96 100644
+index ddaeda56d..39f8f11a1 100644
 --- a/src/wps/wps_defs.h
 +++ b/src/wps/wps_defs.h
 @@ -144,6 +144,7 @@ enum wps_attribute {
@@ -826,7 +825,7 @@ index 9fccb4e..374ae96 100644
  
  /* Device Password ID */
 diff --git a/src/wps/wps_i.h b/src/wps/wps_i.h
-index 2cf22d4..423f577 100644
+index 2cf22d4b7..423f5774e 100644
 --- a/src/wps/wps_i.h
 +++ b/src/wps/wps_i.h
 @@ -167,6 +167,7 @@ int wps_build_version(struct wpabuf *msg);
@@ -838,10 +837,10 @@ index 2cf22d4..423f577 100644
  int wps_build_enrollee_nonce(struct wps_data *wps, struct wpabuf *msg);
  int wps_build_registrar_nonce(struct wps_data *wps, struct wpabuf *msg);
 diff --git a/wpa_supplicant/ap.c b/wpa_supplicant/ap.c
-index 4e3c281..ce6acfc 100644
+index 6a0a69e68..ba4983b55 100644
 --- a/wpa_supplicant/ap.c
 +++ b/wpa_supplicant/ap.c
-@@ -627,9 +627,9 @@ static void ap_wps_event_cb(void *ctx, enum wps_event event,
+@@ -832,9 +832,9 @@ static void ap_wps_event_cb(void *ctx, enum wps_event event,
  
  
  static void ap_sta_authorized_cb(void *ctx, const u8 *mac_addr,
@@ -854,7 +853,7 @@ index 4e3c281..ce6acfc 100644
  
  
 diff --git a/wpa_supplicant/dbus/dbus_new.c b/wpa_supplicant/dbus/dbus_new.c
-index fc2fc2e..ce520ed 100644
+index 9279ae4d5..c770128cd 100644
 --- a/wpa_supplicant/dbus/dbus_new.c
 +++ b/wpa_supplicant/dbus/dbus_new.c
 @@ -27,6 +27,8 @@
@@ -866,7 +865,7 @@ index fc2fc2e..ce520ed 100644
  #ifdef CONFIG_AP /* until needed by something else */
  
  /*
-@@ -1471,10 +1473,12 @@ static void peer_groups_changed(struct wpa_supplicant *wpa_s)
+@@ -1564,10 +1566,12 @@ static void peer_groups_changed(struct wpa_supplicant *wpa_s)
   * @persistent: 0 - non persistent group, 1 - persistent group
   * @ip: When group role is client, it contains local IP address, netmask, and
   *	GO's IP address, if assigned; otherwise, NULL
@@ -880,7 +879,7 @@ index fc2fc2e..ce520ed 100644
  {
  	DBusMessage *msg;
  	DBusMessageIter iter, dict_iter;
-@@ -1514,6 +1518,10 @@ void wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
+@@ -1607,6 +1611,10 @@ void wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
  	    !wpa_dbus_dict_append_string(&dict_iter, "role",
  					 client ? "client" : "GO") ||
  	    !wpa_dbus_dict_append_bool(&dict_iter, "persistent", persistent) ||
@@ -891,7 +890,7 @@ index fc2fc2e..ce520ed 100644
  	    !wpa_dbus_dict_append_object_path(&dict_iter, "group_object",
  					      wpa_s->dbus_groupobj_path) ||
  	    (ip &&
-@@ -1705,13 +1713,14 @@ void wpas_dbus_signal_p2p_invitation_result(struct wpa_supplicant *wpa_s,
+@@ -1798,13 +1806,14 @@ void wpas_dbus_signal_p2p_invitation_result(struct wpa_supplicant *wpa_s,
   * @peer_addr: P2P Device Address of the peer joining the group
   */
  void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
@@ -907,7 +906,7 @@ index fc2fc2e..ce520ed 100644
  
  	iface = wpa_s->global->dbus;
  
-@@ -1733,6 +1742,9 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+@@ -1826,6 +1835,9 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
  			COMPACT_MACSTR,
  			parent->dbus_new_path, MAC2STR(peer_addr));
  
@@ -917,7 +916,7 @@ index fc2fc2e..ce520ed 100644
  	msg = dbus_message_new_signal(wpa_s->dbus_groupobj_path,
  				      WPAS_DBUS_NEW_IFACE_P2P_GROUP,
  				      "PeerJoined");
-@@ -1741,9 +1753,78 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+@@ -1834,9 +1846,78 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
  
  	dbus_message_iter_init_append(msg, &iter);
  	path = peer_obj_path;
@@ -996,7 +995,7 @@ index fc2fc2e..ce520ed 100644
  	} else {
  		dbus_connection_send(iface->con, msg, NULL);
  		wpas_dbus_signal_peer_groups_changed(parent, peer_addr);
-@@ -1762,13 +1843,14 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
+@@ -1855,13 +1936,14 @@ void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
   * @peer_addr: P2P Device Address of the peer joining the group
   */
  void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
@@ -1012,7 +1011,7 @@ index fc2fc2e..ce520ed 100644
  
  	iface = wpa_s->global->dbus;
  
-@@ -1790,6 +1872,9 @@ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+@@ -1883,6 +1965,9 @@ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
  			COMPACT_MACSTR,
  			parent->dbus_new_path, MAC2STR(peer_addr));
  
@@ -1022,7 +1021,7 @@ index fc2fc2e..ce520ed 100644
  	msg = dbus_message_new_signal(wpa_s->dbus_groupobj_path,
  				      WPAS_DBUS_NEW_IFACE_P2P_GROUP,
  				      "PeerDisconnected");
-@@ -1798,10 +1883,13 @@ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
+@@ -1891,10 +1976,13 @@ void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
  
  	dbus_message_iter_init_append(msg, &iter);
  	path = peer_obj_path;
@@ -1036,7 +1035,7 @@ index fc2fc2e..ce520ed 100644
  	} else {
  		dbus_connection_send(iface->con, msg, NULL);
  		wpas_dbus_signal_peer_groups_changed(parent, peer_addr);
-@@ -2105,6 +2193,9 @@ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
+@@ -2198,6 +2286,9 @@ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
  	if (wpa_s->p2p_mgmt)
  		wpa_s = wpa_s->parent;
  
@@ -1046,7 +1045,7 @@ index fc2fc2e..ce520ed 100644
  	msg = dbus_message_new_signal(wpa_s->dbus_new_path,
  				      WPAS_DBUS_NEW_IFACE_P2PDEVICE,
  				      "GroupFormationFailure");
-@@ -2129,12 +2220,13 @@ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
+@@ -2222,12 +2313,13 @@ void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
   * @bssid: P2P Group BSSID or %NULL if not received
   * @id: Persistent group id or %0 if not persistent group
   * @op_freq: Operating frequency for the group
@@ -1061,7 +1060,7 @@ index fc2fc2e..ce520ed 100644
  {
  	DBusMessage *msg;
  	DBusMessageIter iter, dict_iter;
-@@ -2149,6 +2241,9 @@ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+@@ -2242,6 +2334,9 @@ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
  	if (wpa_s->p2p_mgmt)
  		wpa_s = wpa_s->parent;
  
@@ -1071,7 +1070,7 @@ index fc2fc2e..ce520ed 100644
  	msg = dbus_message_new_signal(wpa_s->dbus_new_path,
  				      WPAS_DBUS_NEW_IFACE_P2PDEVICE,
  				      "InvitationReceived");
-@@ -2157,6 +2252,7 @@ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+@@ -2250,6 +2345,7 @@ void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
  
  	dbus_message_iter_init_append(msg, &iter);
  	if (!wpa_dbus_dict_open_write(&iter, &dict_iter) ||
@@ -1079,7 +1078,7 @@ index fc2fc2e..ce520ed 100644
  	    (sa &&
  	     !wpa_dbus_dict_append_byte_array(&dict_iter, "sa",
  					      (const char *) sa, ETH_ALEN)) ||
-@@ -3745,6 +3841,10 @@ static const struct wpa_dbus_property_desc wpas_dbus_interface_properties[] = {
+@@ -3851,6 +3947,10 @@ static const struct wpa_dbus_property_desc wpas_dbus_interface_properties[] = {
  	  wpas_dbus_setter_p2p_device_config,
  	  NULL
  	},
@@ -1090,7 +1089,7 @@ index fc2fc2e..ce520ed 100644
  	{ "Peers", WPAS_DBUS_NEW_IFACE_P2PDEVICE, "ao",
  	  wpas_dbus_getter_p2p_peers,
  	  NULL,
-@@ -3803,6 +3903,11 @@ static const struct wpa_dbus_property_desc wpas_dbus_interface_properties[] = {
+@@ -4521,6 +4621,11 @@ static const struct wpa_dbus_property_desc wpas_dbus_p2p_peer_properties[] = {
  	  NULL,
  	  NULL
  	},
@@ -1102,7 +1101,7 @@ index fc2fc2e..ce520ed 100644
  	{ NULL, NULL, NULL, NULL, NULL, NULL }
  };
  
-@@ -4692,12 +4797,22 @@ static const struct wpa_dbus_signal_desc wpas_dbus_p2p_group_signals[] = {
+@@ -4843,12 +4948,22 @@ static const struct wpa_dbus_signal_desc wpas_dbus_p2p_group_signals[] = {
  	{ "PeerJoined", WPAS_DBUS_NEW_IFACE_P2P_GROUP,
  	  {
  		  { "peer", "o", ARG_OUT },
@@ -1126,10 +1125,10 @@ index fc2fc2e..ce520ed 100644
  	  }
  	},
 diff --git a/wpa_supplicant/dbus/dbus_new.h b/wpa_supplicant/dbus/dbus_new.h
-index 42db389..0f6b847 100644
+index 26bdcb548..b504c1be2 100644
 --- a/wpa_supplicant/dbus/dbus_new.h
 +++ b/wpa_supplicant/dbus/dbus_new.h
-@@ -208,7 +208,7 @@ void wpas_dbus_signal_p2p_go_neg_req(struct wpa_supplicant *wpa_s,
+@@ -213,7 +213,7 @@ void wpas_dbus_signal_p2p_go_neg_req(struct wpa_supplicant *wpa_s,
  				     u8 go_intent);
  void wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
  					int client, int persistent,
@@ -1138,7 +1137,7 @@ index 42db389..0f6b847 100644
  void wpas_dbus_signal_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
  						  const char *reason);
  void wpas_dbus_register_p2p_group(struct wpa_supplicant *wpa_s,
-@@ -224,7 +224,7 @@ int wpas_dbus_unregister_persistent_group(struct wpa_supplicant *wpa_s,
+@@ -229,7 +229,7 @@ int wpas_dbus_unregister_persistent_group(struct wpa_supplicant *wpa_s,
  void wpas_dbus_signal_p2p_invitation_result(struct wpa_supplicant *wpa_s,
  					    int status, const u8 *bssid);
  void wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
@@ -1147,7 +1146,7 @@ index 42db389..0f6b847 100644
  void wpas_dbus_signal_p2p_sd_request(struct wpa_supplicant *wpa_s,
  				     int freq, const u8 *sa, u8 dialog_token,
  				     u16 update_indic, const u8 *tlvs,
-@@ -233,7 +233,7 @@ void wpas_dbus_signal_p2p_sd_response(struct wpa_supplicant *wpa_s,
+@@ -238,7 +238,7 @@ void wpas_dbus_signal_p2p_sd_response(struct wpa_supplicant *wpa_s,
  				      const u8 *sa, u16 update_indic,
  				      const u8 *tlvs, size_t tlvs_len);
  void wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
@@ -1156,7 +1155,7 @@ index 42db389..0f6b847 100644
  void wpas_dbus_signal_p2p_wps_failed(struct wpa_supplicant *wpa_s,
  				     struct wps_event_fail *fail);
  void wpas_dbus_signal_certification(struct wpa_supplicant *wpa_s,
-@@ -254,7 +254,7 @@ void wpas_dbus_signal_sta_deauthorized(struct wpa_supplicant *wpa_s,
+@@ -259,7 +259,7 @@ void wpas_dbus_signal_sta_deauthorized(struct wpa_supplicant *wpa_s,
  void wpas_dbus_signal_p2p_invitation_received(struct wpa_supplicant *wpa_s,
  					      const u8 *sa, const u8 *dev_addr,
  					      const u8 *bssid, int id,
@@ -1165,7 +1164,7 @@ index 42db389..0f6b847 100644
  void wpas_dbus_signal_mesh_group_started(struct wpa_supplicant *wpa_s,
  					 struct wpa_ssid *ssid);
  void wpas_dbus_signal_mesh_group_removed(struct wpa_supplicant *wpa_s,
-@@ -440,7 +440,7 @@ static inline void wpas_dbus_signal_p2p_go_neg_req(struct wpa_supplicant *wpa_s,
+@@ -452,7 +452,7 @@ static inline void wpas_dbus_signal_p2p_go_neg_req(struct wpa_supplicant *wpa_s,
  static inline void
  wpas_dbus_signal_p2p_group_started(struct wpa_supplicant *wpa_s,
  				   int client, int persistent,
@@ -1174,7 +1173,7 @@ index 42db389..0f6b847 100644
  {
  }
  
-@@ -514,7 +514,13 @@ wpas_dbus_unregister_p2p_groupmember(struct wpa_supplicant *wpa_s,
+@@ -526,7 +526,13 @@ wpas_dbus_unregister_p2p_groupmember(struct wpa_supplicant *wpa_s,
  
  static inline void
  wpas_dbus_signal_p2p_peer_joined(struct wpa_supplicant *wpa_s,
@@ -1189,7 +1188,7 @@ index 42db389..0f6b847 100644
  {
  }
  
-@@ -537,7 +543,7 @@ wpas_dbus_signal_peer_device_lost(struct wpa_supplicant *wpa_s,
+@@ -549,7 +555,7 @@ wpas_dbus_signal_peer_device_lost(struct wpa_supplicant *wpa_s,
  
  static inline void
  wpas_dbus_signal_p2p_peer_disconnected(struct wpa_supplicant *wpa_s,
@@ -1199,10 +1198,10 @@ index 42db389..0f6b847 100644
  }
  
 diff --git a/wpa_supplicant/dbus/dbus_new_handlers.c b/wpa_supplicant/dbus/dbus_new_handlers.c
-index 6c36d91..938cad6 100644
+index 959a68b4c..6a1a81591 100644
 --- a/wpa_supplicant/dbus/dbus_new_handlers.c
 +++ b/wpa_supplicant/dbus/dbus_new_handlers.c
-@@ -3091,6 +3091,56 @@ dbus_bool_t wpas_dbus_getter_disconnect_reason(
+@@ -3481,6 +3481,56 @@ dbus_bool_t wpas_dbus_getter_disconnect_reason(
  						&reason, error);
  }
  
@@ -1259,7 +1258,7 @@ index 6c36d91..938cad6 100644
  
  /**
   * wpas_dbus_getter_auth_status_code - Get most recent auth status code
-@@ -4904,6 +4954,12 @@ dbus_bool_t wpas_dbus_getter_network_properties(
+@@ -5507,6 +5557,12 @@ dbus_bool_t wpas_dbus_getter_network_properties(
  
  	iterator = props;
  	while (*iterator) {
@@ -1273,10 +1272,10 @@ index 6c36d91..938cad6 100644
  						 *(iterator + 1))) {
  			dbus_set_error_const(error, DBUS_ERROR_NO_MEMORY,
 diff --git a/wpa_supplicant/dbus/dbus_new_handlers.h b/wpa_supplicant/dbus/dbus_new_handlers.h
-index d922ce1..5afcba2 100644
+index a421083f7..fc15ed81b 100644
 --- a/wpa_supplicant/dbus/dbus_new_handlers.h
 +++ b/wpa_supplicant/dbus/dbus_new_handlers.h
-@@ -152,6 +152,7 @@ DECLARE_ACCESSOR(wpas_dbus_getter_disconnect_reason);
+@@ -168,6 +168,7 @@ DECLARE_ACCESSOR(wpas_dbus_getter_disconnect_reason);
  DECLARE_ACCESSOR(wpas_dbus_getter_disassociate_reason);
  DECLARE_ACCESSOR(wpas_dbus_getter_auth_status_code);
  DECLARE_ACCESSOR(wpas_dbus_getter_assoc_status_code);
@@ -1285,10 +1284,10 @@ index d922ce1..5afcba2 100644
  DECLARE_ACCESSOR(wpas_dbus_getter_roam_complete);
  DECLARE_ACCESSOR(wpas_dbus_getter_session_length);
 diff --git a/wpa_supplicant/dbus/dbus_new_handlers_p2p.c b/wpa_supplicant/dbus/dbus_new_handlers_p2p.c
-index 8cdd885..1d39f0d 100644
+index de79178f4..75e9832c5 100644
 --- a/wpa_supplicant/dbus/dbus_new_handlers_p2p.c
 +++ b/wpa_supplicant/dbus/dbus_new_handlers_p2p.c
-@@ -1166,6 +1166,34 @@ dbus_bool_t wpas_dbus_setter_p2p_device_config(
+@@ -1219,6 +1219,34 @@ dbus_bool_t wpas_dbus_setter_p2p_device_config(
  }
  
  
@@ -1323,7 +1322,7 @@ index 8cdd885..1d39f0d 100644
  dbus_bool_t wpas_dbus_getter_p2p_peers(
  	const struct wpa_dbus_property_desc *property_desc,
  	DBusMessageIter *iter, DBusError *error, void *user_data)
-@@ -1849,8 +1877,10 @@ static int match_group_where_peer_is_client(struct p2p_group *group,
+@@ -1902,8 +1930,10 @@ static int match_group_where_peer_is_client(struct p2p_group *group,
  		goto out_of_memory;
  
  	data->paths = paths;
@@ -1337,7 +1336,7 @@ index 8cdd885..1d39f0d 100644
  	return 1;
  
 diff --git a/wpa_supplicant/dbus/dbus_new_handlers_p2p.h b/wpa_supplicant/dbus/dbus_new_handlers_p2p.h
-index b3c45c1..4cb7013 100644
+index b3c45c110..4cb7013c6 100644
 --- a/wpa_supplicant/dbus/dbus_new_handlers_p2p.h
 +++ b/wpa_supplicant/dbus/dbus_new_handlers_p2p.h
 @@ -91,6 +91,8 @@ DBusMessage *wpas_dbus_handler_p2p_serv_disc_external(
@@ -1350,10 +1349,10 @@ index b3c45c1..4cb7013 100644
  DECLARE_ACCESSOR(wpas_dbus_getter_p2p_role);
  DECLARE_ACCESSOR(wpas_dbus_getter_p2p_group);
 diff --git a/wpa_supplicant/notify.c b/wpa_supplicant/notify.c
-index e41d7c4..dc9b432 100644
+index 821c916c1..8c1e782a8 100644
 --- a/wpa_supplicant/notify.c
 +++ b/wpa_supplicant/notify.c
-@@ -604,6 +604,9 @@ void wpas_notify_p2p_device_found(struct wpa_supplicant *wpa_s,
+@@ -616,6 +616,9 @@ void wpas_notify_p2p_device_found(struct wpa_supplicant *wpa_s,
  		wpas_dbus_register_peer(wpa_s, dev_addr);
  	}
  
@@ -1363,7 +1362,7 @@ index e41d7c4..dc9b432 100644
  	/* Notify a new peer has been detected*/
  	wpas_dbus_signal_peer_device_found(wpa_s, dev_addr);
  }
-@@ -696,12 +699,13 @@ void wpas_notify_p2p_provision_discovery(struct wpa_supplicant *wpa_s,
+@@ -708,12 +711,13 @@ void wpas_notify_p2p_provision_discovery(struct wpa_supplicant *wpa_s,
  
  void wpas_notify_p2p_group_started(struct wpa_supplicant *wpa_s,
  				   struct wpa_ssid *ssid, int persistent,
@@ -1379,7 +1378,7 @@ index e41d7c4..dc9b432 100644
  }
  
  
-@@ -722,11 +726,11 @@ void wpas_notify_p2p_wps_failed(struct wpa_supplicant *wpa_s,
+@@ -734,11 +738,11 @@ void wpas_notify_p2p_wps_failed(struct wpa_supplicant *wpa_s,
  
  void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
  					 const u8 *sa, const u8 *go_dev_addr,
@@ -1393,7 +1392,7 @@ index e41d7c4..dc9b432 100644
  }
  
  #endif /* CONFIG_P2P */
-@@ -734,8 +738,11 @@ void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
+@@ -746,8 +750,11 @@ void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
  
  static void wpas_notify_ap_sta_authorized(struct wpa_supplicant *wpa_s,
  					  const u8 *sta,
@@ -1406,7 +1405,7 @@ index e41d7c4..dc9b432 100644
  #ifdef CONFIG_P2P
  	wpas_p2p_notify_ap_sta_authorized(wpa_s, p2p_dev_addr);
  
-@@ -743,8 +750,12 @@ static void wpas_notify_ap_sta_authorized(struct wpa_supplicant *wpa_s,
+@@ -755,8 +762,12 @@ static void wpas_notify_ap_sta_authorized(struct wpa_supplicant *wpa_s,
  	 * Create 'peer-joined' signal on group object -- will also
  	 * check P2P itself.
  	 */
@@ -1421,7 +1420,7 @@ index e41d7c4..dc9b432 100644
  #endif /* CONFIG_P2P */
  
  	/* Register the station */
-@@ -764,8 +775,8 @@ static void wpas_notify_ap_sta_deauthorized(struct wpa_supplicant *wpa_s,
+@@ -776,8 +787,8 @@ static void wpas_notify_ap_sta_deauthorized(struct wpa_supplicant *wpa_s,
  	 * Create 'peer-disconnected' signal on group object if this
  	 * is a P2P group.
  	 */
@@ -1432,7 +1431,7 @@ index e41d7c4..dc9b432 100644
  #endif /* CONFIG_P2P */
  
  	/* Notify listeners a station has been deauthorized */
-@@ -778,10 +789,10 @@ static void wpas_notify_ap_sta_deauthorized(struct wpa_supplicant *wpa_s,
+@@ -790,10 +801,10 @@ static void wpas_notify_ap_sta_deauthorized(struct wpa_supplicant *wpa_s,
  
  void wpas_notify_sta_authorized(struct wpa_supplicant *wpa_s,
  				const u8 *mac_addr, int authorized,
@@ -1445,7 +1444,7 @@ index e41d7c4..dc9b432 100644
  	else
  		wpas_notify_ap_sta_deauthorized(wpa_s, mac_addr, p2p_dev_addr);
  }
-@@ -886,7 +897,6 @@ void wpas_notify_network_type_changed(struct wpa_supplicant *wpa_s,
+@@ -899,7 +910,6 @@ void wpas_notify_network_type_changed(struct wpa_supplicant *wpa_s,
  #endif /* CONFIG_P2P */
  }
  
@@ -1454,10 +1453,10 @@ index e41d7c4..dc9b432 100644
  
  void wpas_notify_mesh_group_started(struct wpa_supplicant *wpa_s,
 diff --git a/wpa_supplicant/notify.h b/wpa_supplicant/notify.h
-index e843aa1..042a3c4 100644
+index c46e7986e..c9c783dd9 100644
 --- a/wpa_supplicant/notify.h
 +++ b/wpa_supplicant/notify.h
-@@ -91,7 +91,7 @@ void wpas_notify_resume(struct wpa_global *global);
+@@ -92,7 +92,7 @@ void wpas_notify_resume(struct wpa_global *global);
  
  void wpas_notify_sta_authorized(struct wpa_supplicant *wpa_s,
  				const u8 *mac_addr, int authorized,
@@ -1466,7 +1465,7 @@ index e843aa1..042a3c4 100644
  void wpas_notify_p2p_find_stopped(struct wpa_supplicant *wpa_s);
  void wpas_notify_p2p_device_found(struct wpa_supplicant *wpa_s,
  				  const u8 *dev_addr, int new_device);
-@@ -120,7 +120,7 @@ void wpas_notify_p2p_provision_discovery(struct wpa_supplicant *wpa_s,
+@@ -121,7 +121,7 @@ void wpas_notify_p2p_provision_discovery(struct wpa_supplicant *wpa_s,
  					 unsigned int generated_pin);
  void wpas_notify_p2p_group_started(struct wpa_supplicant *wpa_s,
  				   struct wpa_ssid *ssid, int persistent,
@@ -1475,7 +1474,7 @@ index e843aa1..042a3c4 100644
  void wpas_notify_p2p_group_formation_failure(struct wpa_supplicant *wpa_s,
  					     const char *reason);
  void wpas_notify_persistent_group_added(struct wpa_supplicant *wpa_s,
-@@ -146,7 +146,7 @@ void wpas_notify_network_type_changed(struct wpa_supplicant *wpa_s,
+@@ -147,7 +147,7 @@ void wpas_notify_network_type_changed(struct wpa_supplicant *wpa_s,
  				      struct wpa_ssid *ssid);
  void wpas_notify_p2p_invitation_received(struct wpa_supplicant *wpa_s,
  					 const u8 *sa, const u8 *go_dev_addr,
@@ -1485,10 +1484,10 @@ index e843aa1..042a3c4 100644
  				    struct wpa_ssid *ssid);
  void wpas_notify_mesh_group_removed(struct wpa_supplicant *wpa_s,
 diff --git a/wpa_supplicant/p2p_supplicant.c b/wpa_supplicant/p2p_supplicant.c
-index 55b3b08..72c02b0 100644
+index ce44dfb9e..74d14f76d 100644
 --- a/wpa_supplicant/p2p_supplicant.c
 +++ b/wpa_supplicant/p2p_supplicant.c
-@@ -1397,7 +1397,7 @@ static void wpas_group_formation_completed(struct wpa_supplicant *wpa_s,
+@@ -1455,7 +1455,7 @@ static void wpas_group_formation_completed(struct wpa_supplicant *wpa_s,
  	}
  
  	if (!client) {
@@ -1497,7 +1496,7 @@ index 55b3b08..72c02b0 100644
  		os_get_reltime(&wpa_s->global->p2p_go_wait_client);
  	}
  }
-@@ -1832,7 +1832,7 @@ static void p2p_go_configured(void *ctx, void *data)
+@@ -1890,7 +1890,7 @@ static void p2p_go_configured(void *ctx, void *data)
  
  		wpas_notify_p2p_group_started(wpa_s, ssid,
  					      params->persistent_group, 0,
@@ -1506,7 +1505,7 @@ index 55b3b08..72c02b0 100644
  		wpas_p2p_cross_connect_setup(wpa_s);
  		wpas_p2p_set_group_idle_timeout(wpa_s);
  
-@@ -1965,6 +1965,8 @@ static void wpas_start_wps_go(struct wpa_supplicant *wpa_s,
+@@ -2124,6 +2124,8 @@ static void wpas_start_wps_go(struct wpa_supplicant *wpa_s,
  	wpa_s->connect_without_scan = ssid;
  	wpa_s->reassociate = 1;
  	wpa_s->disconnected = 0;
@@ -1515,16 +1514,16 @@ index 55b3b08..72c02b0 100644
  	wpa_dbg(wpa_s, MSG_DEBUG, "P2P: Request scan (that will be skipped) to "
  		"start GO)");
  	wpa_supplicant_req_scan(wpa_s, 0, 0);
-@@ -3088,6 +3090,8 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+@@ -3252,6 +3254,8 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
  					       " persistent=%d",
  					       MAC2STR(sa), s->id);
  			}
 +			wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr, bssid,
 +					    s->id, op_freq, status);
  			wpas_p2p_group_add_persistent(
- 				wpa_s, s, go, 0, op_freq, 0, 0, 0, 0, 0, NULL,
- 				go ? P2P_MAX_INITIAL_CONN_WAIT_GO_REINVOKE : 0,
-@@ -3100,6 +3104,8 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+ 				wpa_s, s, go, 0, op_freq, 0,
+ 				wpa_s->conf->p2p_go_ht40,
+@@ -3269,6 +3273,8 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
  				       " bssid=" MACSTR " unknown-network",
  				       MAC2STR(sa), MAC2STR(go_dev_addr),
  				       MAC2STR(bssid));
@@ -1533,7 +1532,7 @@ index 55b3b08..72c02b0 100644
  			wpas_p2p_join(wpa_s, bssid, go_dev_addr,
  				      wpa_s->p2p_wps_method, 0, op_freq,
  				      ssid, ssid_len);
-@@ -3129,7 +3135,7 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+@@ -3298,7 +3304,7 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
  				       MAC2STR(sa), MAC2STR(go_dev_addr));
  		}
  		wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr,
@@ -1542,7 +1541,7 @@ index 55b3b08..72c02b0 100644
  		return;
  	}
  
-@@ -3143,7 +3149,7 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
+@@ -3312,7 +3318,7 @@ static void wpas_invitation_received(void *ctx, const u8 *sa, const u8 *bssid,
  			       MAC2STR(sa), s->id);
  	}
  	wpas_notify_p2p_invitation_received(wpa_s, sa, go_dev_addr, bssid,
@@ -1551,7 +1550,7 @@ index 55b3b08..72c02b0 100644
  }
  
  
-@@ -6413,6 +6419,8 @@ static int wpas_start_p2p_client(struct wpa_supplicant *wpa_s,
+@@ -6906,6 +6912,8 @@ static int wpas_start_p2p_client(struct wpa_supplicant *wpa_s,
  	wpa_s->p2p_invite_go_freq = freq;
  	wpa_s->p2p_go_group_formation_completed = 0;
  	wpa_s->global->p2p_group_formation = wpa_s;
@@ -1560,7 +1559,7 @@ index 55b3b08..72c02b0 100644
  
  	eloop_cancel_timeout(wpas_p2p_group_formation_timeout, wpa_s->p2pdev,
  			     NULL);
-@@ -6887,6 +6895,10 @@ static void wpas_p2p_stop_find_oper(struct wpa_supplicant *wpa_s)
+@@ -7385,6 +7393,10 @@ static void wpas_p2p_stop_find_oper(struct wpa_supplicant *wpa_s)
  
  void wpas_p2p_stop_find(struct wpa_supplicant *wpa_s)
  {
@@ -1571,7 +1570,7 @@ index 55b3b08..72c02b0 100644
  	wpas_p2p_stop_find_oper(wpa_s);
  	if (!wpa_s->global->pending_group_iface_for_p2ps)
  		wpas_p2p_remove_pending_group_interface(wpa_s);
-@@ -7282,7 +7294,7 @@ void wpas_p2p_completed(struct wpa_supplicant *wpa_s)
+@@ -7788,7 +7800,7 @@ void wpas_p2p_completed(struct wpa_supplicant *wpa_s)
  		wpas_p2p_store_persistent_group(wpa_s->p2pdev,
  						ssid, go_dev_addr);
  
@@ -1580,7 +1579,7 @@ index 55b3b08..72c02b0 100644
  }
  
  
-@@ -8328,13 +8340,19 @@ static void wpas_p2p_remove_client_go(struct wpa_supplicant *wpa_s,
+@@ -8837,13 +8849,19 @@ static void wpas_p2p_remove_client_go(struct wpa_supplicant *wpa_s,
  		sta = ap_get_sta(hapd, peer);
  	else
  		sta = ap_get_sta_p2p(hapd, peer);
@@ -1600,7 +1599,7 @@ index 55b3b08..72c02b0 100644
  	}
  }
  
-@@ -9578,3 +9596,22 @@ int wpas_p2p_lo_stop(struct wpa_supplicant *wpa_s)
+@@ -10105,3 +10123,22 @@ int wpas_p2p_lo_stop(struct wpa_supplicant *wpa_s)
  	wpa_s->p2p_lo_started = 0;
  	return ret;
  }
@@ -1624,10 +1623,10 @@ index 55b3b08..72c02b0 100644
 +	return 0;
 +}
 diff --git a/wpa_supplicant/p2p_supplicant.h b/wpa_supplicant/p2p_supplicant.h
-index 24ec2ca..d6c9431 100644
+index 5a869e730..9ff43557a 100644
 --- a/wpa_supplicant/p2p_supplicant.h
 +++ b/wpa_supplicant/p2p_supplicant.h
-@@ -212,6 +212,7 @@ int wpas_p2p_lo_start(struct wpa_supplicant *wpa_s, unsigned int freq,
+@@ -221,6 +221,7 @@ int wpas_p2p_lo_start(struct wpa_supplicant *wpa_s, unsigned int freq,
  		      unsigned int count);
  int wpas_p2p_lo_stop(struct wpa_supplicant *wpa_s);
  int wpas_p2p_mac_setup(struct wpa_supplicant *wpa_s);
@@ -1636,18 +1635,18 @@ index 24ec2ca..d6c9431 100644
  #else /* CONFIG_P2P */
  
 diff --git a/wpa_supplicant/wpa_supplicant.c b/wpa_supplicant/wpa_supplicant.c
-index 911d79d..7323d58 100644
+index d37a994f9..fbe4a762d 100644
 --- a/wpa_supplicant/wpa_supplicant.c
 +++ b/wpa_supplicant/wpa_supplicant.c
-@@ -126,6 +126,7 @@ static void wpa_bss_tmp_disallow_timeout(void *eloop_ctx, void *timeout_ctx);
- static void wpas_update_fils_connect_params(struct wpa_supplicant *wpa_s);
- #endif /* CONFIG_FILS && IEEE8021X_EAPOL */
+@@ -130,6 +130,7 @@ static void wpas_update_fils_connect_params(struct wpa_supplicant *wpa_s);
+ static void wpas_update_owe_connect_params(struct wpa_supplicant *wpa_s);
+ #endif /* CONFIG_OWE */
  
 +static int prefer_channel = 0;
  
+ #ifdef CONFIG_WEP
  /* Configure default/group WEP keys for static WEP */
- int wpa_set_wep_keys(struct wpa_supplicant *wpa_s, struct wpa_ssid *ssid)
-@@ -7225,8 +7226,12 @@ int get_shared_radio_freqs_data(struct wpa_supplicant *wpa_s,
+@@ -8231,8 +8232,12 @@ int get_shared_radio_freqs_data(struct wpa_supplicant *wpa_s,
  		if (idx == len)
  			break;
  
@@ -1661,7 +1660,7 @@ index 911d79d..7323d58 100644
  
  		if (ifs->current_ssid->mode == WPAS_MODE_AP ||
  		    ifs->current_ssid->mode == WPAS_MODE_P2P_GO ||
-@@ -7249,9 +7254,19 @@ int get_shared_radio_freqs_data(struct wpa_supplicant *wpa_s,
+@@ -8255,9 +8260,19 @@ int get_shared_radio_freqs_data(struct wpa_supplicant *wpa_s,
  			freqs_data[i].flags |= ifs->current_ssid->p2p_group ?
  				WPA_FREQ_USED_BY_P2P_CLIENT :
  				WPA_FREQ_USED_BY_INFRA_STATION;

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.service
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.service
@@ -1,0 +1,31 @@
+# Copyright (c) 2019-2021 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# A Client for Wi-Fi Protected Access (WPA)
+
+[Unit]
+Description=webos - "%n"
+ConditionHost=!qemux86*
+Requires=ls-hubd.service
+After=ls-hubd.service
+
+[Service]
+Type=simple
+OOMScoreAdjust=-500
+EnvironmentFile=-/var/systemd/system/env/wpa-supplicant.env
+ExecStartPre=/etc/systemd/system/scripts/wpa-supplicant.sh
+ExecStart=/usr/sbin/wpa_supplicant -u -s
+Restart=on-failure

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.service
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.service
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 LG Electronics, Inc.
+# Copyright (c) 2019-2022 LG Electronics, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ Type=simple
 OOMScoreAdjust=-500
 EnvironmentFile=-/var/systemd/system/env/wpa-supplicant.env
 ExecStartPre=/etc/systemd/system/scripts/wpa-supplicant.sh
-ExecStart=/usr/sbin/wpa_supplicant -u -s
+ExecStart=/usr/sbin/wpa_supplicant -u $WPA_EXTRA_PARAM -s
 Restart=on-failure

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.sh
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2019-2022 LG Electronics, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.sh
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Copyright (c) 2019 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if grep -qs qemu /etc/hostname ; then
+    systemctl stop wpa-supplicant.service # tells systemd that we mean to stop _this_ job
+    systemctl start connman.service # since this pre-start stopping means
+                                    # that wpa-supplicant will never enter the
+                                    # starting or started states.
+    exit 0
+fi
+
+if [ -f /var/lib/connman/debug-mode ] ; then
+   systemctl set-environment WPA_EXTRA_PARAM=" -ddd -t -K"
+fi

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,18 +1,19 @@
-# Copyright (c) 2017-2021 LG Electronics, Inc.
+# Copyright (c) 2017-2022 LG Electronics, Inc.
 
-EXTENDPRAUTO_append = "webos4"
+EXTENDPRAUTO:append = "webos5"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI += "file://wpa-supplicant.sh \
-            file://wpa-supplicant.service \
-            file://0001-Add-p2p-changes.patch \
+SRC_URI += " \
+    file://wpa-supplicant.sh \
+    file://wpa-supplicant.service \
+    file://0001-Add-p2p-changes.patch \
 "
 # Replace the wpa_supplicant.service from wpa-supplicant source with our own version (for some unknown reason)
-SYSTEMD_SERVICE_${PN}_remove = "wpa_supplicant.service"
-SYSTEMD_SERVICE_${PN}_append = " wpa-supplicant.service"
+SYSTEMD_SERVICE:${PN}:remove = "wpa_supplicant.service"
+SYSTEMD_SERVICE:${PN}:append = " wpa-supplicant.service"
 
-do_configure_append() {
+do_configure:append() {
     # Enable DBus Introspection for easier debugging
     echo "CONFIG_CTRL_IFACE_DBUS_INTRO=y" >> ${B}/wpa_supplicant/.config
 
@@ -42,7 +43,7 @@ do_configure_append() {
 
 }
 
-do_install_append() {
+do_install:append() {
     # systemd service files
     install -d ${D}${sysconfdir}/systemd/system
     install -v -m 644 ${WORKDIR}/wpa-supplicant.service ${D}${sysconfdir}/systemd/system/wpa-supplicant.service
@@ -56,4 +57,4 @@ do_install_append() {
     sed -i 's/SystemdService=wpa_supplicant.service/SystemdService=wpa-supplicant.service/g' ${D}/${datadir}/dbus-1/system-services/*service
 }
 
-FILES_${PN} += "${systemd_unitdir}"
+FILES:${PN} += "${systemd_unitdir}"

--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,59 @@
+# Copyright (c) 2017-2021 LG Electronics, Inc.
+
+EXTENDPRAUTO_append = "webos4"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://wpa-supplicant.sh \
+            file://wpa-supplicant.service \
+            file://0001-Add-p2p-changes.patch \
+"
+# Replace the wpa_supplicant.service from wpa-supplicant source with our own version (for some unknown reason)
+SYSTEMD_SERVICE_${PN}_remove = "wpa_supplicant.service"
+SYSTEMD_SERVICE_${PN}_append = " wpa-supplicant.service"
+
+do_configure_append() {
+    # Enable DBus Introspection for easier debugging
+    echo "CONFIG_CTRL_IFACE_DBUS_INTRO=y" >> ${B}/wpa_supplicant/.config
+
+    # Enable debugging output to a file
+    echo "CONFIG_DEBUG_FILE=y" >> ${B}/wpa_supplicant/.config
+
+    # Redirect log to syslog instead of stdout
+    echo "CONFIG_DEBUG_SYSLOG=y" >> ${B}/wpa_supplicant/.config
+    echo "CONFIG_DEBUG_SYSLOG_FACILITY=LOG_DAEMON" >> ${B}/wpa_supplicant/.config
+
+    # P2P config
+    echo "bss_max_count=400" >> ${WORKDIR}/wpa_supplicant.conf-sane
+    echo "max_num_sta=2" >> ${WORKDIR}/wpa_supplicant.conf-sane
+    echo "manufacturer=LGE" >> ${WORKDIR}/wpa_supplicant.conf-sane
+    echo "model_name=webOS" >> ${WORKDIR}/wpa_supplicant.conf-sane
+    echo "model_number=webOS" >> ${WORKDIR}/wpa_supplicant.conf-sane
+    echo "device_name=webOS" >> ${WORKDIR}/wpa_supplicant.conf-sane
+    echo "serial_number=webOS" >> ${WORKDIR}/wpa_supplicant.conf-sane
+
+    # Enable P2P (aka WiFi direct) support
+    echo "CONFIG_P2P=y" >> ${B}/wpa_supplicant/.config
+    echo "CONFIG_AP=y" >> ${B}/wpa_supplicant/.config
+    echo "CONFIG_WPS=y" >> ${B}/wpa_supplicant/.config
+    echo "CONFIG_WPS2=y" >> ${B}/wpa_supplicant/.config
+    echo "CONFIG_WIFI_DISPLAY=y" >> ${B}/wpa_supplicant/.config
+    echo "CONFIG_IEEE80211N=y" >> ${B}/wpa_supplicant/.config
+
+}
+
+do_install_append() {
+    # systemd service files
+    install -d ${D}${sysconfdir}/systemd/system
+    install -v -m 644 ${WORKDIR}/wpa-supplicant.service ${D}${sysconfdir}/systemd/system/wpa-supplicant.service
+    # Remove the wpa_supplicant.service from upstream, but be aware that we're still
+    # keeping upstream wpa_supplicant-nl80211@.service wpa_supplicant@.service  wpa_supplicant-wired@.service
+    rm -vf ${D}${systemd_unitdir}/system/wpa_supplicant.service
+    install -d ${D}${sysconfdir}/systemd/system/scripts
+    install -v -m 755 ${WORKDIR}/wpa-supplicant.sh ${D}${sysconfdir}/systemd/system/scripts/
+
+    # Replace the removed wpa_supplicant.service from upstream with our =wpa-supplicant.service
+    sed -i 's/SystemdService=wpa_supplicant.service/SystemdService=wpa-supplicant.service/g' ${D}/${datadir}/dbus-1/system-services/*service
+}
+
+FILES_${PN} += "${systemd_unitdir}"

--- a/meta-luneos/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-luneos/recipes-core/systemd/systemd_%.bbappend
@@ -6,8 +6,18 @@ SRC_URI += " \
     file://0003-Disable-ProtectHome-and-ProtectSystem-for-old-kernel.patch \
 "
 
+RDEPENDS:${PN}:remove = "update-rc.d"
+
 PACKAGECONFIG:remove = " \
     networkd    \
     resolved    \
     nss-resolve \
+    timedated   \
+    timesyncd   \
 "
+
+# By default systemd's Predictable Network Interface Names policy configured for qemu
+# Currently we don't support this policy in qemu, so removing from systemd's configuration
+do_install:append:qemuall() {
+    rm -rf ${D}/${base_libdir}/systemd/network/99-default.link
+}

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api.bb
@@ -22,5 +22,8 @@ inherit pkgconfig
 inherit webos_cmake
 inherit webos_public_repo
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+            file://0001-Revert-Removing-support-for-com.webos.service.wan-se.patch \
+"
+
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api.bb
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-2022 LG Electronics, Inc.
+
+SUMMARY = "webOS connman adapter support API"
+AUTHOR = "Muralidhar N <muralidhar.n@lge.com>"
+SECTION = "webos/libs"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
+    file://oss-pkg-info.yaml;md5=6846cc431bc5281393713ebd4300401d \
+"
+
+DEPENDS = "libpbnjson luna-service2"
+
+WEBOS_VERSION = "1.0.0-4_54eca17251c81e7291893682ed86bc39a8f568ac"
+PR = "r2"
+
+PV = "1.0.0-4+git${SRCPV}"
+
+SRCREV = "54eca17251c81e7291893682ed86bc39a8f568ac"
+
+inherit pkgconfig
+inherit webos_cmake
+inherit webos_public_repo
+
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api/0001-Revert-Removing-support-for-com.webos.service.wan-se.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api/0001-Revert-Removing-support-for-com.webos.service.wan-se.patch
@@ -1,0 +1,39 @@
+From 58320d03a44fdf7c11603425a1202092b7e48958 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Tue, 14 Jul 2020 13:53:00 +0200
+Subject: [PATCH] Revert "Removing support for com.webos.service.wan service"
+
+This reverts commit aab98f49317bf5a4e416861ca9c14f9b25505ab9.
+---
+ include/public/wca-support.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/include/public/wca-support.h b/include/public/wca-support.h
+index 1c9fb99..55417bf 100644
+--- a/include/public/wca-support.h
++++ b/include/public/wca-support.h
+@@ -1,4 +1,4 @@
+-// Copyright (c) 2015-2019 LG Electronics, Inc.
++// Copyright (c) 2015-2018 LG Electronics, Inc.
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+@@ -145,13 +145,14 @@ typedef struct {
+  *        will fail.
+  * @param ls_wifi_handle : LS2 handle for com.webos.service.wifi
+  * @param ls_cm_handle : LS2 handle for com.webos.service.connectionmanager
++ * @param ls_wan_handle : LS2 handle for com.webos.service.wan
+  * @param wca_callbacks : Callbacks that provide information about different
+  *                        network properties
+  * @param callback Callback which is called when the operation is done or
+  *                 has failed.
+  * @param user_data User data which is handed over when the callback is called.
+  */
+-int wca_support_init(LSHandle *ls_wifi_handle, LSHandle *ls_cm_handle,
++int wca_support_init(LSHandle *ls_wifi_handle, LSHandle *ls_cm_handle, LSHandle *ls_wan_handle,
+ 		wca_support_connman_update_callbacks *wca_callbacks,
+ 		wca_support_callback callback, void *user_data);
+ 
+-- 
+2.37.3.windows.1
+

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support.bb
@@ -25,5 +25,7 @@ inherit pkgconfig
 inherit webos_machine_impl_dep
 inherit webos_public_repo
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+            file://0001-Revert-Removing-support-for-com.webos.service.wan-se.patch \
+"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support.bb
@@ -1,0 +1,29 @@
+# Copyright (c) 2017-2022 LG Electronics, Inc.
+
+SUMMARY = "webOS connman adapter support library"
+AUTHOR = "Muralidhar N <muralidhar.n@lge.com>"
+SECTION = "webos/libs"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = " \
+    file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
+    file://oss-pkg-info.yaml;md5=1c44bb8384dc6f3479834afcdfa98054 \
+"
+
+WEBOS_VERSION = "1.0.0-4_a59127baf2ddebc99874f714c9fe5528772e94d1"
+PR = "r2"
+
+PV = "1.0.0-4+git${SRCPV}"
+
+SRCREV = "a59127baf2ddebc99874f714c9fe5528772e94d1"
+
+DEPENDS = "glib-2.0 luna-service2 libpbnjson pmloglib luna-prefs wca-support-api"
+
+RDEPENDS:${PN} = "iw"
+
+inherit webos_cmake
+inherit pkgconfig
+inherit webos_machine_impl_dep
+inherit webos_public_repo
+
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support/0001-Revert-Removing-support-for-com.webos.service.wan-se.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support/0001-Revert-Removing-support-for-com.webos.service.wan-se.patch
@@ -1,0 +1,32 @@
+From 084bf16087be3eb55f81999224ae93d9f4f3515c Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Tue, 14 Jul 2020 14:00:52 +0200
+Subject: [PATCH] Revert "Removing support for com.webos.service.wan service"
+
+This reverts commit 5add6ff117ecc54f3612d76538da070ce5f15ab6.
+---
+ src/support_none.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/support_none.c b/src/support_none.c
+index b5a3494..da1a8a2 100644
+--- a/src/support_none.c
++++ b/src/support_none.c
+@@ -1,4 +1,4 @@
+-// Copyright (c) 2015-2019 LG Electronics, Inc.
++// Copyright (c) 2015-2018 LG Electronics, Inc.
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+@@ -17,7 +17,7 @@
+ #include <errno.h>
+ #include <wca-support.h>
+ 
+-int wca_support_init(LSHandle *ls_wifi_handle, LSHandle *ls_cm_handle,
++int wca_support_init(LSHandle *ls_wifi_handle, LSHandle *ls_cm_handle, LSHandle *ls_wan_handle,
+                 wca_support_connman_update_callbacks *wca_callbacks,
+                 wca_support_callback callback, void *user_data)
+ {
+-- 
+2.37.3.windows.1
+

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter.bb
@@ -1,29 +1,42 @@
-# Copyright (c) 2012-2014 LG Electronics, Inc.
+# Copyright (c) 2012-2022 LG Electronics, Inc.
 
-DESCRIPTION = "Open webOS component for managing network connections using connman"
-AUTHOR = "Sapna Todwal <sapna.todwal@lge.com>"
+DESCRIPTION = "webOS component for managing network connections using connman"
+AUTHOR = "Muralidhar N <muralidhar.n@lge.com>"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=2763f3ed850f8412903ea776e0526bea \
+    file://oss-pkg-info.yaml;md5=b0cf0d697c8340cbfa56b94bdc2539fb \
+"
+
 SECTION = "webos/services"
 
-DEPENDS = "luna-service2 libpbnjson glib-2.0 luna-prefs openssl glib-2.0-native"
+DEPENDS = "luna-service2 libpbnjson glib-2.0 luna-prefs openssl glib-2.0-native wca-support-api wca-support"
 RDEPENDS:${PN} = "connman connman-client"
 
-WEBOS_GIT_PARAM_BRANCH = "herrie/enhanced-acg"
+WEBOS_VERSION = "1.1.0-39_dc622623142035004f2354cc90cfee0e8fc3c5b3"
+PR = "r10"
 
-PV = "1.0.0-11+git${SRCPV}"
-SRCREV = "e4ac60667ff86a77434eb7a194969a4a6e25eb70"
+PV = "1.1.0-39+git${SRCPV}"
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+SRCREV = "dc622623142035004f2354cc90cfee0e8fc3c5b3"
 
-inherit webos_ports_ose_repo
+inherit webos_public_repo
 inherit webos_cmake
-inherit pkgconfig
 inherit webos_system_bus
 inherit webos_systemd
+inherit pkgconfig
 
 # Set EXTRA_OECMAKE in webos-connman-adapter.bbappend to override default value for wifi and wired interfaces, for eg.
 # EXTRA_OECMAKE += "-DWIFI_IFACE_NAME=wlan0 -DWIRED_IFACE_NAME=eth1"
 
-SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
+EXTRA_OECMAKE += "-DENABLE_SCAN_ON_SOFTAP=true"
+
+PACKAGECONFIG[enable-multiple-routing-table] = "-DMULTIPLE_ROUTING_TABLE:BOOL=true,-DMULTIPLE_ROUTING_TABLE:BOOL=false,"
+PACKAGECONFIG = "enable-multiple-routing-table"
+
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+            file://0001-Workaround-to-prevent-luna-call-pending.patch \
+            file://0002-Add-systemd-service-file.patch\ 
+"
+
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter.bb
@@ -36,7 +36,8 @@ PACKAGECONFIG = "enable-multiple-routing-table"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
             file://0001-Workaround-to-prevent-luna-call-pending.patch \
-            file://0002-Add-systemd-service-file.patch\ 
+            file://0002-Add-systemd-service-file.patch \
+            file://0003-Add-back-com.palm.wan-for-cellular-support.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0001-Workaround-to-prevent-luna-call-pending.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0001-Workaround-to-prevent-luna-call-pending.patch
@@ -1,0 +1,34 @@
+From eaa80cf0278dc019280d2eb840ab50a41587ccdb Mon Sep 17 00:00:00 2001
+From: "piyush10.asalmol" <piyush10.asalmol@lge.com>
+Date: Wed, 9 Nov 2022 19:47:16 +0530
+Subject: [PATCH] Workaround to prevent luna call pending
+
+---
+ src/wifi_service.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/wifi_service.c b/src/wifi_service.c
+index dbbb36a..9085c5a 100644
+--- a/src/wifi_service.c
++++ b/src/wifi_service.c
+@@ -1932,7 +1932,7 @@ static gboolean signal_polling_cb(gpointer user_data)
+ 	        manager);
+ 	connman_technology_interface_t interface_properties;
+ 
+-	if (connman_technology_get_interface_properties(wifi_technology,
++	/*if (connman_technology_get_interface_properties(wifi_technology,
+ 	        CONNMAN_WIFI_INTERFACE_NAME, &interface_properties) == TRUE)
+ 	{
+ 
+@@ -1946,7 +1946,7 @@ static gboolean signal_polling_cb(gpointer user_data)
+ 			send_findnetworks_status_to_subscribers();
+ 			send_getnetworks_status_to_subscribers();
+ 		}
+-	}
++	}*/
+ 
+ 	return TRUE;
+ }
+-- 
+2.17.1
+

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0002-Add-systemd-service-file.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0002-Add-systemd-service-file.patch
@@ -1,0 +1,34 @@
+From b450c331d451af5d2d559f5d01aea2564ab2df7e Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Wed, 14 Dec 2022 11:48:07 +0100
+Subject: [PATCH] Add systemd service file
+
+---
+ files/systemd/webos-connman-adapter.service | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+ create mode 100644 files/systemd/webos-connman-adapter.service
+
+diff --git a/files/systemd/webos-connman-adapter.service b/files/systemd/webos-connman-adapter.service
+new file mode 100644
+index 0000000..15450d0
+--- /dev/null
++++ b/files/systemd/webos-connman-adapter.service
+@@ -0,0 +1,15 @@
++[Unit]
++Description=webos - "%n"
++Requires=ls-hubd.service
++Wants=connman.service
++After=ls-hubd.service connman.service
++
++[Service]
++Type=simple
++OOMScoreAdjust=-500
++EnvironmentFile=-/var/systemd/system/env/webos-connman-adapter.env
++ExecStart=/usr/sbin/webos-connman-adapter
++Restart=on-failure
++
++[Install]
++WantedBy=multi-user.target
+-- 
+2.37.3.windows.1
+

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0003-Add-back-com.palm.wan-for-cellular-support.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0003-Add-back-com.palm.wan-for-cellular-support.patch
@@ -1,0 +1,1942 @@
+From 63172d779c5ac4442d837bc42c8690a04b5abbc1 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Fri, 16 Dec 2022 15:37:34 +0100
+Subject: [PATCH] Add back com.palm.wan for cellular support
+
+Since we use it in LuneOS.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ CMakeLists.txt                                |   1 +
+ files/sysbus/webos-connman-adapter.api.json   |  22 +-
+ files/sysbus/webos-connman-adapter.perm.json  |   8 +
+ .../sysbus/webos-connman-adapter.role.json.in |   9 +-
+ files/sysbus/webos-connman-adapter.service.in |   2 +-
+ src/common.c                                  |  59 ++
+ src/common.h                                  |   4 +
+ src/connectionmanager_service.c               | 110 +-
+ src/connman_manager.c                         |  77 +-
+ src/connman_manager.h                         |  12 +
+ src/connman_service.c                         |  71 ++
+ src/connman_service.h                         |  20 +
+ src/errors.h                                  |   3 +
+ src/logging.h                                 |   8 +-
+ src/main.c                                    |  12 +-
+ src/wan_service.c                             | 996 ++++++++++++++++++
+ src/wan_service.h                             |  39 +
+ src/wifi_service.c                            |   9 +
+ 18 files changed, 1448 insertions(+), 14 deletions(-)
+ create mode 100644 src/wan_service.c
+ create mode 100644 src/wan_service.h
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2fa2af5..39058c3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -135,6 +135,7 @@ file(GLOB SOURCE_FILES
+     src/main.c
+     src/pacrunner_client.c
+     src/utils.c
++    src/wan_service.c
+     src/wifi_p2p_service.c
+     src/wifi_tethering_service.c
+     src/wifi_profile.c
+diff --git a/files/sysbus/webos-connman-adapter.api.json b/files/sysbus/webos-connman-adapter.api.json
+index c238f03..8209bd7 100644
+--- a/files/sysbus/webos-connman-adapter.api.json
++++ b/files/sysbus/webos-connman-adapter.api.json
+@@ -64,6 +64,26 @@
+         "com.webos.service.wifi/p2p/setstate",
+         "com.webos.service.wifi/p2p/settethering",
+         "com.webos.service.wifi/p2p/setwifidisplayinfo"
+-
++    ],
++    "networking.query": [
++        "com.webos.service.connectionmanager/checkinternetstatus",
++        "com.webos.service.connectionmanager/findProxyForURL",
++        "com.webos.service.connectionmanager/getinfo",
++        "com.webos.service.connectionmanager/getStatus",
++        "com.webos.service.connectionmanager/getstatus",
++        "com.webos.service.connectionmanager/getUserStatus",
++        "com.webos.service.connectionmanager/getwolwowlstatus",
++        "com.webos.service.connectionmanager/monitorActivity",
++        "com.webos.service.wan/getStatus",
++        "com.webos.service.wan/getContexts",
++        "com.webos.service.wan/getContext",
++        "com.webos.service.wan/connect",
++        "com.webos.service.wan/disconnect",
++        "com.webos.service.wan/getStatus",
++        "com.webos.service.wan/getContexts",
++        "com.webos.service.wan/getContext",
++        "com.webos.service.wan/setHostRoutes",
++        "com.webos.service.wifi/getstatus",
++        "com.webos.service.wifi/getwifidiagnostics"
+     ]
+ }
+diff --git a/files/sysbus/webos-connman-adapter.perm.json b/files/sysbus/webos-connman-adapter.perm.json
+index 2621a73..f65c5fe 100644
+--- a/files/sysbus/webos-connman-adapter.perm.json
++++ b/files/sysbus/webos-connman-adapter.perm.json
+@@ -14,5 +14,13 @@
+         "wifi.query",
+         "wifi.management",
+         "systemconfig.query"
++    ],
++    "com.webos.service.wan": [
++        "settings.query",
++        "networkconnection.query",
++        "networkconnection.management",
++        "wifi.query",
++        "wifi.management",
++        "systemconfig.query"
+     ]
+ }
+diff --git a/files/sysbus/webos-connman-adapter.role.json.in b/files/sysbus/webos-connman-adapter.role.json.in
+index 4d1cf9b..c619766 100644
+--- a/files/sysbus/webos-connman-adapter.role.json.in
++++ b/files/sysbus/webos-connman-adapter.role.json.in
+@@ -2,7 +2,7 @@
+     "exeName":"@WEBOS_INSTALL_SBINDIR@/webos-connman-adapter",
+     "type":"regular",
+     "trustLevel": "oem",
+-    "allowedNames":["com.webos.service.wifi", "com.webos.service.connectionmanager"],
++    "allowedNames":["com.webos.service.wifi", "com.webos.service.connectionmanager", "com.webos.service.wan"],
+     "permissions": [
+         {
+             "service":"com.webos.service.wifi",
+@@ -18,6 +18,13 @@
+                         "com.webos.settingsservice",
+                         "com.webos.service.wifi",
+                         "com.webos.service.config"]
++        },
++        {
++            "service":"com.webos.service.wan",
++            "outbound":["com.webos.service.pdm",
++                        "com.webos.settingsservice",
++                        "com.webos.service.wifi",
++                        "com.webos.service.config"]
+         }
+     ]
+ }
+diff --git a/files/sysbus/webos-connman-adapter.service.in b/files/sysbus/webos-connman-adapter.service.in
+index da323a1..f10bace 100644
+--- a/files/sysbus/webos-connman-adapter.service.in
++++ b/files/sysbus/webos-connman-adapter.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+-Name=com.webos.service.wifi;com.webos.service.connectionmanager
++Name=com.webos.service.wifi;com.webos.service.wan;com.webos.service.connectionmanager;
+ Exec="@WEBOS_INSTALL_SBINDIR@/webos-connman-adapter
+ Type=static
+diff --git a/src/common.c b/src/common.c
+index c7c7d42..84238d0 100644
+--- a/src/common.c
++++ b/src/common.c
+@@ -177,6 +177,65 @@ gboolean set_wifi_powered_status(gboolean state)
+ 	return FALSE;
+ }
+ 
++void set_cellular_powered_status(gboolean state)
++{
++	connman_technology_t *cellular_tech = connman_manager_find_cellular_technology(
++	        manager);
++
++	if (!cellular_tech)
++	{
++		return;
++	}
++
++	connman_technology_set_powered(cellular_tech, state, NULL);
++}
++
++/**
++*  @brief Returns true if wan technology is powered on
++*
++*/
++
++gboolean is_cellular_powered(void)
++{
++	connman_technology_t *technology = connman_manager_find_cellular_technology(
++	                                       manager);
++	return (NULL != technology) && technology->powered;
++}
++
++/**
++*  @brief Check if the wan technology is available
++*   Send an error luna message if its not available
++*
++*  @param sh
++*  @param message
++*/
++
++gboolean cellular_technology_status_check(LSHandle *sh, LSMessage *message)
++{
++	if (NULL == connman_manager_find_cellular_technology(manager))
++	{
++		LSMessageReplyCustomError(sh, message, "Cellular technology unavailable",
++		                          WCA_API_ERROR_CELLULAR_TECH_UNAVAILABLE);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++gboolean cellular_technology_status_check_with_subscription(LSHandle *sh,
++        LSMessage *message, bool subscribed)
++{
++	if (NULL == connman_manager_find_cellular_technology(manager))
++	{
++		LSMessageReplyCustomErrorWithSubscription(sh, message,
++		        "Cellular technology unavailable",
++		        WCA_API_ERROR_CELLULAR_TECH_UNAVAILABLE, subscribed);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
+ bool is_valid_ipv6address(char *ipAddress)
+ {
+ 	unsigned char ipv6_addr[sizeof(struct in6_addr)];
+diff --git a/src/common.h b/src/common.h
+index f58dae2..7cacbb1 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -29,8 +29,11 @@ extern gboolean connman_status_check(connman_manager_t *manager, LSHandle *sh,
+                                      LSMessage *message);
+ extern gboolean is_wifi_powered(void);
+ extern gboolean is_wifi_tethering(void);
++extern gboolean is_cellular_powered(void);
+ extern gboolean wifi_technology_status_check(LSHandle *sh, LSMessage *message);
+ extern gboolean p2p_technology_status_check(LSHandle *sh, LSMessage *message);
++extern gboolean cellular_technology_status_check(LSHandle *sh,
++        LSMessage *message);
+ extern gboolean wifi_technology_status_check_with_subscription(LSHandle *sh,
+                                                         LSMessage *message, bool subscribed);
+ extern gboolean p2p_technology_status_check_with_subscription(LSHandle *sh,
+@@ -40,6 +43,7 @@ extern gboolean connman_status_check_with_subscription(connman_manager_t *manage
+ extern gboolean set_wifi_powered_status(gboolean state);
+ extern const gchar *get_current_system_locale();
+ extern void retrieve_system_locale_info(LSHandle *handle);
++extern void set_cellular_powered_status(gboolean state);
+ extern bool is_valid_ipv6address(char *ipAddress);
+ extern bool is_valid_ipaddress(char *ipAddress);
+ 
+diff --git a/src/connectionmanager_service.c b/src/connectionmanager_service.c
+index 1183b49..a8d46cc 100644
+--- a/src/connectionmanager_service.c
++++ b/src/connectionmanager_service.c
+@@ -59,6 +59,7 @@ errorText | Yes | String | Error description
+ #include "wifi_profile.h"
+ #include "utils.h"
+ #include "pacrunner_client.h"
++#include "wan_service.h"
+ #include "wifi_setting.h"
+ #include "wifi_tethering_service.h"
+ 
+@@ -81,6 +82,8 @@ gboolean wifi_online_checking_status = FALSE;
+ gboolean wired_connected = FALSE;
+ gboolean wifi_connected = FALSE;
+ gboolean p2p_connected = FALSE;
++gboolean cellular_powered = FALSE;
++gboolean wan_connected = FALSE;
+ guint block_getstatus_response = 0;
+ gboolean wifi_tethering = FALSE;
+ gboolean wired_plugged = FALSE;
+@@ -96,6 +99,30 @@ static void getinfo_update(void);
+ 
+ #define IS_WIRED_PLUGGED() g_slist_length(manager->wired_services)
+ 
++static bool is_caller_using_new_interface(LSMessage *message)
++{
++	if (!message)
++	{
++		return false;
++	}
++
++	LSHandle *handle = LSMessageGetConnection(message);
++
++	if (!handle)
++	{
++		return false;
++	}
++
++	const char *name = LSHandleGetName(handle);
++
++	if (!name)
++	{
++		return false;
++	}
++
++	return (g_strcmp0(name, "com.webos.service.connectionmanager") == 0);
++}
++
+ static void update_string_value(jvalue_ref *status, jvalue_ref key, gchar *inVal)
+ {
+ 	if (NULL != inVal)
+@@ -383,7 +410,8 @@ static void append_p2p_connection_status(jvalue_ref *status,
+  * @param reply JSON object where we will append the connection status to.
+  */
+ 
+-static void append_connection_status(jvalue_ref *reply, bool subscribed)
++static void append_connection_status(jvalue_ref *reply, bool subscribed,
++                                     bool with_new_interface)
+ {
+ 	if (NULL == reply)
+ 	{
+@@ -514,6 +542,31 @@ static void append_connection_status(jvalue_ref *reply, bool subscribed)
+ 		jobject_put(*reply, J_CSTR_TO_JVAL("wifiDirect"), disconnected_p2p_status);
+ 		j_release(&connected_p2p_status);
+ 	}
++	if (with_new_interface)
++	{
++		jvalue_ref cellular_obj = jobject_create();
++		gboolean cellular_enabled = is_cellular_powered();
++
++		jobject_put(cellular_obj, J_CSTR_TO_JVAL("enabled"),
++		            jboolean_create(cellular_enabled));
++		jobject_put(*reply, J_CSTR_TO_JVAL("cellular"), cellular_obj);
++
++		jvalue_ref wan_obj = jobject_create();
++
++		if (cellular_enabled)
++		{
++			append_wan_status(wan_obj);
++		}
++		else
++		{
++			jvalue_ref connected_contexts_obj = jarray_create(NULL);
++			jobject_put(wan_obj, J_CSTR_TO_JVAL("connected"), jboolean_create(false));
++			jobject_put(wan_obj, J_CSTR_TO_JVAL("connectedContexts"),
++			            connected_contexts_obj);
++		}
++
++		jobject_put(*reply, J_CSTR_TO_JVAL("wan"), wan_obj);
++	}
+ }
+ 
+ /**
+@@ -639,16 +692,49 @@ static gboolean check_update_is_needed(void)
+ 		needed = TRUE;
+ 	}
+ 
+-	guint p2p_connected_count_now = connman_manager_get_p2p_connected_service_count(manager->p2p_services);
+-	if(p2p_connected_count != p2p_connected_count_now)
++	if (cellular_powered != is_cellular_powered())
+ 	{
++		cellular_powered = is_cellular_powered();
+ 		needed = TRUE;
+ 	}
+ 
++	guint p2p_connected_count_now = connman_manager_get_p2p_connected_service_count(manager->p2p_services);
++	if(p2p_connected_count != p2p_connected_count_now)
++
+ 	p2p_connected_count = p2p_connected_count_now;
+ 
+ 	p2p_connected = (connected_p2p_service != NULL && manager->groups != NULL);
+ 
++
++	GSList *iter;
++	guint num_connected = 0;
++
++	for (iter = manager->cellular_services; iter != NULL; iter = iter->next)
++	{
++		connman_service_t *service = iter->data;
++
++		if (!connman_service_is_connected(service))
++		{
++			continue;
++		}
++
++		num_connected++;
++
++		if (check_service_for_update(service, wan_connected || (num_connected > 0)))
++		{
++			needed = TRUE;
++		}
++	}
++
++	gboolean new_wan_connected = (num_connected > 0);
++
++	if (wan_connected != new_wan_connected)
++	{
++		needed = TRUE;
++	}
++
++	wan_connected = new_wan_connected;
++
+ 	WCALOG_INFO(MSGID_CONNECTION_INFO, 0, "needed: %d",needed);
+ 
+ 	return needed;
+@@ -756,8 +842,10 @@ void connectionmanager_send_status_to_subscribers(void)
+ 
+ 	jvalue_ref reply = jobject_create();
+ 	jvalue_ref reply_deprecated = jobject_create();
+-	append_connection_status(&reply, true);
+-	append_connection_status(&reply_deprecated, true);
++	append_connection_status(&reply, true, true);
++	// Same but without mentioning WAN and PAN as we don't support it on the
++	// com.webos.service.connectionmanager service face
++	append_connection_status(&reply_deprecated, true, false);
+ 
+ 	jschema_ref response_schema = jschema_parse(j_cstr_to_buffer("{}"),
+ 	                              DOMOPT_NOOPT, NULL);
+@@ -925,7 +1013,8 @@ static bool handle_get_status_command(LSHandle *sh, LSMessage *message,
+ 		}
+ 	}
+ 
+-	append_connection_status(&reply, subscribed);
++	append_connection_status(&reply, subscribed,
++	                         is_caller_using_new_interface(message));
+ 
+ 	response_schema = jschema_parse(j_cstr_to_buffer("{}"), DOMOPT_NOOPT, NULL);
+ 
+@@ -2177,6 +2266,11 @@ static void counter_usage_callback(const gchar *path, GVariant *home,
+ 	{
+ 		service = connman_manager_find_service_by_path(manager->wifi_services, path);
+ 
++		if (NULL == service)
++		{
++			service = connman_manager_find_service_by_path(manager->cellular_services,
++			          path);
++		}
+ 	}
+ 
+ 	if (NULL == service)
+@@ -2252,6 +2346,10 @@ static void append_data_activity(jvalue_ref *reply)
+ 	jobject_put(*reply, J_CSTR_TO_JVAL("wired"), wired_stats);
+ 	jobject_put(*reply, J_CSTR_TO_JVAL("wifi"), wifi_stats);
+ 
++	jvalue_ref wan_stats = jobject_create();
++	append_interface_data_activity(&wan_stats, CONNMAN_SERVICE_TYPE_CELLULAR);
++	jobject_put(*reply, J_CSTR_TO_JVAL("wan"), wan_stats);
++
+ 	memcpy(counter_data_old, counter_data_new, sizeof(counter_data_old));
+ 	memset(counter_data_new, 0, sizeof(counter_data_new));
+ }
+diff --git a/src/connman_manager.c b/src/connman_manager.c
+index b76a53c..33c3a0b 100644
+--- a/src/connman_manager.c
++++ b/src/connman_manager.c
+@@ -320,6 +320,13 @@ static connman_service_t *find_service_from_path(connman_manager_t *manager,
+ 
+ 		service = connman_manager_find_service_by_path(manager->p2p_services, path);
+ 
++		if (NULL != service)
++		{
++			return service;
++		}
++
++		service = connman_manager_find_service_by_path(manager->cellular_services,
++		                                               path);
+ 	}
+ 
+ 	return service;
+@@ -451,6 +458,14 @@ static gboolean service_on_configured_iface(GVariant *service_v,
+ 				g_variant_unref(property);
+ 				g_variant_unref(key_v);
+ 
++				return TRUE;
++			}
++			else if (!g_strcmp0(type, "cellular"))
++			{
++				g_variant_unref(properties);
++				g_variant_unref(property);
++				g_variant_unref(key_v);
++
+ 				return TRUE;
+ 			}
+ 		}
+@@ -496,6 +511,11 @@ static void add_service_to_list(connman_manager_t *manager,
+ 		{
+ 			manager->p2p_services = g_slist_append(manager->p2p_services, service);
+ 		}
++		else if (connman_service_type_wan(service))
++		{
++			manager->cellular_services = g_slist_append(manager->cellular_services,
++			                             service);
++		}
+ 	}
+ }
+ 
+@@ -603,6 +623,10 @@ static gboolean connman_manager_update_services(connman_manager_t *manager,
+ 					*service_type |= P2P_SERVICES_CHANGED;
+ 					break;
+ 
++				case CONNMAN_SERVICE_TYPE_CELLULAR:
++					*service_type |= CELLULAR_SERVICES_CHANGED;
++					break;
++
+ 				default:
+ 					break;
+ 			}
+@@ -684,7 +708,7 @@ static gboolean connman_manager_remove_old_services(connman_manager_t *manager,
+ 	}
+ 
+ 	gboolean wifi_services_removed = FALSE, wired_services_removed = FALSE,
+-	         p2p_services_removed = FALSE;
++	         p2p_services_removed = FALSE, cellular_services_removed = FALSE;
+ 
+ 	wifi_services_removed = remove_services_from_list(&manager->wifi_services,
+ 	                        services_removed);
+@@ -692,6 +716,8 @@ static gboolean connman_manager_remove_old_services(connman_manager_t *manager,
+ 	                         services_removed);
+ 	p2p_services_removed = remove_services_from_list(&manager->p2p_services,
+ 	                       services_removed);
++	cellular_services_removed = remove_services_from_list(
++	                                &manager->cellular_services, services_removed);
+ 
+ 	if (wired_services_removed)
+ 	{
+@@ -716,7 +742,13 @@ static gboolean connman_manager_remove_old_services(connman_manager_t *manager,
+ 		}
+ 	}
+ 
+-	return (wifi_services_removed | wired_services_removed | p2p_services_removed);
++	if (cellular_services_removed)
++	{
++		*service_type |= CELLULAR_SERVICES_CHANGED;
++	}
++
++	return (wifi_services_removed | wired_services_removed | p2p_services_removed |
++	        cellular_services_removed);
+ }
+ 
+ /**
+@@ -745,6 +777,10 @@ static void connman_manager_free_services(connman_manager_t *manager)
+ 	g_slist_free(manager->p2p_services);
+ 	manager->p2p_services = NULL;
+ 
++	g_slist_foreach(manager->cellular_services, (GFunc) connman_service_free, NULL);
++	g_slist_free(manager->cellular_services);
++	manager->cellular_services = NULL;
++
+ 	g_slist_foreach(manager->saved_services, (GFunc) connman_service_free, NULL);
+ 	g_slist_free(manager->saved_services);
+ 	manager->saved_services = NULL;
+@@ -1484,6 +1520,39 @@ connman_technology_t *connman_manager_find_ethernet_technology(
+ 	return NULL;
+ }
+ 
++/**
++ * Go through the manager's technologies list and get the cellular one
++ * (see header for API details)
++ */
++
++connman_technology_t *connman_manager_find_cellular_technology(
++    connman_manager_t *manager)
++{
++	if (NULL == manager)
++	{
++		return NULL;
++	}
++
++	GSList *iter;
++
++	for (iter = manager->technologies; NULL != iter; iter = iter->next)
++	{
++		connman_technology_t *tech = (struct connman_technology *)(iter->data);
++
++		if (!tech)
++		{
++			continue;
++		}
++
++		if (g_strcmp0("cellular", tech->type) == 0)
++		{
++			return tech;
++		}
++	}
++
++	return NULL;
++}
++
+ /**
+  * Go through the manager's technologies list and get the p2p one
+  * (see header for API details)
+@@ -2255,6 +2324,10 @@ connman_manager_t *connman_manager_new(void)
+ 	             g_slist_length(manager->wifi_services),
+ 	             g_slist_length(manager->technologies));
+ 
++	WCALOG_DEBUG("%d cellular services, %d technologies",
++	             g_slist_length(manager->cellular_services),
++	             g_slist_length(manager->technologies));
++
+ 	return manager;
+ }
+ 
+diff --git a/src/connman_manager.h b/src/connman_manager.h
+index e418f4c..0bdeaa5 100644
+--- a/src/connman_manager.h
++++ b/src/connman_manager.h
+@@ -42,6 +42,8 @@ typedef enum
+ 	CONNMAN_SERVICE_TYPE_P2P_WiFiDisplayIEs
+ } connman_p2p_service_type;
+ 
++#define CELLULAR_SERVICES_CHANGED   8
++
+ /**
+  * Callback function for handling any changes in connman services
+  *
+@@ -70,6 +72,7 @@ typedef struct connman_manager
+ 	GSList  *wifi_services;
+ 	GSList  *wired_services;
+ 	GSList  *p2p_services;
++	GSList  *cellular_services;
+ 	GSList  *saved_services;
+ 	GSList  *technologies;
+ 	GSList  *groups;
+@@ -168,6 +171,15 @@ extern connman_technology_t *connman_manager_find_ethernet_technology(
+  */
+ extern connman_technology_t *connman_manager_find_p2p_technology(
+     connman_manager_t *manager);
++/**
++* Go through the manager's technologies list and get the technology with type "cellular"
++*
++* @param[IN]  manager A manager instance
++*
++* @return Technology with type "cellular"
++*/
++extern connman_technology_t *connman_manager_find_cellular_technology(
++    connman_manager_t *manager);
+ /**
+  * Go through the manager's given services list and get the one which is in "ready" or
+  * "online" state , i.e  one of the connected states.
+diff --git a/src/connman_service.c b/src/connman_service.c
+index 2cd2017..d9b415a 100644
+--- a/src/connman_service.c
++++ b/src/connman_service.c
+@@ -65,6 +65,45 @@ gboolean connman_service_type_p2p(connman_service_t *service)
+ 	return (NULL != service) && (CONNMAN_SERVICE_TYPE_P2P == service->type);
+ }
+ 
++/**
++
++* Check if the type of the service is wan (see header for API details)
++*/
++
++gboolean connman_service_type_wan(connman_service_t *service)
++{
++	return (NULL != service) && (service->type == CONNMAN_SERVICE_TYPE_CELLULAR);
++}
++
++/**
++ * @brief Gets hostroutes for the connman service
++ */
++
++gboolean connman_service_set_hostroutes(connman_service_t *service,
++                                        GStrv hostroutes)
++{
++	if (NULL == service || NULL == hostroutes)
++	{
++		return FALSE;
++	}
++
++	GError *error = NULL;
++
++	connman_interface_service_call_set_property_sync(service->remote,
++	        "HostRoutes.Configuration",
++	        g_variant_new_variant(g_variant_new_strv((const gchar * const *)hostroutes,
++	                              g_strv_length(hostroutes))), NULL, &error);
++
++	if (error)
++	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_WAN_SET_HOSTROUTE_ERROR, error->message);
++		g_error_free(error);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
+ /**
+  * Map the service connection status to corresponding webos state
+  * (see header for API details)
+@@ -899,6 +938,18 @@ gboolean connman_service_get_ipinfo(connman_service_t *service)
+ 			g_variant_unref(va);
+ 		}
+ 
++		if (!g_strcmp0(key, "HostRoutes"))
++		{
++			GVariant *v = g_variant_get_child_value(property, 1);
++			GVariant *va = g_variant_get_child_value(v, 0);
++
++			g_strfreev(service->hostroutes);
++			service->hostroutes = g_variant_dup_strv(va, NULL);
++
++			g_variant_unref(v);
++			g_variant_unref(va);
++		}
++
+ 		g_variant_unref(property);
+ 		g_variant_unref(key_v);
+ 	}
+@@ -1602,6 +1653,23 @@ void connman_service_update_properties(connman_service_t *service,
+ 		{
+ 			const gchar *v = g_variant_get_string(val, NULL);
+ 			connman_service_update_type(service,v);
++
++			if (!g_strcmp0(v, "wifi"))
++			{
++				service->type = CONNMAN_SERVICE_TYPE_WIFI;
++			}
++			else if (!g_strcmp0(v, "ethernet"))
++			{
++				service->type = CONNMAN_SERVICE_TYPE_ETHERNET;
++			}
++			else if (!g_strcmp0(v, "Peer"))
++			{
++				service->type = CONNMAN_SERVICE_TYPE_P2P;
++			}
++			else if (!g_strcmp0(v, "cellular"))
++			{
++				service->type = CONNMAN_SERVICE_TYPE_CELLULAR;
++			}
+ 		}
+ 		else if (!g_strcmp0(key, "State"))
+ 		{
+@@ -2031,6 +2099,9 @@ void connman_service_free(gpointer data, gpointer user_data)
+ 	g_strfreev(service->proxyinfo.excludes);
+ 
+ 
++	g_strfreev(service->hostroutes);
++	service->hostroutes = NULL;
++
+ 	g_free(service->peer.address);
+ 	g_free(service->peer.service_discovery_response);
+ 	service->peer.service_discovery_response = NULL;
+diff --git a/src/connman_service.h b/src/connman_service.h
+index 35c62b8..38aa7d0 100644
+--- a/src/connman_service.h
++++ b/src/connman_service.h
+@@ -146,6 +146,7 @@ typedef struct connman_service
+ 	gint type;
+ 	ipinfo_t ipinfo;
+ 	proxyinfo_t proxyinfo;
++	GStrv hostroutes;
+ 	gulong sighandler_id;
+ 	peer_t peer;
+ 
+@@ -180,6 +181,7 @@ typedef enum
+ 	CONNMAN_SERVICE_TYPE_ETHERNET,
+ 	CONNMAN_SERVICE_TYPE_WIFI,
+ 	CONNMAN_SERVICE_TYPE_P2P,
++	CONNMAN_SERVICE_TYPE_CELLULAR,
+ 	CONNMAN_SERVICE_TYPE_MAX
+ } connman_service_types;
+ 
+@@ -236,6 +238,16 @@ extern gboolean connman_service_type_ethernet(connman_service_t *service);
+ extern gboolean connman_service_type_p2p(connman_service_t *service);
+ 
+ /**
++* Check if the type of the service is wan
++*
++* @param[IN]  service A service instance
++*
++* @return TRUE if the service has "wan" type
++*/
++extern gboolean connman_service_type_wan(connman_service_t *service);
++
++/**
++
+  * Stringify the service connection status to corresponding webos state
+  * This function is required to send appropriate connection status to the webos world.
+  *
+@@ -418,6 +430,14 @@ extern void connman_service_register_property_changed_cb(
+ extern void connman_service_register_p2p_requests_cb(connman_service_t *service,
+         connman_p2p_request_cb func);
+ 
++/**
++ * Gets hostroutes for the connman service
++ *
++ * @param[IN] service A service instance
++ * @param[IN] hostroutes Hostroutes
++ */
++gboolean connman_service_set_hostroutes(connman_service_t *service, GStrv hostroutes);
++
+ /**
+  * Create a new connman service instance and set its properties
+  *
+diff --git a/src/errors.h b/src/errors.h
+index 724946c..0261938 100644
+--- a/src/errors.h
++++ b/src/errors.h
+@@ -23,7 +23,9 @@
+ #define WCA_API_ERROR_INVALID_PARAMETERS    3
+ #define WCA_API_ERROR_CONNMAN_UNAVAILABLE   4
+ #define WCA_API_ERROR_WIFI_TECH_UNAVAILABLE 5
++#define WCA_API_ERROR_CELLULAR_TECH_UNAVAILABLE 6
+ #define WCA_API_ERROR_WIFI_SWITCHED_OFF     7
++#define WCA_API_ERROR_WAN_SWITCHED_OFF      8
+ #define WCA_API_ERROR_SCHEMA_VALIDATION     9
+ 
+ #define WCA_API_ERROR_INVALID_KEY       10
+@@ -96,6 +98,7 @@
+ #define WCA_API_ERROR_FAILED_TO_ENABLE_DISABLE_TECHNOLOGIES 163
+ #define WCA_API_ERROR_FAILED_TO_SET_LISTEN_CHANNEL  164
+ #define WCA_API_ERROR_ALREADY_CONNECTED 165
++#define WCA_API_ERROR_HOST_ROUTE_NOT_SET 166
+ #define WCA_API_ERROR_REJECT_PEER 171
+ #define WCA_API_ERROR_LISTEN_PARAMS_INVALID_VALUES 172
+ #define WCA_API_ERROR_NO_SERVICE_CONNECTED              175
+diff --git a/src/logging.h b/src/logging.h
+index 7260c44..13f9c41 100644
+--- a/src/logging.h
++++ b/src/logging.h
+@@ -63,7 +63,8 @@ extern PmLogContext gLogContext;
+ /** common ones */
+ #define MSGID_WIFI_SRVC_REGISTER_FAIL                   "WIFI_SRVC_REGISTER_FAIL"
+ #define MSGID_CM_SRVC_REGISTER_FAIL                     "WIFI_CM_REGISTER_FAIL"
+-
++#define MSGID_WAN_SRVC_REGISTER_FAIL                    "WAN_SRVC_REGISTER_FAIL"
++#define MSGID_WAN_SRVC_ALLOC_FAIL                       "WAN_SRVC_ALLOC_FAIL"
+ #define MSGID_INVALID_STATE                             "INVALID_STATE"
+ 
+ /** main.c */
+@@ -224,6 +225,11 @@ extern PmLogContext gLogContext;
+ #define MSGID_COUNTRY_CODE_INFO                         "COUNTRY_CODE_INFO"
+ #define MSGID_COUNTRY_CODE_FAILED                       "COUNTRY_CODE_FAILED"
+ 
++/** Wan info codes **/
++#define MSGID_WAN_CONNECT_INFO                          "WAN_CONNECT_INFO"
++#define MSGID_WAN_DISCONNECT_INFO                       "WAN_DISCONNECT_INFO"
++#define MSGID_WAN_SET_HOSTROUTE_ERROR                   "WAN_SET_HOSTROUTE_ERR"
++
+ /** json_utils.c **/
+ #define MSGID_JSON_KEY_NULL                             "JSON_KEY_NULL"
+ #define MSGID_JSON_DEST_NULL                            "JSON_DEST_NULL"
+diff --git a/src/main.c b/src/main.c
+index f0f872d..aef01e9 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -35,6 +35,7 @@
+ #include "logging.h"
+ #include "wifi_service.h"
+ #include "wifi_setting.h"
++#include "wan_service.h"
+ #include "connectionmanager_service.h"
+ 
+ static GMainLoop *mainloop = NULL;
+@@ -57,7 +58,7 @@ term_handler(int signal)
+ int
+ main(int argc, char **argv)
+ {
+-	LSHandle *wifi_handle, *cm_handle;
++	LSHandle *wifi_handle, *wan_handle, *cm_handle;
+ 	signal(SIGTERM, term_handler);
+ 	signal(SIGINT, term_handler);
+ 
+@@ -74,6 +75,13 @@ main(int argc, char **argv)
+ 		return -1;
+ 	}
+ 
++	if (initialize_wan_ls2_calls(mainloop, &wan_handle) < 0)
++	{
++		WCALOG_ERROR(MSGID_WAN_SRVC_REGISTER_FAIL, 0,
++		             "Error in initializing com.webos.service.wan service");
++		return -1;
++	}
++
+ 	if (initialize_connectionmanager_ls2_calls(mainloop, &cm_handle) < 0)
+ 	{
+ 		WCALOG_ERROR(MSGID_CM_SRVC_REGISTER_FAIL, 0,
+@@ -83,7 +91,7 @@ main(int argc, char **argv)
+ 
+ 	wca_support_connman_update_callbacks wca_support_library_cb = { 0 };
+ 
+-	if (wca_support_init(wifi_handle, cm_handle,
++	if (wca_support_init(wifi_handle, cm_handle, wan_handle,
+ 	                     &wca_support_library_cb, NULL, &gLogContext) < 0)
+ 	{
+ 		WCALOG_ERROR(MSGID_WCA_SUPPORT_FAIL, 0,
+diff --git a/src/wan_service.c b/src/wan_service.c
+new file mode 100644
+index 0000000..2468a33
+--- /dev/null
++++ b/src/wan_service.c
+@@ -0,0 +1,996 @@
++// Copyright (c) 2013-2018 LG Electronics, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++// http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++//
++// SPDX-License-Identifier: Apache-2.0
++
++#include <glib.h>
++#include <stdbool.h>
++#include <time.h>
++#include <string.h>
++#include <pbnjson.h>
++#include <sys/ioctl.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
++#include <linux/if.h>
++
++#include "wan_service.h"
++#include "connman_manager.h"
++#include "connman_agent.h"
++#include "connman_service.h"
++#include "lunaservice_utils.h"
++#include "common.h"
++#include "connectionmanager_service.h"
++#include "logging.h"
++#include "errors.h"
++
++static LSHandle *pLsHandle;
++
++extern connman_manager_t *manager;
++extern connman_agent_t *agent;
++
++static void service_changed_cb(gpointer user_data, const gchar *name,
++                               GVariant *value)
++{
++	connectionmanager_send_status_to_subscribers();
++}
++
++static void retrieve_wan_context(jvalue_ref context_obj,
++                                 connman_service_t *service)
++{
++	jvalue_ref ipv4_obj, ipv6_obj, dns_obj, hosts_obj;
++	int i;
++
++	jobject_put(context_obj, J_CSTR_TO_JVAL("name"), jstring_create(service->name));
++	jobject_put(context_obj, J_CSTR_TO_JVAL("connected"),
++	            jboolean_create(connman_service_is_connected(service)));
++	jobject_put(context_obj, J_CSTR_TO_JVAL("onInternet"),
++	            jboolean_create(connman_service_is_online(service)));
++
++	if (service->ipinfo.iface)
++	{
++		jobject_put(context_obj, J_CSTR_TO_JVAL("interface"),
++		            jstring_create(service->ipinfo.iface));
++	}
++
++	ipv4_obj = jobject_create();
++
++	if (service->ipinfo.ipv4.address)
++	{
++		jobject_put(ipv4_obj, J_CSTR_TO_JVAL("address"),
++		            jstring_create(service->ipinfo.ipv4.address));
++	}
++
++	if (service->ipinfo.ipv4.netmask)
++	{
++		jobject_put(ipv4_obj, J_CSTR_TO_JVAL("subnet"),
++		            jstring_create(service->ipinfo.ipv4.netmask));
++	}
++
++	if (service->ipinfo.ipv4.gateway)
++	{
++		jobject_put(ipv4_obj, J_CSTR_TO_JVAL("gateway"),
++		            jstring_create(service->ipinfo.ipv4.gateway));
++	}
++
++	if (jobject_size(ipv4_obj) > 0)
++	{
++		jobject_put(context_obj, J_CSTR_TO_JVAL("ipv4"), ipv4_obj);
++	}
++	else
++	{
++		j_release(&ipv4_obj);
++	}
++
++	ipv6_obj = jobject_create();
++
++	if (service->ipinfo.ipv6.address)
++	{
++		jobject_put(ipv6_obj, J_CSTR_TO_JVAL("address"),
++		            jstring_create(service->ipinfo.ipv6.address));
++	}
++
++	if (service->ipinfo.ipv6.prefix_length > 0)
++	{
++		jobject_put(ipv6_obj, J_CSTR_TO_JVAL("prefixLength"),
++		            jnumber_create_i32(service->ipinfo.ipv6.prefix_length));
++	}
++
++	if (service->ipinfo.ipv6.gateway)
++	{
++		jobject_put(ipv6_obj, J_CSTR_TO_JVAL("gateway"),
++		            jstring_create(service->ipinfo.ipv6.gateway));
++	}
++
++	if (jobject_size(ipv6_obj) > 0)
++	{
++		jobject_put(context_obj, J_CSTR_TO_JVAL("ipv6"), ipv6_obj);
++	}
++	else
++	{
++		j_release(&ipv6_obj);
++	}
++
++	dns_obj = jarray_create(NULL);
++
++	if (service->ipinfo.dns)
++	{
++		for (i = 0; i < g_strv_length(service->ipinfo.dns); i++)
++		{
++			jarray_append(dns_obj, jstring_create(service->ipinfo.dns[i]));
++		}
++	}
++
++	jobject_put(context_obj, J_CSTR_TO_JVAL("dns"), dns_obj);
++
++	hosts_obj = jarray_create(NULL);
++
++	for (i = 0; i < g_strv_length(service->hostroutes); i++)
++	{
++		jarray_append(hosts_obj, jstring_create(service->hostroutes[i]));
++	}
++
++	jobject_put(context_obj, J_CSTR_TO_JVAL("hosts"), hosts_obj);
++
++}
++static void append_context(jvalue_ref contexts_obj, connman_service_t *service)
++{
++	if (!jis_array(contexts_obj))
++	{
++		return;
++	}
++
++	jvalue_ref context_obj = jobject_create();
++
++	retrieve_wan_context(context_obj, service);
++
++	jarray_append(contexts_obj, context_obj);
++}
++
++void append_wan_status(jvalue_ref reply_obj)
++{
++	GSList *iter;
++	connman_service_t *service = NULL;
++	bool connected = false;
++	bool online = false;
++	jvalue_ref connected_contexts_obj;
++
++	if (!reply_obj)
++	{
++		return;
++	}
++
++	connected_contexts_obj = jarray_create(NULL);
++
++	for (iter = manager->cellular_services; NULL != iter; iter = iter->next)
++	{
++		service = (connman_service_t *)(iter->data);
++
++		if (!connman_service_is_connected(service))
++		{
++			continue;
++		}
++
++		connected = TRUE;
++
++		if (connman_service_is_online(service))
++		{
++			online = true;
++		}
++
++		connman_service_get_ipinfo(service);
++
++		append_context(connected_contexts_obj, service);
++	}
++
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("onInternet"), jboolean_create(online));
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("connected"), jboolean_create(connected));
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("connectedContexts"),
++	            connected_contexts_obj);
++}
++
++void send_wan_connection_status_to_subscribers()
++{
++	jvalue_ref reply = jobject_create();
++
++	jobject_put(reply, J_CSTR_TO_JVAL("returnValue"), jboolean_create(true));
++	jobject_put(reply, J_CSTR_TO_JVAL("subscribed"), jboolean_create(true));
++
++	append_wan_status(reply);
++
++	jschema_ref response_schema = jschema_parse(j_cstr_to_buffer("{}"),
++	                              DOMOPT_NOOPT, NULL);
++
++	if (response_schema)
++	{
++		const char *payload = jvalue_tostring(reply, response_schema);
++
++		LSError lserror;
++		LSErrorInit(&lserror);
++
++		if (!LSSubscriptionReply(pLsHandle, LUNA_CATEGORY_ROOT LUNA_METHOD_WAN_GETSTATUS, payload, &lserror))
++		{
++			LSErrorPrint(&lserror, stderr);
++			LSErrorFree(&lserror);
++		}
++
++		jschema_release(&response_schema);
++	}
++
++	j_release(&reply);
++}
++
++static void append_contexts(jvalue_ref reply_obj)
++{
++	connman_service_t *service;
++	GSList *iter;
++
++	jvalue_ref contexts_obj = jarray_create(NULL);
++
++	for (iter = manager->cellular_services; NULL != iter; iter = iter->next)
++	{
++		service = (connman_service_t *) iter->data;
++
++		connman_service_get_ipinfo(service);
++
++		append_context(contexts_obj, service);
++	}
++
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("contexts"), contexts_obj);
++}
++
++void send_wan_contexts_update_to_subscribers()
++{
++	jvalue_ref reply_obj = jobject_create();
++
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("returnValue"), jboolean_create(true));
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("subscribed"), jboolean_create(true));
++
++	append_contexts(reply_obj);
++
++	jschema_ref response_schema = jschema_parse(j_cstr_to_buffer("{}"),
++	                              DOMOPT_NOOPT, NULL);
++
++	if (response_schema)
++	{
++		const char *payload = jvalue_tostring(reply_obj, response_schema);
++
++		LSError lserror;
++		LSErrorInit(&lserror);
++
++		if (!LSSubscriptionReply(pLsHandle, LUNA_CATEGORY_ROOT LUNA_METHOD_WAN_GETCONTEXTS, payload, &lserror))
++		{
++			LSErrorPrint(&lserror, stderr);
++			LSErrorFree(&lserror);
++		}
++
++		jschema_release(&response_schema);
++	}
++
++	j_release(&reply_obj);
++}
++
++static void service_connect_callback(gboolean success, gpointer user_data)
++{
++	luna_service_request_t *service_req = user_data;
++	connman_service_t *service = service_req->user_data;
++
++	if (!success)
++	{
++		LSMessageReplyCustomError(service_req->handle, service_req->message,
++		                          "Failed to connect cellular service", WCA_API_ERROR_FAILED_TO_CONNECT);
++		goto cleanup;
++	}
++
++	LSMessageReplySuccess(service_req->handle, service_req->message);
++
++	connman_service_register_property_changed_cb(service, service_changed_cb);
++
++cleanup:
++	luna_service_request_free(service_req);
++}
++
++
++static void connect_wan_service(const char *name,
++                                luna_service_request_t *service_req)
++{
++	GSList *iter;
++	gboolean found_service = FALSE;
++	connman_service_t *service = NULL;
++
++	if (!name)
++	{
++		LSMessageReplyErrorInvalidParams(service_req->handle, service_req->message);
++		goto cleanup;
++	}
++
++	for (iter = manager->cellular_services; NULL != iter ; iter = iter->next)
++	{
++		service = (connman_service_t *) iter->data;
++
++		if (g_strcmp0(service->name, name) == 0)
++		{
++			WCALOG_INFO(MSGID_WAN_CONNECT_INFO, 0, "Connecting to cellular service %s",
++			            service->name);
++			found_service = TRUE;
++			break;
++		}
++	}
++
++	if (!found_service)
++	{
++		LSMessageReplyCustomError(service_req->handle, service_req->message,
++		                          "Cellular service not found", WCA_API_ERROR_NETWORK_NOT_FOUND);
++		goto cleanup;
++	}
++
++	service_req->user_data = service;
++
++	if (!connman_service_connect(service, service_connect_callback, service_req))
++	{
++		LSMessageReplyErrorUnknown(service_req->handle, service_req->message);
++		goto cleanup;
++	}
++
++	return;
++
++cleanup:
++	luna_service_request_free(service_req);
++}
++
++
++static void disconnect_wan_service(const char *name, LSHandle *handle,
++                                   LSMessage *message)
++{
++	GSList *iter;
++	gboolean found_service = FALSE;
++	connman_service_t *service = NULL;
++
++	if (!name)
++	{
++		LSMessageReplyErrorInvalidParams(handle, message);
++		return;
++	}
++
++	/* Look up for the service with the given type */
++	for (iter = manager->cellular_services; NULL != iter ; iter = iter->next)
++	{
++		service = (connman_service_t *) iter->data;
++
++		if (g_strcmp0(service->name, name) == 0)
++		{
++			WCALOG_INFO(MSGID_WAN_DISCONNECT_INFO, 0,
++			            "Disconnecting from cellular service %s", service->name);
++			found_service = TRUE;
++			break;
++		}
++	}
++
++	if (!found_service)
++	{
++		LSMessageReplyCustomError(handle, message,
++		                          "Cellular service not found", WCA_API_ERROR_NETWORK_NOT_FOUND);
++		return;
++	}
++
++	if (!connman_service_disconnect(service))
++	{
++		LSMessageReplyErrorUnknown(handle, message);
++		return;
++	}
++
++	LSMessageReplySuccess(handle, message);
++}
++
++static void technology_property_changed_callback(gpointer data,
++        const gchar *property, GVariant *value)
++{
++	connman_technology_t *technology = (connman_technology_t *)data;
++
++	if (NULL == technology)
++	{
++		return;
++	}
++
++	WCALOG_DEBUG("WAN technology: property [%s] changed", property);
++
++	if ((technology == connman_manager_find_cellular_technology(manager)) &&
++	        (g_strcmp0(property, "Powered") == 0 || g_strcmp0(property, "Connected") == 0))
++	{
++		send_wan_connection_status_to_subscribers();
++		connectionmanager_send_status_to_subscribers();
++	}
++}
++
++/**
++ * @brief The connect method connects to a single context which is specified by its name.
++ *
++ * @param name Name of the context to connect to.
++ */
++
++static bool handle_wan_connect_command(LSHandle *sh, LSMessage *message,
++                                       void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	if (!cellular_technology_status_check(sh, message))
++	{
++		return true;
++	}
++
++	if (!is_cellular_powered())
++	{
++		LSMessageReplyCustomError(sh, message, "WAN switched off",
++		                          WCA_API_ERROR_WAN_SWITCHED_OFF);
++		return true;
++	}
++
++	// To prevent memory leaks, schema should be checked before the variables will be initialized.
++	jvalue_ref parsed_obj = 0;
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_1(PROP(name, string))  REQUIRED_1(name))),
++	                             &parsed_obj))
++	{
++		return true;
++	}
++
++	luna_service_request_t *service_req;
++	jvalue_ref name_obj = 0;
++	char *name = NULL;
++
++	if (jobject_get_exists(parsed_obj, J_CSTR_TO_BUF("name"), &name_obj))
++	{
++		raw_buffer name_buf = jstring_get(name_obj);
++		name = g_strdup(name_buf.m_str);
++		jstring_free_buffer(name_buf);
++	}
++
++	if (name == NULL || strlen(name) == 0)
++	{
++		LSMessageReplyErrorInvalidParams(sh, message);
++		goto cleanup;
++	}
++
++	service_req = luna_service_request_new(sh, message);
++
++	connect_wan_service(name, service_req);
++
++cleanup:
++
++	if (!jis_null(parsed_obj))
++	{
++		j_release(&parsed_obj);
++	}
++
++	g_free(name);
++
++	return true;
++}
++
++/**
++ * @brief The disconnect method disconnects a single context which is specified by its name.
++ *
++ * @param name Name of the context to disconnect
++ */
++
++static bool handle_wan_disconnect_command(LSHandle *sh, LSMessage *message,
++        void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	if (!cellular_technology_status_check(sh, message))
++	{
++		return true;
++	}
++
++	if (!is_cellular_powered())
++	{
++		LSMessageReplyCustomError(sh, message, "WAN switched off",
++		                          WCA_API_ERROR_WAN_SWITCHED_OFF);
++		return true;
++	}
++
++	// To prevent memory leaks, schema should be checked before the variables will be initialized.
++	jvalue_ref parsed_obj = 0;
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_1(PROP(name, string))  REQUIRED_1(name))),
++	                             &parsed_obj))
++	{
++		return true;
++	}
++
++	jvalue_ref name_obj = 0;
++	char *name = NULL;
++
++	if (jobject_get_exists(parsed_obj, J_CSTR_TO_BUF("name"), &name_obj))
++	{
++		raw_buffer name_buf = jstring_get(name_obj);
++		name = g_strdup(name_buf.m_str);
++		jstring_free_buffer(name_buf);
++	}
++
++	if (name == NULL || strlen(name) == 0)
++	{
++		LSMessageReplyErrorInvalidParams(sh, message);
++		goto cleanup;
++	}
++
++	disconnect_wan_service(name, sh, message);
++
++cleanup:
++
++	if (!jis_null(parsed_obj))
++	{
++		j_release(&parsed_obj);
++	}
++
++	g_free(name);
++
++	return true;
++}
++
++/**
++ * @brief Reports the current WAN status to the caller.
++ *
++ * @param subscribe To be notified of any status changes, set subscribe to true
++ */
++
++static bool handle_wan_get_status_command(LSHandle *sh, LSMessage *message,
++        void *context)
++{
++	jvalue_ref parsedObj = {0};
++
++	if (!LSMessageValidateSchema(sh, message,
++                                     j_cstr_to_buffer(SCHEMA_1(PROP(subscribe, boolean))), &parsedObj))
++	{
++                return true;
++	}
++
++	jvalue_ref reply_obj = 0;
++	LSError lserror;
++	LSErrorInit(&lserror);
++	bool subscribed = false;
++
++	reply_obj = jobject_create();
++
++	if (LSMessageIsSubscription(message))
++	{
++		if (!LSSubscriptionProcess(sh, message, &subscribed, &lserror))
++		{
++			LSErrorPrint(&lserror, stderr);
++			LSErrorFree(&lserror);
++		}
++	}
++
++	if (!connman_status_check_with_subscription(manager, sh, message, subscribed))
++	{
++		goto cleanup;
++	}
++
++	if (!cellular_technology_status_check_with_subscription(sh, message,
++		subscribed))
++	{
++		goto cleanup;
++	}
++
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("returnValue"), jboolean_create(true));
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("subscribed"),
++	            jboolean_create(subscribed));
++
++	append_wan_status(reply_obj);
++
++	if (!LSMessageReply(sh, message, jvalue_tostring(reply_obj, jschema_all()),
++	                    &lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++cleanup:
++
++	if (LSErrorIsSet(&lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++	j_release(&reply_obj);
++	j_release(&parsedObj);
++
++	return true;
++}
++
++/**
++ * @brief  Lists all available contexts
++ *
++ * @param subscribe To be notified of any status changes, set subscribe to true
++ */
++
++static bool handle_wan_get_contexts_command(LSHandle *sh, LSMessage *message,
++        void *context)
++{
++	jvalue_ref parsedObj = {0};
++
++	if (!LSMessageValidateSchema(sh, message,
++                                     j_cstr_to_buffer(SCHEMA_1(PROP(subscribe, boolean))), &parsedObj))
++	{
++                return true;
++	}
++
++	jvalue_ref reply_obj = 0;
++	LSError lserror;
++	LSErrorInit(&lserror);
++	bool subscribed = false;
++
++	reply_obj = jobject_create();
++
++	if (LSMessageIsSubscription(message))
++	{
++		if (!LSSubscriptionProcess(sh, message, &subscribed, &lserror))
++		{
++			LSErrorPrint(&lserror, stderr);
++			LSErrorFree(&lserror);
++		}
++	}
++
++	if (!connman_status_check_with_subscription(manager, sh, message, subscribed))
++	{
++		goto cleanup;
++	}
++
++	if (!cellular_technology_status_check_with_subscription(sh, message,
++	        subscribed))
++	{
++		goto cleanup;
++	}
++
++
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("returnValue"), jboolean_create(true));
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("subscribed"),
++	            jboolean_create(subscribed));
++
++	append_contexts(reply_obj);
++
++	if (!LSMessageReply(sh, message, jvalue_tostring(reply_obj, jschema_all()),
++	                    &lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++cleanup:
++
++	if (LSErrorIsSet(&lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++	j_release(&reply_obj);
++	j_release(&parsedObj);
++
++	return true;
++}
++
++/**
++ * @brief  Get information of a given context
++ *
++ * @param name name of the context
++ */
++
++static bool handle_wan_get_context_command(LSHandle *sh, LSMessage *message,
++        void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	if (!cellular_technology_status_check(sh, message))
++	{
++		return true;
++	}
++
++	// To prevent memory leaks, schema should be checked before the variables will be initialized.
++	jvalue_ref parsed_obj = 0;
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_1(PROP(name, string)) REQUIRED_1(name))),
++	                             &parsed_obj))
++	{
++		return true;
++	}
++
++	jvalue_ref reply_obj = 0;
++	jvalue_ref name_obj = 0;
++	LSError lserror;
++	LSErrorInit(&lserror);
++	bool found_service = FALSE;
++	GSList *iter;
++	char *name = NULL;
++	connman_service_t *service = NULL;
++
++	if (jobject_get_exists(parsed_obj, J_CSTR_TO_BUF("name"), &name_obj))
++	{
++		raw_buffer name_buf = jstring_get(name_obj);
++		name = g_strdup(name_buf.m_str);
++		jstring_free_buffer(name_buf);
++	}
++
++	reply_obj = jobject_create();
++
++	jobject_put(reply_obj, J_CSTR_TO_JVAL("returnValue"), jboolean_create(true));
++
++	for (iter = manager->cellular_services; NULL != iter; iter = iter->next)
++	{
++		service = (connman_service_t *) iter->data;
++
++		if (g_strcmp0(service->name, name) == 0)
++		{
++			connman_service_get_ipinfo(service);
++			jvalue_ref wan_context_obj = jobject_create();
++			retrieve_wan_context(wan_context_obj, service);
++			jobject_put(reply_obj, J_CSTR_TO_JVAL("contextInfo"), wan_context_obj);
++			found_service = TRUE;
++			break;
++		}
++	}
++
++	if (!found_service)
++	{
++		LSMessageReplyCustomError(sh, message, "Cellular service not found",
++		                          WCA_API_ERROR_NETWORK_NOT_FOUND);
++		goto cleanup;
++	}
++
++	if (!LSMessageReply(sh, message, jvalue_tostring(reply_obj, jschema_all()),
++                            &lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++cleanup:
++
++	if (!jis_null(reply_obj))
++	{
++		j_release(&reply_obj);
++	}
++
++	if (!jis_null(parsed_obj))
++	{
++		j_release(&parsed_obj);
++	}
++
++	g_free(name);
++
++	return true;
++}
++
++/**
++ * @brief  Set static host routing for a given context
++ *
++ * @param name  name of the context
++ * @param hosts an array of host IP address to setup static route
++ */
++
++static bool handle_set_hostroutes_command(LSHandle *sh, LSMessage *message,
++        void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	if (!cellular_technology_status_check(sh, message))
++	{
++		return true;
++	}
++
++	if (!is_cellular_powered())
++	{
++		LSMessageReplyCustomError(sh, message, "WAN switched off",
++		                          WCA_API_ERROR_WAN_SWITCHED_OFF);
++		return true;
++	}
++
++	// To prevent memory leaks, schema should be checked before the variables will be initialized.
++	jvalue_ref parsed_obj = 0;
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_2(ARRAY(hosts, string), PROP(name, string))
++	                                     REQUIRED_2(name, hosts))), &parsed_obj))
++	{
++		return true;
++	}
++
++	GStrv hosts = NULL;
++	jvalue_ref name_obj = 0;
++	jvalue_ref hosts_obj = 0;
++	char *name = NULL;
++	GSList *iter;
++	gboolean found_service = false;
++	connman_service_t *service = NULL;
++
++	if (jobject_get_exists(parsed_obj, J_CSTR_TO_BUF("name"), &name_obj))
++	{
++		raw_buffer name_buf = jstring_get(name_obj);
++		name = g_strdup(name_buf.m_str);
++		jstring_free_buffer(name_buf);
++	}
++
++	if (jobject_get_exists(parsed_obj, J_CSTR_TO_BUF("hosts"), &hosts_obj))
++	{
++		int i, host_arrsize = jarray_size(hosts_obj);
++		hosts = (GStrv) g_new0(GStrv, host_arrsize + 1);
++
++		for (i = 0; i < host_arrsize; i++)
++		{
++			raw_buffer host_buf = jstring_get(jarray_get(hosts_obj, i));
++			hosts[i] = g_strdup(host_buf.m_str);
++			jstring_free_buffer(host_buf);
++
++			if (!(is_valid_ipaddress(hosts[i]) || is_valid_ipv6address(hosts[i])))
++			{
++				LSMessageReplyErrorInvalidParams(sh, message);
++				goto cleanup;
++			}
++		}
++	}
++
++	/* Look up for the service with the given type */
++	for (iter = manager->cellular_services; NULL != iter ; iter = iter->next)
++	{
++		service = (connman_service_t *) iter->data;
++
++		if (g_strcmp0(service->name, name) == 0)
++		{
++			WCALOG_DEBUG("Setting host route for service %s", service->name);
++			found_service = true;
++			break;
++		}
++	}
++
++	if (!found_service)
++	{
++		LSMessageReplyCustomError(sh, message,
++		                          "Cellular service not found", WCA_API_ERROR_NETWORK_NOT_FOUND);
++		goto cleanup;
++	}
++
++	if (connman_service_set_hostroutes(service, hosts))
++	{
++		LSMessageReplySuccess(sh, message);
++	}
++	else
++	{
++		LSMessageReplyCustomError(sh, message, "Hosts could not be set as static route",
++		                          WCA_API_ERROR_HOST_ROUTE_NOT_SET);
++	}
++
++cleanup:
++
++	if (!jis_null(parsed_obj))
++	{
++		j_release(&parsed_obj);
++	}
++
++	g_free(name);
++	g_strfreev(hosts);
++
++	return true;
++}
++
++static LSMethod wan_methods[] =
++{
++	{ LUNA_METHOD_WAN_CONNECT,       handle_wan_connect_command },
++	{ LUNA_METHOD_WAN_DISCONNECT,    handle_wan_disconnect_command },
++	{ LUNA_METHOD_WAN_GETSTATUS,     handle_wan_get_status_command },
++	{ LUNA_METHOD_WAN_GETCONTEXTS,   handle_wan_get_contexts_command },
++	{ LUNA_METHOD_WAN_GETCONTEXT,    handle_wan_get_context_command },
++	{ LUNA_METHOD_WAN_SETHOSTROUTES, handle_set_hostroutes_command },
++	{ },
++};
++
++int initialize_wan_ls2_calls(GMainLoop *mainloop, LSHandle **wan_handle)
++{
++	LSError lserror;
++	LSErrorInit(&lserror);
++	pLsHandle = NULL;
++
++	if (NULL == mainloop)
++	{
++		goto Exit;
++	}
++
++	if (LSRegister(WAN_LUNA_SERVICE_NAME, &pLsHandle, &lserror) == false)
++	{
++		WCALOG_ERROR(MSGID_WAN_SRVC_REGISTER_FAIL, 0,
++		             "LSRegister() returned error");
++		goto Exit;
++	}
++
++	if (LSRegisterCategory(pLsHandle, LUNA_CATEGORY_ROOT, wan_methods, NULL, NULL,
++	                       &lserror) == false)
++	{
++		WCALOG_ERROR(MSGID_WAN_SRVC_REGISTER_FAIL, 0,
++		             "LSRegisterCategory() returned error");
++		goto Exit;
++	}
++
++	if (LSGmainAttach(pLsHandle, mainloop, &lserror) == false)
++	{
++		WCALOG_ERROR(MSGID_WAN_SRVC_REGISTER_FAIL, 0,
++		             "LSGmainAttach() returned error");
++		goto Exit;
++	}
++
++	*wan_handle = pLsHandle;
++
++	return 0;
++
++Exit:
++
++	if (LSErrorIsSet(&lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++	if (pLsHandle)
++	{
++		LSErrorInit(&lserror);
++
++		if (LSUnregister(pLsHandle, &lserror) == false)
++		{
++			LSErrorPrint(&lserror, stderr);
++			LSErrorFree(&lserror);
++		}
++	}
++
++	return -1;
++}
++
++void check_and_initialize_cellular_technology(void)
++{
++	connman_technology_t *technology = connman_manager_find_cellular_technology(
++	                                       manager);
++
++	if (!technology)
++	{
++		return;
++	}
++
++	connman_technology_register_property_changed_cb(technology,
++	        technology_property_changed_callback);
++
++	/* Register property change callback for all connected cellular services */
++	GSList *iter;
++
++	for (iter = manager->cellular_services; iter != NULL; iter = iter->next)
++	{
++		connman_service_t *service = iter->data;
++
++		if (!connman_service_is_connected(service))
++		{
++			continue;
++		}
++
++		connman_service_register_property_changed_cb(service, service_changed_cb);
++	}
++}
+diff --git a/src/wan_service.h b/src/wan_service.h
+new file mode 100644
+index 0000000..d94595d
+--- /dev/null
++++ b/src/wan_service.h
+@@ -0,0 +1,39 @@
++// Copyright (c) 2012-2018 LG Electronics, Inc.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++// http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++//
++// SPDX-License-Identifier: Apache-2.0
++
++#ifndef _WAN_SERVICE_H_
++#define _WAN_SERVICE_H_
++
++#include <luna-service2/lunaservice.h>
++
++#define WAN_LUNA_SERVICE_NAME "com.webos.service.wan"
++
++#define LUNA_CATEGORY_ROOT            "/"
++
++#define LUNA_METHOD_WAN_CONNECT       "connect"
++#define LUNA_METHOD_WAN_DISCONNECT    "disconnect"
++#define LUNA_METHOD_WAN_GETSTATUS     "getStatus"
++#define LUNA_METHOD_WAN_GETCONTEXTS   "getContexts"
++#define LUNA_METHOD_WAN_GETCONTEXT    "getContext"
++#define LUNA_METHOD_WAN_SETHOSTROUTES "setHostRoutes"
++
++extern void check_and_initialize_cellular_technology(void);
++extern void send_wan_connection_status_to_subscribers(void);
++extern void send_wan_contexts_update_to_subscribers(void);
++extern void append_wan_status(jvalue_ref reply_obj);
++extern int initialize_wan_ls2_calls(GMainLoop *mainloop, LSHandle **wan_handle);
++
++#endif /* _WAN_SERVICE_H_ */
+diff --git a/src/wifi_service.c b/src/wifi_service.c
+index dbbb36a..28d965f 100644
+--- a/src/wifi_service.c
++++ b/src/wifi_service.c
+@@ -58,6 +58,7 @@ errorText | Yes | String | Error description
+ #include "logging.h"
+ #include "wifi_p2p_service.h"
+ #include "wifi_tethering_service.h"
++#include "wan_service.h"
+ #include "errors.h"
+ 
+ /* Range for converting signal strength to signal bars */
+@@ -1849,6 +1850,12 @@ static void manager_services_changed_callback(gpointer data,
+ 		connectionmanager_send_status_to_subscribers();
+ 	}
+ 
++	if (service_type & CELLULAR_SERVICES_CHANGED)
++	{
++		connectionmanager_send_status_to_subscribers();
++		send_wan_connection_status_to_subscribers();
++		send_wan_contexts_update_to_subscribers();
++	}
+ }
+ 
+ void send_getnetworks_status_to_subscribers()
+@@ -2145,6 +2152,7 @@ static void manager_technologies_changed_callback(gpointer data)
+ {
+ 	check_and_initialize_wifi_technology();
+ 	check_and_initialize_p2p_technology();
++	check_and_initialize_cellular_technology();
+ 	check_and_initialize_ethernet_technology();
+ }
+ 
+@@ -4059,6 +4067,7 @@ static void connman_service_started(GDBusConnection *conn, const gchar *name,
+ 	check_and_initialize_wifi_technology();
+ 	check_and_initialize_p2p_technology();
+ 	check_and_initialize_ethernet_technology();
++	check_and_initialize_cellular_technology();
+ 
+ 	connectionmanager_send_status_to_subscribers();
+ }
+-- 
+2.37.3.windows.1
+

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0003-Add-back-com.palm.wan-for-cellular-support.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0003-Add-back-com.palm.wan-for-cellular-support.patch
@@ -1,4 +1,4 @@
-From 63172d779c5ac4442d837bc42c8690a04b5abbc1 Mon Sep 17 00:00:00 2001
+From cd705f11757e1a08086be05947db89008d68a48d Mon Sep 17 00:00:00 2001
 From: Herman van Hazendonk <github.com@herrie.org>
 Date: Fri, 16 Dec 2022 15:37:34 +0100
 Subject: [PATCH] Add back com.palm.wan for cellular support
@@ -7,10 +7,10 @@ Since we use it in LuneOS.
 
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 ---
- CMakeLists.txt                                |   1 +
+ CMakeLists.txt                                |   2 +
  files/sysbus/webos-connman-adapter.api.json   |  22 +-
  files/sysbus/webos-connman-adapter.perm.json  |   8 +
- .../sysbus/webos-connman-adapter.role.json.in |   9 +-
+ .../sysbus/webos-connman-adapter.role.json.in |  36 +-
  files/sysbus/webos-connman-adapter.service.in |   2 +-
  src/common.c                                  |  59 ++
  src/common.h                                  |   4 +
@@ -25,15 +25,23 @@ Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
  src/wan_service.c                             | 996 ++++++++++++++++++
  src/wan_service.h                             |  39 +
  src/wifi_service.c                            |   9 +
- 18 files changed, 1448 insertions(+), 14 deletions(-)
+ 18 files changed, 1468 insertions(+), 22 deletions(-)
  create mode 100644 src/wan_service.c
  create mode 100644 src/wan_service.h
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2fa2af5..39058c3 100644
+index 2fa2af5..76e4015 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -135,6 +135,7 @@ file(GLOB SOURCE_FILES
+@@ -29,6 +29,7 @@ webos_component(1 1 0)
+ 
+ set(WIFI_IFACE_NAME "wlan0" CACHE STRING "WiFi interface name")
+ set(WIRED_IFACE_NAME "eth0" CACHE STRING "Wired interface name")
++set(CELLULAR_IFACE_NAME "rmnet_usb0" CACHE STRING "Cellular interface name")
+ set(CONNMAN_CONFIG_DIR "/var/lib/connman" CACHE STRING "Default connman config folder")
+ 
+ find_program(GDBUS_CODEGEN_EXECUTABLE NAMES gdbus-codegen DOC "gdbus-codegen executable")
+@@ -135,6 +136,7 @@ file(GLOB SOURCE_FILES
      src/main.c
      src/pacrunner_client.c
      src/utils.c
@@ -92,29 +100,57 @@ index 2621a73..f65c5fe 100644
      ]
  }
 diff --git a/files/sysbus/webos-connman-adapter.role.json.in b/files/sysbus/webos-connman-adapter.role.json.in
-index 4d1cf9b..c619766 100644
+index 4d1cf9b..917c391 100644
 --- a/files/sysbus/webos-connman-adapter.role.json.in
 +++ b/files/sysbus/webos-connman-adapter.role.json.in
-@@ -2,7 +2,7 @@
+@@ -1,23 +1,41 @@
+ {
      "exeName":"@WEBOS_INSTALL_SBINDIR@/webos-connman-adapter",
-     "type":"regular",
+-    "type":"regular",
++     "type":"regular",
      "trustLevel": "oem",
 -    "allowedNames":["com.webos.service.wifi", "com.webos.service.connectionmanager"],
 +    "allowedNames":["com.webos.service.wifi", "com.webos.service.connectionmanager", "com.webos.service.wan"],
      "permissions": [
          {
              "service":"com.webos.service.wifi",
-@@ -18,6 +18,13 @@
-                         "com.webos.settingsservice",
-                         "com.webos.service.wifi",
-                         "com.webos.service.config"]
+-            "outbound":["com.webos.service.pdm",
+-                        "com.webos.settingsservice",
+-                        "com.webos.service.wifi",
++            "outbound":["com.webos.service.activitymanager.client",
+                         "com.webos.service.config",
+-                        "com.webos.service.connectionmanager"]
++                        "com.webos.service.connectionmanager",
++                        "com.webos.service.eventmonitor",
++                        "com.webos.service.pdm",
++                        "com.webos.service.systemservice",
++                        "com.webos.service.wifi",
++                        "com.webos.settingsservice"]
+         },
+         {
+             "service":"com.webos.service.connectionmanager",
+-            "outbound":["com.webos.service.pdm",
+-                        "com.webos.settingsservice",
++            "outbound":["com.webos.service.activitymanager.client",
++                        "com.webos.service.config",
++                        "com.webos.service.connectionmanager",
++                        "com.webos.service.eventmonitor",
++                        "com.webos.service.pdm",
++                        "com.webos.service.systemservice",
++                        "com.webos.service.wifi",
++                        "com.webos.settingsservice"]
 +        },
 +        {
 +            "service":"com.webos.service.wan",
-+            "outbound":["com.webos.service.pdm",
-+                        "com.webos.settingsservice",
-+                        "com.webos.service.wifi",
-+                        "com.webos.service.config"]
++            "outbound":["com.webos.service.activitymanager.client",
++                        "com.webos.service.config",
++                        "com.webos.service.connectionmanager",
++                        "com.webos.service.eventmonitor",
++                        "com.webos.service.pdm",
++                        "com.webos.service.systemservice",
+                         "com.webos.service.wifi",
+-                        "com.webos.service.config"]
++                        "com.webos.settingsservice"]
          }
      ]
  }
@@ -1937,6 +1973,3 @@ index dbbb36a..28d965f 100644
  
  	connectionmanager_send_status_to_subscribers();
  }
--- 
-2.37.3.windows.1
-


### PR DESCRIPTION
Move to webos-connman-adapter, wca-supplicant, connman, connman-conf from webOS OSE since they provide more funcitionality in terms of WiFi, tethering etc.

I removed cdc_ether (3G/4G dongles for WAN) from ConnMan since we don't really need that by the looks of it.

https://github.com/webosose/webos-initscripts/blob/master/rootfs/lib/systemd/system/scripts/webos-connman-adapter.sh.in

Only thing really missing is the handling of the cellular interface in webos-connman-adapter.

We'd need to see which approach we'd want to add there:

I.e. (partially revert) https://github.com/webosose/webos-connman-adapter/commit/1babacfd9743f473ead6cb4c895826df5f476791 or forward port the patch we had:

https://github.com/webOS-ports/webos-connman-adapter/commit/d1841e9b681b228a7a89ef68c2949db4f1b4b92d

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>