### PR TITLE
luneos-preferred-provides.inc: Fix the systemd-machine-units

### DIFF
--- a/meta-luneos/conf/distro/include/luneos-preferred-providers.inc
+++ b/meta-luneos/conf/distro/include/luneos-preferred-providers.inc
@@ -79,7 +79,7 @@ BAD_RECOMMENDATIONS:append:qemux86 = " kernel-vmlinux"
 # used by meta-networking/recipes-connectivity/autossh/autossh_1.4g.bb
 PREFERRED_RPROVIDER_ssh = "openssh"
 
-VIRTUAL-RUNTIME_init_manager = "systemd"
+VIRTUAL-RUNTIME_init_manager = "systemd systemd-compat-units systemd-machine-units"
 
 # With upstart we don't need update-rc.d, as bonus fixes following avahi issue for us:
 # http://lists.openembedded.org/pipermail/openembedded-core/2013-November/086901.html


### PR DESCRIPTION
After the OSE rebase, seems I overlooked this and it got broken, let's bring it back. Otherwise we cannot get wifi stuff to work properly on our Android targets and PT2.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
