### PR TITLE
connman-conf: handle usb0 via connman

### DIFF
--- a/meta-luneos/recipes-connectivity/connman/connman-conf.bbappend
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf.bbappend
@@ -6,6 +6,7 @@ SRC_URI += " \
     file://connman.service \
     file://connman.sh.in \
     file://main.conf \
+    file://usb-dev.config \
 "
 do_configure:append () {
     sed -e 's/@WEBOS_CONNMAN_PREACTIVATE_INTERFACE_LIST@/${WEBOS_CONNMAN_PREACTIVATE_INTERFACE_LIST}/g; s%@DATADIR@%${datadir}%g' \
@@ -16,6 +17,9 @@ do_install:append() {
     install -d ${D}${sysconfdir}/connman
     install -m 0644 ${WORKDIR}/main.conf ${D}${sysconfdir}/connman/
 
+    install -d ${D}${localstatedir}/lib/connman
+    install -m 0644 ${WORKDIR}/usb-dev.config ${D}${localstatedir}/lib/connman/
+
     install -d ${D}${sysconfdir}/systemd/system
     install -v -m 644 ${WORKDIR}/connman.service ${D}${sysconfdir}/systemd/system/
     install -d ${D}${sysconfdir}/systemd/system/scripts
@@ -25,4 +29,5 @@ do_install:append() {
 FILES:${PN} += " \
     ${sysconfdir}/connman \
     ${sysconfdir} \
+    ${localstatedir}/lib/connman \
 "

--- a/meta-luneos/recipes-connectivity/connman/connman-conf/main.conf
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf/main.conf
@@ -59,7 +59,6 @@ PreferredTechnologies=ethernet,wifi,cellular
 # match any of the list entries. Default value is
 # vmnet,vboxnet,virbr,ifb,ve-,vb-.
 # NetworkInterfaceBlacklist = vmnet,vboxnet,virbr,ifb,ve-,vb-
-NetworkInterfaceBlacklist = usb
 
 # Allow connman to change the system hostname. This can
 # happen for example if we receive DHCP hostname option.

--- a/meta-luneos/recipes-connectivity/connman/connman-conf/usb-dev.config
+++ b/meta-luneos/recipes-connectivity/connman/connman-conf/usb-dev.config
@@ -1,0 +1,7 @@
+[global]
+Name=Gadget USB network
+
+[service_gadget_usb0]
+Type=gadget
+DeviceName=usb0
+IPv4=172.16.42.2/255.255.0.0

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0002-Add-systemd-service-file.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0002-Add-systemd-service-file.patch
@@ -13,7 +13,7 @@ new file mode 100644
 index 0000000..15450d0
 --- /dev/null
 +++ b/files/systemd/webos-connman-adapter.service
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,16 @@
 +[Unit]
 +Description=webos - "%n"
 +Requires=ls-hubd.service
@@ -24,6 +24,7 @@ index 0000000..15450d0
 +Type=simple
 +OOMScoreAdjust=-500
 +EnvironmentFile=-/var/systemd/system/env/webos-connman-adapter.env
++ExecStartPre=-/usr/bin/connmanctl enable gadget
 +ExecStart=/usr/sbin/webos-connman-adapter
 +Restart=on-failure
 +


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>

This version forces the gadget technology to be enabled once connmand is started, but this PR isn't as nice-looking as before...