### PR TITLE
sam: remove procps dependency

### DIFF
--- a/meta-luneos/recipes-webos/sam/sam.bb
+++ b/meta-luneos/recipes-webos/sam/sam.bb
@@ -35,6 +35,7 @@ file://0008-AppDescription.h-Add-org.webosports-as-privileged-as.patch \
 file://0009-LuneOS-style-module-name-is-now-QtQuick.Controls.Lun.patch \
 file://0010-Setup-QT_IM_MODULE-for-client-apps.patch \
 file://0011-NativeContainer-configure-native-apps.patch \
+file://0001-CMakeLists.txt-use-libproc2-from-procps-4.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/sam/sam.bb
+++ b/meta-luneos/recipes-webos/sam/sam.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=89aea4e17d99a7cacdbeed46a0096b10 \
                     file://oss-pkg-info.yaml;md5=2bdfe040dcf81b4038370ae96036c519 \
 "
 
-DEPENDS = "glib-2.0 luna-service2 libpbnjson boost icu pmloglib procps libwebosi18n"
+DEPENDS = "glib-2.0 luna-service2 libpbnjson boost icu pmloglib libwebosi18n"
 RDEPENDS:${PN} = "ecryptfs-utils"
 RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_webos-customization}"
 
@@ -36,6 +36,7 @@ file://0009-LuneOS-style-module-name-is-now-QtQuick.Controls.Lun.patch \
 file://0010-Setup-QT_IM_MODULE-for-client-apps.patch \
 file://0011-NativeContainer-configure-native-apps.patch \
 file://0001-CMakeLists.txt-use-libproc2-from-procps-4.patch \
+file://0002-sam-remove-procps-dependency.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/sam/sam/0001-CMakeLists.txt-use-libproc2-from-procps-4.patch
+++ b/meta-luneos/recipes-webos/sam/sam/0001-CMakeLists.txt-use-libproc2-from-procps-4.patch
@@ -1,0 +1,31 @@
+From b657b01f6ecb6a5f65039f13b74b5c16762ea9a2 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Sat, 11 Mar 2023 15:38:55 +0100
+Subject: [PATCH] CMakeLists.txt: use libproc2 from procps-4
+
+* there might be many more changes needed to adapt to procps 4 API, see:
+  https://gitlab.com/procps-ng/procps/-/issues/239
+
+* procps upgrade was now merged in oe-core together with igt-gpu-tools adaptation in:
+  https://git.openembedded.org/openembedded-core/commit/?id=631eba02d64f1a42514e0ae4361bbecc5cce5fa7
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ffa77a..2c2d690 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,7 +66,7 @@ find_package(Boost REQUIRED COMPONENTS regex system filesystem)
+ include_directories(${Boost_INCLUDE_DIRS})
+ webos_add_compiler_flags(ALL ${Boost_CFLAGS_OTHER})
+ 
+-pkg_check_modules(PROCPS REQUIRED libprocps)
++pkg_check_modules(PROCPS REQUIRED libproc2)
+ include_directories(PROCPS_INCLUDE_DIRS)
+ webos_add_compiler_flags(ALL ${PROCPS_CFLAGS})
+ 

--- a/meta-luneos/recipes-webos/sam/sam/0002-sam-remove-procps-dependency.patch
+++ b/meta-luneos/recipes-webos/sam/sam/0002-sam-remove-procps-dependency.patch
@@ -1,0 +1,37 @@
+From 386ff1942979a7d987c20aafd0bc6f02b1c22224 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Sat, 11 Mar 2023 16:08:44 +0100
+Subject: [PATCH] sam: remove procps dependency
+
+* doesn't seem to be actually used anywhere
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ CMakeLists.txt                          | 11 ++++---
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ffa77a..7d0ef61 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,10 +66,6 @@ find_package(Boost REQUIRED COMPONENTS regex system filesystem)
+ include_directories(${Boost_INCLUDE_DIRS})
+ webos_add_compiler_flags(ALL ${Boost_CFLAGS_OTHER})
+ 
+-pkg_check_modules(PROCPS REQUIRED libproc2)
+-include_directories(PROCPS_INCLUDE_DIRS)
+-webos_add_compiler_flags(ALL ${PROCPS_CFLAGS})
+-
+ find_library(ICU NAMES icuuc)
+ if(ICU STREQUAL "ICU-NOTFOUND")
+    message(FATAL_ERROR "Failed to find ICU4C libraries. Please install.")
+@@ -103,7 +99,7 @@ set(LIBS
+     ${Boost_LIBRARIES}
+     ${ICU}
+     ${RT}
+-    ${PROCPS_LDFLAGS})
++    )
+ target_link_libraries(${CMAKE_PROJECT_NAME} ${LIBS})
+ 
+ webos_build_system_bus_files()

--- a/meta-luneos/recipes-webos/sam/sam/0011-NativeContainer-configure-native-apps.patch
+++ b/meta-luneos/recipes-webos/sam/sam/0011-NativeContainer-configure-native-apps.patch
@@ -4,6 +4,7 @@ Date: Tue, 21 Feb 2023 17:57:20 +0000
 Subject: [PATCH] NativeContainer: configure native apps
 
 Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+Upstream-Status: Pending
 ---
  src/bus/client/NativeContainer.cpp | 6 ++++++
  1 file changed, 6 insertions(+)


### PR DESCRIPTION
Doesn't seem to be needed and would require to be changed for mickledore builds, so better to remove it completely from all 3 active branches.