### PR TITLE
qtwayland: fix virtual keyboard not showing up for Qt apps

### DIFF
--- a/meta-luneos/recipes-qt/qt6/qtwayland/0004-QWaylandDisplay-don-t-ignore-wayland-QT_IM_MODULE.patch
+++ b/meta-luneos/recipes-qt/qt6/qtwayland/0004-QWaylandDisplay-don-t-ignore-wayland-QT_IM_MODULE.patch
@@ -1,0 +1,27 @@
+From f67fe919f2e35f39826858ff0d190f95213e4e90 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 8 Apr 2023 13:46:44 +0000
+Subject: [PATCH] QWaylandDisplay: don't ignore 'wayland' QT_IM_MODULE
+
+Upstream-Status: Pending
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/client/qwaylanddisplay_p.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/client/qwaylanddisplay_p.h b/src/client/qwaylanddisplay_p.h
+index 473016f1..4234033a 100644
+--- a/src/client/qwaylanddisplay_p.h
++++ b/src/client/qwaylanddisplay_p.h
+@@ -278,7 +278,7 @@ private:
+ 
+     bool mClientSideInputContextRequested = [] () {
+         const QString& requested = QPlatformInputContextFactory::requested();
+-        return !requested.isEmpty() && requested != QLatin1String("wayland");
++        return !requested.isEmpty() /* && requested != QLatin1String("wayland") */;
+     }();
+     QStringList mTextInputManagerList;
+     int mTextInputManagerIndex = INT_MAX;
+-- 
+2.34.1
+

--- a/meta-luneos/recipes-qt/qt6/qtwayland_git.bbappend
+++ b/meta-luneos/recipes-qt/qt6/qtwayland_git.bbappend
@@ -13,6 +13,7 @@ SRC_URI:append = " \
     file://0001-Support-presentation-time-protocol.patch;maxver=6.2.* \
     file://0002-Use-scope-resolution-operator-for-request.patch;maxver=6.2.* \
     file://0003-Fix-to-have-presentation-feedback-sequence-timely.patch;maxver=6.3.1 \
+    file://0004-QWaylandDisplay-don-t-ignore-wayland-QT_IM_MODULE.patch \
 "
 
 # More options for fine-tuned configuration


### PR DESCRIPTION
webOS-OSE uses the "wayland" key name for its specific inputcontext plugin, confusing Qt about whether it is a specific request or not.

Ideally the plugin should use another key like wayland-webos, but that would have a much larger impact.