### PR TITLE
webos_app_generate_security_files.bbclass: Add fix for legacy apps

### DIFF
--- a/meta-luneos/classes/webos_app_generate_security_files.bbclass
+++ b/meta-luneos/classes/webos_app_generate_security_files.bbclass
@@ -30,6 +30,12 @@ def webos_app_generate_security_files_write_permission_file(d, app_info):
 
     if "requiredPermissions" in app_info:
         permission[key] = app_info["requiredPermissions"]
+        
+        # START Hack for legacy com.palm apps to fix issues with proxied LS2 calls, we want to make sure to allow the "app_id*" and "app_id-*"
+        if type == "web" and "com.palm." in app_id:
+            permission[app_id] = app_info["requiredPermissions"]
+        # END Hack for legacy com.palm apps to fix issues with proxied LS2 calls, we want to make sure to allow the "app_id*" and "app_id-*"
+
     else:
         permission[key] = []
         pub_bus = False


### PR DESCRIPTION
Legacy apps don't behave nicely due to new "proxied" LS2 calls.

Causes issues like:
Dec 16 10:16:09 qemux86-64 sam[600]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.app.calendar_com.webos.service.activitymanager_proxy","CATEGORY":"/","METHOD":"launch"} Service security groups don't allow method call.

Therefore add 2 variants in the generated file.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>