### PR TITLE
Add meta-luneos-backports-4.3: Add newer geoclue and mesa

### DIFF
--- a/meta-luneos-backports/meta-luneos-backports-4.3/conf/layer.conf
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/conf/layer.conf
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 Herman van Hazendonk <github.com@herrie.org>
+
+# We have conf and classes directories => add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories => add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-luneos-backports-4.3"
+BBFILE_PATTERN_meta-luneos-backports-4.3 := "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-luneos-backports-4.3 = "32"
+
+LAYERSERIES_COMPAT_meta-luneos-backports-4.3 = "kirkstone"
+
+LAYERDEPENDS_meta-luneos-backports-4.3 = " \
+    core \
+    openembedded-layer \
+"

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-gallium-Fix-build-with-llvm-17.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-gallium-Fix-build-with-llvm-17.patch
@@ -1,0 +1,41 @@
+From 6d07f6aa7f92f40d78a2db645f16f0f3e7d3c2e8 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 23 Jun 2023 01:20:38 -0700
+Subject: [PATCH] gallium: Fix build with llvm 17
+
+These headers are not available for C files in llvm 17+
+and they seem to be not needed to compile after all with llvm 17
+so add conditions to exclude them for llvm >= 17
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/23827]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ src/gallium/auxiliary/gallivm/lp_bld_init.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_init.c b/src/gallium/auxiliary/gallivm/lp_bld_init.c
+index cd2108f..b1a4d03 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_init.c
++++ b/src/gallium/auxiliary/gallivm/lp_bld_init.c
+@@ -46,15 +46,19 @@
+ #if GALLIVM_USE_NEW_PASS == 1
+ #include <llvm-c/Transforms/PassBuilder.h>
+ #elif GALLIVM_HAVE_CORO == 1
++#if LLVM_VERSION_MAJOR < 17
+ #include <llvm-c/Transforms/Scalar.h>
+-#if LLVM_VERSION_MAJOR >= 7
++#endif
++#if LLVM_VERSION_MAJOR >= 7 && LLVM_VERSION_MAJOR < 17
+ #include <llvm-c/Transforms/Utils.h>
+ #endif
+ #if LLVM_VERSION_MAJOR <= 8 && (DETECT_ARCH_AARCH64 || DETECT_ARCH_ARM || DETECT_ARCH_S390 || DETECT_ARCH_MIPS64)
+ #include <llvm-c/Transforms/IPO.h>
+ #endif
++#if LLVM_VERSION_MAJOR < 17
+ #include <llvm-c/Transforms/Coroutines.h>
+ #endif
++#endif
+ 
+ unsigned gallivm_perf = 0;
+ 

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-meson-Disable-cmake-dependency-detector-for-llvm.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-meson-Disable-cmake-dependency-detector-for-llvm.patch
@@ -1,0 +1,42 @@
+From 00d41cd5aa3f4b494dc276c9b4ccdc096310c91f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 28 Sep 2023 15:34:22 -0700
+Subject: [PATCH] meson: use llvm-config instead of cmake to fix linking errors with meson 1.2.1
+
+meson dependency auto dependency detection uses cmake and then
+config-tool to process dependencies, in mesa the logic to detect llvm is
+using auto detection which means if it finds cmake then it will try to
+use cmake method. Cmake method works ok except a case when llvm-dev
+package is installed on the build host then it generates its own
+native.meson file and ignores OE supplied meson.native file which has
+correct llvm-config tool specified which is pointing to llvm-config from
+native sysroot. The generated meson.native file points to one found in
+/usr/bin and there onwards detector finds native install of llvm and
+configures that into building native mesa package.
+
+Since cmake detector does not always work, disable it by default and use
+config-tool which works in all cases. This is suggested in below issues
+too
+
+A similar issue is open in meson upstream [1] and mesa [2]
+
+[1] https://github.com/mesonbuild/meson/issues/10483
+[2] https://gitlab.freedesktop.org/mesa/mesa/-/issues/6738
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25438]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/meson.build
++++ b/meson.build
+@@ -1659,6 +1659,7 @@ with_llvm = false
+ if _llvm.allowed()
+   dep_llvm = dependency(
+     'llvm',
++    method : host_machine.system() == 'windows' ? 'auto' : 'config-tool',
+     version : _llvm_version,
+     modules : llvm_modules,
+     optional_modules : llvm_optional_modules,

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
@@ -1,0 +1,25 @@
+From 3ef37c63f03ad6f2af407de350486fdd25e9132a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Jan 2020 15:23:47 -0800
+Subject: [PATCH] meson misdetects 64bit atomics on mips/clang
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ src/util/u_atomic.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/util/u_atomic.c b/src/util/u_atomic.c
+index 5a5eab4..e499516 100644
+--- a/src/util/u_atomic.c
++++ b/src/util/u_atomic.c
+@@ -21,7 +21,7 @@
+  * IN THE SOFTWARE.
+  */
+ 
+-#if defined(MISSING_64BIT_ATOMICS) && defined(HAVE_PTHREAD)
++#if !defined(__clang__) && defined(MISSING_64BIT_ATOMICS) && defined(HAVE_PTHREAD)
+ 
+ #include <stdint.h>
+ #include <pthread.h>

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
@@ -1,0 +1,43 @@
+From b251af67df5a6840d2e9cc06edae2c387f8778f1 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair@alistair23.me>
+Date: Thu, 14 Nov 2019 13:04:49 -0800
+Subject: [PATCH] meson.build: check for all linux host_os combinations
+
+Make sure that we are also looking for our host_os combinations like
+linux-musl etc. when assuming support for DRM/KMS.
+
+Also delete a duplicate line.
+
+Upstream-Status: Pending
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 22385d8..15f48a6 100644
+--- a/meson.build
++++ b/meson.build
+@@ -121,7 +121,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
+ # Only build shared_glapi if at least one OpenGL API is enabled
+ with_shared_glapi = with_shared_glapi and with_any_opengl
+ 
+-system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'sunos', 'android'].contains(host_machine.system())
++system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'sunos', 'android'].contains(host_machine.system()) or host_machine.system().startswith('linux')
+ 
+ gallium_drivers = get_option('gallium-drivers')
+ if gallium_drivers.contains('auto')
+@@ -909,7 +909,7 @@ if cc.has_function('fmemopen')
+ endif
+ 
+ # TODO: this is very incomplete
+-if ['linux', 'cygwin', 'gnu', 'freebsd', 'gnu/kfreebsd', 'haiku', 'android'].contains(host_machine.system())
++if ['linux', 'cygwin', 'gnu', 'freebsd', 'gnu/kfreebsd', 'haiku'].contains(host_machine.system()) or host_machine.system().startswith('linux')
+   pre_args += '-D_GNU_SOURCE'
+ elif host_machine.system() == 'sunos'
+   pre_args += '-D__EXTENSIONS__'

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/libglu_9.0.3.bb
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/libglu_9.0.3.bb
@@ -1,0 +1,31 @@
+SUMMARY = "The OpenGL utility toolkit"
+DESCRIPTION = "GLU is a utility toolkit used with OpenGL implementations"
+
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://include/GL/glu.h;endline=29;md5=6b79c570f644363b356456e7d44471d9 \
+                    file://src/libtess/tess.c;endline=29;md5=6b79c570f644363b356456e7d44471d9"
+
+# Epoch as this used to be part of mesa
+PE = "2"
+
+SRC_URI = "https://mesa.freedesktop.org/archive/glu/glu-${PV}.tar.xz \
+           "
+
+SRC_URI[sha256sum] = "bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f"
+
+S = "${WORKDIR}/glu-${PV}"
+
+DEPENDS = "virtual/libgl"
+
+inherit meson pkgconfig features_check
+
+EXTRA_OEMESON = "-Dgl_provider=gl"
+
+# Requires libGL.so which is provided by mesa when x11 in DISTRO_FEATURES
+REQUIRED_DISTRO_FEATURES = "x11 opengl"
+
+# Remove the mesa-glu dependency in mesa-glu-dev, as mesa-glu is empty
+DEV_PKG_DEPENDENCY = ""

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-demos/0001-mesa-demos-Add-missing-data-files.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-demos/0001-mesa-demos-Add-missing-data-files.patch
@@ -1,0 +1,624 @@
+From b695c3a3fa3f4cd48c13aa26542110de27075518 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew_moseley@mentor.com>
+Date: Mon, 12 May 2014 15:22:32 -0400
+Subject: [PATCH 1/9] mesa-demos: Add missing data files.
+
+Add some data files that are present in the git repository:
+   http://cgit.freedesktop.org/mesa/demos/tree/?id=mesa-demos-8.1.0
+but not in the release tarball
+   ftp://ftp.freedesktop.org/pub/mesa/demos/8.1.0/mesa-demos-8.1.0.tar.bz2
+
+Upstream-Status: Backport
+Signed-off-by: Drew Moseley <drew_moseley@mentor.com>
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+ src/fpglsl/depth-read.glsl      |   4 +
+ src/fpglsl/infinite-loop.glsl   |   7 +
+ src/glsl/CH11-bumpmaptex.frag   |  47 +++++++
+ src/glsl/blinking-teapot.frag   |  31 +++++
+ src/glsl/blinking-teapot.vert   |  16 +++
+ src/glsl/convolution.frag       |  21 +++
+ src/glsl/simplex-noise.glsl     | 279 ++++++++++++++++++++++++++++++++++++++++
+ src/glsl/skinning.vert          |  24 ++++
+ src/perf/glslstateschange1.frag |  19 +++
+ src/perf/glslstateschange1.vert |  14 ++
+ src/perf/glslstateschange2.frag |  17 +++
+ src/perf/glslstateschange2.vert |  14 ++
+ src/vpglsl/infinite-loop.glsl   |   8 ++
+ 13 files changed, 501 insertions(+)
+ create mode 100644 src/fpglsl/depth-read.glsl
+ create mode 100644 src/fpglsl/infinite-loop.glsl
+ create mode 100644 src/glsl/CH11-bumpmaptex.frag
+ create mode 100644 src/glsl/blinking-teapot.frag
+ create mode 100644 src/glsl/blinking-teapot.vert
+ create mode 100644 src/glsl/convolution.frag
+ create mode 100644 src/glsl/simplex-noise.glsl
+ create mode 100644 src/glsl/skinning.vert
+ create mode 100644 src/perf/glslstateschange1.frag
+ create mode 100644 src/perf/glslstateschange1.vert
+ create mode 100644 src/perf/glslstateschange2.frag
+ create mode 100644 src/perf/glslstateschange2.vert
+ create mode 100644 src/vpglsl/infinite-loop.glsl
+
+diff --git a/src/fpglsl/depth-read.glsl b/src/fpglsl/depth-read.glsl
+new file mode 100644
+index 0000000..86d298e
+--- /dev/null
++++ b/src/fpglsl/depth-read.glsl
+@@ -0,0 +1,4 @@
++void main()
++{
++   gl_FragColor = gl_FragCoord.zzzz;
++}
+diff --git a/src/fpglsl/infinite-loop.glsl b/src/fpglsl/infinite-loop.glsl
+new file mode 100644
+index 0000000..c6dc6ee
+--- /dev/null
++++ b/src/fpglsl/infinite-loop.glsl
+@@ -0,0 +1,7 @@
++void main() {
++   vec4 sum = vec4(0);
++   for (int i = 1; i != 2; i += 2) {
++      sum += vec4(0.1, 0.1, 0.1, 0.1);
++   }
++   gl_FragColor = sum;
++}
+diff --git a/src/glsl/CH11-bumpmaptex.frag b/src/glsl/CH11-bumpmaptex.frag
+new file mode 100644
+index 0000000..b5dabb4
+--- /dev/null
++++ b/src/glsl/CH11-bumpmaptex.frag
+@@ -0,0 +1,47 @@
++//
++// Fragment shader for procedural bumps
++//
++// Authors: John Kessenich, Randi Rost
++//
++// Copyright (c) 2002-2006 3Dlabs Inc. Ltd. 
++//
++// See 3Dlabs-License.txt for license information
++//
++// Texture mapping/modulation added by Brian Paul
++//
++
++varying vec3 LightDir;
++varying vec3 EyeDir;
++
++uniform float BumpDensity;     // = 16.0
++uniform float BumpSize;        // = 0.15
++uniform float SpecularFactor;  // = 0.5
++
++uniform sampler2D Tex;
++
++void main()
++{
++    vec3 ambient = vec3(0.25);
++    vec3 litColor;
++    vec2 c = BumpDensity * gl_TexCoord[0].st;
++    vec2 p = fract(c) - vec2(0.5);
++
++    float d, f;
++    d = p.x * p.x + p.y * p.y;
++    f = inversesqrt(d + 1.0);
++
++    if (d >= BumpSize)
++        { p = vec2(0.0); f = 1.0; }
++
++    vec3 SurfaceColor = texture2D(Tex, gl_TexCoord[0].st).xyz;
++
++    vec3 normDelta = vec3(p.x, p.y, 1.0) * f;
++    litColor = SurfaceColor * (ambient + max(dot(normDelta, LightDir), 0.0));
++    vec3 reflectDir = reflect(LightDir, normDelta);
++    
++    float spec = max(dot(EyeDir, reflectDir), 0.0);
++    spec *= SpecularFactor;
++    litColor = min(litColor + spec, vec3(1.0));
++
++    gl_FragColor = vec4(litColor, 1.0);
++}
+diff --git a/src/glsl/blinking-teapot.frag b/src/glsl/blinking-teapot.frag
+new file mode 100644
+index 0000000..0db060b
+--- /dev/null
++++ b/src/glsl/blinking-teapot.frag
+@@ -0,0 +1,31 @@
++#extension GL_ARB_uniform_buffer_object : enable
++
++layout(std140) uniform colors0
++{
++    float DiffuseCool;
++    float DiffuseWarm;
++    vec3  SurfaceColor;
++    vec3  WarmColor;
++    vec3  CoolColor;
++    vec4  some[8];
++};
++
++varying float NdotL;
++varying vec3  ReflectVec;
++varying vec3  ViewVec;
++
++void main (void)
++{
++
++    vec3 kcool    = min(CoolColor + DiffuseCool * SurfaceColor, 1.0);
++    vec3 kwarm    = min(WarmColor + DiffuseWarm * SurfaceColor, 1.0);
++    vec3 kfinal   = mix(kcool, kwarm, NdotL);
++
++    vec3 nreflect = normalize(ReflectVec);
++    vec3 nview    = normalize(ViewVec);
++
++    float spec    = max(dot(nreflect, nview), 0.0);
++    spec          = pow(spec, 32.0);
++
++    gl_FragColor = vec4 (min(kfinal + spec, 1.0), 1.0);
++}
+diff --git a/src/glsl/blinking-teapot.vert b/src/glsl/blinking-teapot.vert
+new file mode 100644
+index 0000000..397d733
+--- /dev/null
++++ b/src/glsl/blinking-teapot.vert
+@@ -0,0 +1,16 @@
++vec3 LightPosition = vec3(0.0, 10.0, 4.0); 
++ 
++varying float NdotL;
++varying vec3  ReflectVec;
++varying vec3  ViewVec;
++ 
++void main(void)
++{
++    vec3 ecPos      = vec3 (gl_ModelViewMatrix * gl_Vertex);
++    vec3 tnorm      = normalize(gl_NormalMatrix * gl_Normal);
++    vec3 lightVec   = normalize(LightPosition - ecPos);
++    ReflectVec      = normalize(reflect(-lightVec, tnorm));
++    ViewVec         = normalize(-ecPos);
++    NdotL           = (dot(lightVec, tnorm) + 1.0) * 0.5;
++    gl_Position     = ftransform();
++}
+diff --git a/src/glsl/convolution.frag b/src/glsl/convolution.frag
+new file mode 100644
+index 0000000..e49b8ac
+--- /dev/null
++++ b/src/glsl/convolution.frag
+@@ -0,0 +1,21 @@
++
++const int KernelSize = 9;
++
++//texture offsets
++uniform vec2 Offset[KernelSize];
++//convolution kernel
++uniform vec4 KernelValue[KernelSize];
++uniform sampler2D srcTex;
++uniform vec4 ScaleFactor;
++uniform vec4 BaseColor;
++
++void main(void)
++{
++    int i;
++    vec4 sum = vec4(0.0);
++    for (i = 0; i < KernelSize; ++i) {
++        vec4 tmp = texture2D(srcTex, gl_TexCoord[0].st + Offset[i]);
++        sum += tmp * KernelValue[i];
++    }
++    gl_FragColor = sum * ScaleFactor + BaseColor;
++}
+diff --git a/src/glsl/simplex-noise.glsl b/src/glsl/simplex-noise.glsl
+new file mode 100644
+index 0000000..b6833cb
+--- /dev/null
++++ b/src/glsl/simplex-noise.glsl
+@@ -0,0 +1,279 @@
++//
++// Description : Array and textureless GLSL 2D/3D/4D simplex
++// noise functions.
++// Author : Ian McEwan, Ashima Arts.
++// Maintainer : ijm
++// Lastmod : 20110223
++// License : Copyright (C) 2011 Ashima Arts. All rights reserved.
++// Distributed under the Artistic License 2.0; See LICENCE file.
++//
++
++#define NORMALIZE_GRADIENTS
++#undef USE_CIRCLE
++#define COLLAPSE_SORTNET
++
++float permute(float x0,vec3 p) {
++  float x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++vec2 permute(vec2 x0,vec3 p) {
++  vec2 x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++vec3 permute(vec3 x0,vec3 p) {
++  vec3 x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++vec4 permute(vec4 x0,vec3 p) {
++  vec4 x1 = mod(x0 * p.y, p.x);
++  return floor( mod( (x1 + p.z) *x0, p.x ));
++  }
++
++uniform vec4 pParam;
++// Example
++// const vec4 pParam = vec4( 17.* 17., 34., 1., 7.);
++
++float taylorInvSqrt(float r)
++  {
++  return ( 0.83666002653408 + 0.7*0.85373472095314 - 0.85373472095314 * r );
++  }
++
++float simplexNoise2(vec2 v)
++  {
++  const vec2 C = vec2(0.211324865405187134, // (3.0-sqrt(3.0))/6.;
++                      0.366025403784438597); // 0.5*(sqrt(3.0)-1.);
++  const vec3 D = vec3( 0., 0.5, 2.0) * 3.14159265358979312;
++// First corner
++  vec2 i = floor(v + dot(v, C.yy) );
++  vec2 x0 = v - i + dot(i, C.xx);
++
++// Other corners
++  vec2 i1 = (x0.x > x0.y) ? vec2(1.,0.) : vec2(0.,1.) ;
++
++   // x0 = x0 - 0. + 0. * C
++  vec2 x1 = x0 - i1 + 1. * C.xx ;
++  vec2 x2 = x0 - 1. + 2. * C.xx ;
++
++// Permutations
++  i = mod(i, pParam.x);
++  vec3 p = permute( permute(
++             i.y + vec3(0., i1.y, 1. ), pParam.xyz)
++           + i.x + vec3(0., i1.x, 1. ), pParam.xyz);
++
++#ifndef USE_CIRCLE
++// ( N points uniformly over a line, mapped onto a diamond.)
++  vec3 x = fract(p / pParam.w) ;
++  vec3 h = 0.5 - abs(x) ;
++
++  vec3 sx = vec3(lessThan(x,D.xxx)) *2. -1.;
++  vec3 sh = vec3(lessThan(h,D.xxx));
++
++  vec3 a0 = x + sx*sh;
++  vec2 p0 = vec2(a0.x,h.x);
++  vec2 p1 = vec2(a0.y,h.y);
++  vec2 p2 = vec2(a0.z,h.z);
++
++#ifdef NORMALISE_GRADIENTS
++  p0 *= taylorInvSqrt(dot(p0,p0));
++  p1 *= taylorInvSqrt(dot(p1,p1));
++  p2 *= taylorInvSqrt(dot(p2,p2));
++#endif
++
++  vec3 g = 2.0 * vec3( dot(p0, x0), dot(p1, x1), dot(p2, x2) );
++#else
++// N points around a unit circle.
++  vec3 phi = D.z * mod(p,pParam.w) /pParam.w ;
++  vec4 a0 = sin(phi.xxyy+D.xyxy);
++  vec2 a1 = sin(phi.zz +D.xy);
++  vec3 g = vec3( dot(a0.xy, x0), dot(a0.zw, x1), dot(a1.xy, x2) );
++#endif
++// mix
++  vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x1,x1), dot(x2,x2)), 0.);
++  m = m*m ;
++  return 1.66666* 70.*dot(m*m, g);
++  }
++
++float simplexNoise3(vec3 v)
++  {
++  const vec2 C = vec2(1./6. , 1./3. ) ;
++  const vec4 D = vec4(0., 0.5, 1.0, 2.0);
++
++// First corner
++  vec3 i = floor(v + dot(v, C.yyy) );
++  vec3 x0 = v - i + dot(i, C.xxx) ;
++  
++// Other corners
++#ifdef COLLAPSE_SORTNET
++  vec3 g = vec3( greaterThan( x0.xyz, x0.yzx) );
++  vec3 l = vec3( lessThanEqual( x0.xyz, x0.yzx) );
++
++  vec3 i1 = g.xyz * l.zxy;
++  vec3 i2 = max( g.xyz, l.zxy);
++#else
++// Keeping this clean - let the compiler optimize.
++  vec3 q1;
++  q1.x = max(x0.x, x0.y);
++  q1.y = min(x0.x, x0.y);
++  q1.z = x0.z;
++
++  vec3 q2;
++  q2.x = max(q1.x,q1.z);
++  q2.z = min(q1.x,q1.z);
++  q2.y = q1.y;
++
++  vec3 q3;
++  q3.y = max(q2.y, q2.z);
++  q3.z = min(q2.y, q2.z);
++  q3.x = q2.x;
++
++  vec3 i1 = vec3(equal(q3.xxx, x0));
++  vec3 i2 = i1 + vec3(equal(q3.yyy, x0));
++#endif
++
++   // x0 = x0 - 0. + 0. * C
++  vec3 x1 = x0 - i1 + 1. * C.xxx;
++  vec3 x2 = x0 - i2 + 2. * C.xxx;
++  vec3 x3 = x0 - 1. + 3. * C.xxx;
++
++// Permutations
++  i = mod(i, pParam.x );
++  vec4 p = permute( permute( permute(
++             i.z + vec4(0., i1.z, i2.z, 1. ), pParam.xyz)
++           + i.y + vec4(0., i1.y, i2.y, 1. ), pParam.xyz)
++           + i.x + vec4(0., i1.x, i2.x, 1. ), pParam.xyz);
++
++// Gradients
++// ( N*N points uniformly over a square, mapped onto a octohedron.)
++  float n_ = 1.0/pParam.w ;
++  vec3 ns = n_ * D.wyz - D.xzx ;
++
++  vec4 j = p - pParam.w*pParam.w*floor(p * ns.z *ns.z); // mod(p,N*N)
++
++  vec4 x_ = floor(j * ns.z) ;
++  vec4 y_ = floor(j - pParam.w * x_ ) ; // mod(j,N)
++
++  vec4 x = x_ *ns.x + ns.yyyy;
++  vec4 y = y_ *ns.x + ns.yyyy;
++  vec4 h = 1. - abs(x) - abs(y);
++
++  vec4 b0 = vec4( x.xy, y.xy );
++  vec4 b1 = vec4( x.zw, y.zw );
++
++  vec4 s0 = vec4(lessThan(b0,D.xxxx)) *2. -1.;
++  vec4 s1 = vec4(lessThan(b1,D.xxxx)) *2. -1.;
++  vec4 sh = vec4(lessThan(h, D.xxxx));
++
++  vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
++  vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
++
++  vec3 p0 = vec3(a0.xy,h.x);
++  vec3 p1 = vec3(a0.zw,h.y);
++  vec3 p2 = vec3(a1.xy,h.z);
++  vec3 p3 = vec3(a1.zw,h.w);
++
++#ifdef NORMALISE_GRADIENTS
++  p0 *= taylorInvSqrt(dot(p0,p0));
++  p1 *= taylorInvSqrt(dot(p1,p1));
++  p2 *= taylorInvSqrt(dot(p2,p2));
++  p3 *= taylorInvSqrt(dot(p3,p3));
++#endif
++
++// Mix
++  vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.);
++  m = m * m;
++//used to be 64.
++  return 48.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
++                                dot(p2,x2), dot(p3,x3) ) );
++  }
++
++vec4 grad4(float j, vec4 ip)
++  {
++  const vec4 ones = vec4(1.,1.,1.,-1.);
++  vec4 p,s;
++
++  p.xyz = floor( fract (vec3(j) * ip.xyz) *pParam.w) * ip.z -1.0;
++  p.w = 1.5 - dot(abs(p.xyz), ones.xyz);
++  s = vec4(lessThan(p,vec4(0.)));
++  p.xyz = p.xyz + (s.xyz*2.-1.) * s.www;
++
++  return p;
++  }
++
++float simplexNoise4(vec4 v)
++  {
++  const vec2 C = vec2( 0.138196601125010504, // (5 - sqrt(5))/20 G4
++                        0.309016994374947451); // (sqrt(5) - 1)/4 F4
++// First corner
++  vec4 i = floor(v + dot(v, C.yyyy) );
++  vec4 x0 = v - i + dot(i, C.xxxx);
++
++// Other corners
++
++// Force existance of strict total ordering in sort.
++  vec4 q0 = floor(x0 * 1024.0) + vec4( 0., 1./4., 2./4. , 3./4.);
++  vec4 q1;
++  q1.xy = max(q0.xy,q0.zw); // x:z y:w
++  q1.zw = min(q0.xy,q0.zw);
++
++  vec4 q2;
++  q2.xz = max(q1.xz,q1.yw); // x:y z:w
++  q2.yw = min(q1.xz,q1.yw);
++  
++  vec4 q3;
++  q3.y = max(q2.y,q2.z); // y:z
++  q3.z = min(q2.y,q2.z);
++  q3.xw = q2.xw;
++
++  vec4 i1 = vec4(lessThanEqual(q3.xxxx, q0));
++  vec4 i2 = vec4(lessThanEqual(q3.yyyy, q0));
++  vec4 i3 = vec4(lessThanEqual(q3.zzzz, q0));
++
++   // x0 = x0 - 0. + 0. * C
++  vec4 x1 = x0 - i1 + 1. * C.xxxx;
++  vec4 x2 = x0 - i2 + 2. * C.xxxx;
++  vec4 x3 = x0 - i3 + 3. * C.xxxx;
++  vec4 x4 = x0 - 1. + 4. * C.xxxx;
++
++// Permutations
++  i = mod(i, pParam.x );
++  float j0 = permute( permute( permute( permute (
++              i.w, pParam.xyz) + i.z, pParam.xyz)
++            + i.y, pParam.xyz) + i.x, pParam.xyz);
++  vec4 j1 = permute( permute( permute( permute (
++             i.w + vec4(i1.w, i2.w, i3.w, 1. ), pParam.xyz)
++           + i.z + vec4(i1.z, i2.z, i3.z, 1. ), pParam.xyz)
++           + i.y + vec4(i1.y, i2.y, i3.y, 1. ), pParam.xyz)
++           + i.x + vec4(i1.x, i2.x, i3.x, 1. ), pParam.xyz);
++// Gradients
++// ( N*N*N points uniformly over a cube, mapped onto a 4-octohedron.)
++  vec4 ip = pParam ;
++  ip.xy *= pParam.w ;
++  ip.x *= pParam.w ;
++  ip = vec4(1.,1.,1.,2.) / ip ;
++
++  vec4 p0 = grad4(j0, ip);
++  vec4 p1 = grad4(j1.x, ip);
++  vec4 p2 = grad4(j1.y, ip);
++  vec4 p3 = grad4(j1.z, ip);
++  vec4 p4 = grad4(j1.w, ip);
++
++#ifdef NORMALISE_GRADIENTS
++  p0 *= taylorInvSqrt(dot(p0,p0));
++  p1 *= taylorInvSqrt(dot(p1,p1));
++  p2 *= taylorInvSqrt(dot(p2,p2));
++  p3 *= taylorInvSqrt(dot(p3,p3));
++  p4 *= taylorInvSqrt(dot(p4,p4));
++#endif
++
++// Mix
++  vec3 m0 = max(0.6 - vec3(dot(x0,x0), dot(x1,x1), dot(x2,x2)), 0.);
++  vec2 m1 = max(0.6 - vec2(dot(x3,x3), dot(x4,x4) ), 0.);
++  m0 = m0 * m0;
++  m1 = m1 * m1;
++  return 32. * ( dot(m0*m0, vec3( dot( p0, x0 ), dot( p1, x1 ), dot( p2, x2 )))
++               + dot(m1*m1, vec2( dot( p3, x3 ), dot( p4, x4 ) ) ) ) ;
++
++  }
++
++
++
+diff --git a/src/glsl/skinning.vert b/src/glsl/skinning.vert
+new file mode 100644
+index 0000000..28970ee
+--- /dev/null
++++ b/src/glsl/skinning.vert
+@@ -0,0 +1,24 @@
++// Vertex weighting/blendin shader
++// Brian Paul
++// 4 Nov 2008
++
++uniform mat4 mat0, mat1;
++attribute float weight;
++
++void main() 
++{
++   // simple diffuse shading
++   // Note that we should really transform the normal vector along with
++   // the postion below... someday.
++   vec3 lightVec = vec3(0, 0, 1);
++   vec3 norm = gl_NormalMatrix * gl_Normal;
++   float dot = 0.2 + max(0.0, dot(norm, lightVec));
++   gl_FrontColor = vec4(dot);
++
++   // compute sum of weighted transformations
++   vec4 pos0 = mat0 * gl_Vertex;
++   vec4 pos1 = mat1 * gl_Vertex;
++   vec4 pos = mix(pos0, pos1, weight);
++
++   gl_Position = gl_ModelViewProjectionMatrix * pos;
++}
+diff --git a/src/perf/glslstateschange1.frag b/src/perf/glslstateschange1.frag
+new file mode 100644
+index 0000000..0839436
+--- /dev/null
++++ b/src/perf/glslstateschange1.frag
+@@ -0,0 +1,19 @@
++// Multi-texture fragment shader
++// Brian Paul
++
++// Composite second texture over first.
++// We're assuming the 2nd texture has a meaningful alpha channel.
++
++uniform sampler2D tex1;
++uniform sampler2D tex2;
++uniform vec4 UniV1;
++uniform vec4 UniV2;
++
++void main()
++{
++   vec4 t3;
++   vec4 t1 = texture2D(tex1, gl_TexCoord[0].xy);
++   vec4 t2 = texture2D(tex2, gl_TexCoord[1].xy);
++   t3 = mix(t1, t2, t2.w);
++   gl_FragColor = t3 + UniV1 + UniV2;
++}
+diff --git a/src/perf/glslstateschange1.vert b/src/perf/glslstateschange1.vert
+new file mode 100644
+index 0000000..cef50db
+--- /dev/null
++++ b/src/perf/glslstateschange1.vert
+@@ -0,0 +1,14 @@
++// Multi-texture vertex shader
++// Brian Paul
++
++
++attribute vec4 TexCoord0, TexCoord1;
++attribute vec4 VertCoord;
++
++void main()
++{
++   gl_TexCoord[0] = TexCoord0;
++   gl_TexCoord[1] = TexCoord1;
++   // note: may use gl_Vertex or VertCoord here for testing:
++   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
++}
+diff --git a/src/perf/glslstateschange2.frag b/src/perf/glslstateschange2.frag
+new file mode 100644
+index 0000000..0df0319
+--- /dev/null
++++ b/src/perf/glslstateschange2.frag
+@@ -0,0 +1,17 @@
++// Multi-texture fragment shader
++// Brian Paul
++
++// Composite second texture over first.
++// We're assuming the 2nd texture has a meaningful alpha channel.
++
++uniform sampler2D tex1;
++uniform sampler2D tex2;
++uniform vec4 UniV1;
++uniform vec4 UniV2;
++
++void main()
++{
++   vec4 t1 = texture2D(tex1, gl_TexCoord[0].xy);
++   vec4 t2 = texture2D(tex2, gl_TexCoord[1].xy);
++   gl_FragColor = t1 + t2 + UniV1 + UniV2;
++}
+diff --git a/src/perf/glslstateschange2.vert b/src/perf/glslstateschange2.vert
+new file mode 100644
+index 0000000..cef50db
+--- /dev/null
++++ b/src/perf/glslstateschange2.vert
+@@ -0,0 +1,14 @@
++// Multi-texture vertex shader
++// Brian Paul
++
++
++attribute vec4 TexCoord0, TexCoord1;
++attribute vec4 VertCoord;
++
++void main()
++{
++   gl_TexCoord[0] = TexCoord0;
++   gl_TexCoord[1] = TexCoord1;
++   // note: may use gl_Vertex or VertCoord here for testing:
++   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
++}
+diff --git a/src/vpglsl/infinite-loop.glsl b/src/vpglsl/infinite-loop.glsl
+new file mode 100644
+index 0000000..bc7ae4b
+--- /dev/null
++++ b/src/vpglsl/infinite-loop.glsl
+@@ -0,0 +1,8 @@
++void main() {
++   gl_Position = gl_Vertex;
++   vec4 sum = vec4(0);
++   for (int i = 1; i != 2; i += 2) {
++      sum += vec4(0.1, 0.1, 0.1, 0.1);
++   }
++   gl_FrontColor = sum;
++}
+-- 
+2.0.0
+

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-demos/0004-Use-DEMOS_DATA_DIR-to-locate-data-files.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-demos/0004-Use-DEMOS_DATA_DIR-to-locate-data-files.patch
@@ -1,0 +1,234 @@
+From 5e10108d76a59abac21c7e540bcfd2ddaccca2cb Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew_moseley@mentor.com>
+Date: Fri, 9 May 2014 11:50:24 -0400
+Subject: [PATCH 4/9] Use DEMOS_DATA_DIR to locate data files
+
+Upstream-Status: Submitted [https://bugs.freedesktop.org/show_bug.cgi?id=78496]
+Signed-off-by: Drew Moseley <drew_moseley@mentor.com>
+---
+ src/glsl/bezier.c           |  2 +-
+ src/glsl/blinking-teapot.c  |  4 ++--
+ src/glsl/brick.c            |  4 ++--
+ src/glsl/bump.c             |  6 +++---
+ src/glsl/convolutions.c     |  2 +-
+ src/glsl/mandelbrot.c       |  4 ++--
+ src/glsl/multitex.c         |  4 ++--
+ src/glsl/simplex-noise.c    |  2 +-
+ src/glsl/skinning.c         |  4 ++--
+ src/glsl/texdemo1.c         |  8 ++++----
+ src/glsl/toyball.c          |  4 ++--
+ src/objviewer/objview.c     | 12 ++++++------
+ src/perf/glslstateschange.c |  8 ++++----
+ 13 files changed, 32 insertions(+), 32 deletions(-)
+
+diff --git a/src/glsl/bezier.c b/src/glsl/bezier.c
+index 0b56bc1..e01603d 100644
+--- a/src/glsl/bezier.c
++++ b/src/glsl/bezier.c
+@@ -13,7 +13,7 @@
+ #include "glut_wrap.h"
+ #include "shaderutil.h"
+ 
+-static const char *filename = "bezier.geom";
++static const char *filename = DEMOS_DATA_DIR "bezier.geom";
+ 
+ static GLuint fragShader;
+ static GLuint vertShader;
+diff --git a/src/glsl/blinking-teapot.c b/src/glsl/blinking-teapot.c
+index e3bf24d..7662b1f 100644
+--- a/src/glsl/blinking-teapot.c
++++ b/src/glsl/blinking-teapot.c
+@@ -63,8 +63,8 @@ init_opengl (void)
+      exit(1);
+   }     
+ 
+-  vshad_id = CompileShaderFile (GL_VERTEX_SHADER, "blinking-teapot.vert");
+-  fshad_id = CompileShaderFile (GL_FRAGMENT_SHADER, "blinking-teapot.frag");
++  vshad_id = CompileShaderFile (GL_VERTEX_SHADER, DEMOS_DATA_DIR "blinking-teapot.vert");
++  fshad_id = CompileShaderFile (GL_FRAGMENT_SHADER, DEMOS_DATA_DIR "blinking-teapot.frag");
+   prog_id = LinkShaders (vshad_id, fshad_id);
+ 
+   UseProgram (prog_id);
+diff --git a/src/glsl/brick.c b/src/glsl/brick.c
+index 3021856..fe5f190 100644
+--- a/src/glsl/brick.c
++++ b/src/glsl/brick.c
+@@ -14,8 +14,8 @@
+ #include "shaderutil.h"
+ 
+ 
+-static char *FragProgFile = "CH06-brick.frag";
+-static char *VertProgFile = "CH06-brick.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH06-brick.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH06-brick.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/glsl/bump.c b/src/glsl/bump.c
+index 59f62cd..3a1b20a 100644
+--- a/src/glsl/bump.c
++++ b/src/glsl/bump.c
+@@ -15,9 +15,9 @@
+ #include "readtex.h"
+ 
+ 
+-static char *FragProgFile = "CH11-bumpmap.frag";
+-static char *FragTexProgFile = "CH11-bumpmaptex.frag";
+-static char *VertProgFile = "CH11-bumpmap.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH11-bumpmap.frag";
++static char *FragTexProgFile = DEMOS_DATA_DIR "CH11-bumpmaptex.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH11-bumpmap.vert";
+ static char *TextureFile = DEMOS_DATA_DIR "tile.rgb";
+ 
+ /* program/shader objects */
+diff --git a/src/glsl/convolutions.c b/src/glsl/convolutions.c
+index a120cfe..9312f00 100644
+--- a/src/glsl/convolutions.c
++++ b/src/glsl/convolutions.c
+@@ -340,7 +340,7 @@ static void init(void)
+ 
+    menuInit();
+    readTexture(textureLocation);
+-   createProgram("convolution.vert", "convolution.frag");
++   createProgram(DEMOS_DATA_DIR "convolution.vert", DEMOS_DATA_DIR "convolution.frag");
+ 
+    glEnable(GL_TEXTURE_2D);
+    glClearColor(1.0, 1.0, 1.0, 1.0);
+diff --git a/src/glsl/mandelbrot.c b/src/glsl/mandelbrot.c
+index 31ede1d..ab34a0f 100644
+--- a/src/glsl/mandelbrot.c
++++ b/src/glsl/mandelbrot.c
+@@ -14,8 +14,8 @@
+ #include "shaderutil.h"
+ 
+ 
+-static char *FragProgFile = "CH18-mandel.frag";
+-static char *VertProgFile = "CH18-mandel.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH18-mandel.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH18-mandel.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/glsl/multitex.c b/src/glsl/multitex.c
+index 262ea50..546bd27 100644
+--- a/src/glsl/multitex.c
++++ b/src/glsl/multitex.c
+@@ -35,8 +35,8 @@
+ 
+ static const char *Demo = "multitex";
+ 
+-static const char *VertFile = "multitex.vert";
+-static const char *FragFile = "multitex.frag";
++static const char *VertFile = DEMOS_DATA_DIR "multitex.vert";
++static const char *FragFile = DEMOS_DATA_DIR "multitex.frag";
+ 
+ static const char *TexFiles[2] = 
+    {
+diff --git a/src/glsl/simplex-noise.c b/src/glsl/simplex-noise.c
+index 13fdd5d..885f01e 100644
+--- a/src/glsl/simplex-noise.c
++++ b/src/glsl/simplex-noise.c
+@@ -169,7 +169,7 @@ SpecialKey(int key, int x, int y)
+ static void
+ Init(void)
+ {
+-   const char *filename = "simplex-noise.glsl";
++   const char *filename = DEMOS_DATA_DIR "simplex-noise.glsl";
+    char noiseText[10000];
+    FILE *f;
+    int len;
+diff --git a/src/glsl/skinning.c b/src/glsl/skinning.c
+index bf38d77..536d475 100644
+--- a/src/glsl/skinning.c
++++ b/src/glsl/skinning.c
+@@ -20,8 +20,8 @@
+ #define M_PI 3.1415926535
+ #endif
+ 
+-static char *FragProgFile = "skinning.frag";
+-static char *VertProgFile = "skinning.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "skinning.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "skinning.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/glsl/texdemo1.c b/src/glsl/texdemo1.c
+index 6cde239..a082342 100644
+--- a/src/glsl/texdemo1.c
++++ b/src/glsl/texdemo1.c
+@@ -35,11 +35,11 @@
+ 
+ static const char *Demo = "texdemo1";
+ 
+-static const char *ReflectVertFile = "reflect.vert";
+-static const char *CubeFragFile = "cubemap.frag";
++static const char *ReflectVertFile = DEMOS_DATA_DIR "reflect.vert";
++static const char *CubeFragFile = DEMOS_DATA_DIR "cubemap.frag";
+ 
+-static const char *SimpleVertFile = "simple.vert";
+-static const char *SimpleTexFragFile = "shadowtex.frag";
++static const char *SimpleVertFile = DEMOS_DATA_DIR "simple.vert";
++static const char *SimpleTexFragFile = DEMOS_DATA_DIR "shadowtex.frag";
+ 
+ static const char *GroundImage = DEMOS_DATA_DIR "tile.rgb";
+ 
+diff --git a/src/glsl/toyball.c b/src/glsl/toyball.c
+index 5f27951..4e7e832 100644
+--- a/src/glsl/toyball.c
++++ b/src/glsl/toyball.c
+@@ -14,8 +14,8 @@
+ #include "shaderutil.h"
+ 
+ 
+-static char *FragProgFile = "CH11-toyball.frag";
+-static char *VertProgFile = "CH11-toyball.vert";
++static char *FragProgFile = DEMOS_DATA_DIR "CH11-toyball.frag";
++static char *VertProgFile = DEMOS_DATA_DIR "CH11-toyball.vert";
+ 
+ /* program/shader objects */
+ static GLuint fragShader;
+diff --git a/src/objviewer/objview.c b/src/objviewer/objview.c
+index 6def726..78a6acf 100644
+--- a/src/objviewer/objview.c
++++ b/src/objviewer/objview.c
+@@ -162,12 +162,12 @@ init_model(void)
+ static void
+ init_skybox(void)
+ {
+-   SkyboxTex = LoadSkyBoxCubeTexture("alpine_east.rgb",
+-                                     "alpine_west.rgb",
+-                                     "alpine_up.rgb",
+-                                     "alpine_down.rgb",
+-                                     "alpine_south.rgb",
+-                                     "alpine_north.rgb");
++   SkyboxTex = LoadSkyBoxCubeTexture(DEMOS_DATA_DIR "alpine_east.rgb",
++                                     DEMOS_DATA_DIR "alpine_west.rgb",
++                                     DEMOS_DATA_DIR "alpine_up.rgb",
++                                     DEMOS_DATA_DIR "alpine_down.rgb",
++                                     DEMOS_DATA_DIR "alpine_south.rgb",
++                                     DEMOS_DATA_DIR "alpine_north.rgb");
+    glmSpecularTexture(Model, SkyboxTex);
+ }
+ 
+diff --git a/src/perf/glslstateschange.c b/src/perf/glslstateschange.c
+index 7422b78..dbf8332 100644
+--- a/src/perf/glslstateschange.c
++++ b/src/perf/glslstateschange.c
+@@ -33,10 +33,10 @@
+ #include "glmain.h"
+ #include "common.h"
+ 
+-static const char *VertFile1 = "glslstateschange1.vert";
+-static const char *FragFile1 = "glslstateschange1.frag";
+-static const char *VertFile2 = "glslstateschange2.vert";
+-static const char *FragFile2 = "glslstateschange2.frag";
++static const char *VertFile1 = DEMOS_DATA_DIR "glslstateschange1.vert";
++static const char *FragFile1 = DEMOS_DATA_DIR "glslstateschange1.frag";
++static const char *VertFile2 = DEMOS_DATA_DIR "glslstateschange2.vert";
++static const char *FragFile2 = DEMOS_DATA_DIR "glslstateschange2.frag";
+ static struct uniform_info Uniforms1[] = {
+    { "tex1",  1, GL_SAMPLER_2D, { 0, 0, 0, 0 }, -1 },
+    { "tex2",  1, GL_SAMPLER_2D, { 1, 0, 0, 0 }, -1 },
+-- 
+2.0.0
+

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-demos_8.5.0.bb
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-demos_8.5.0.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Mesa demo applications"
+DESCRIPTION = "This package includes the demonstration application, such as glxgears. \
+These applications can be used for Mesa validation and benchmarking."
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+
+LICENSE = "MIT & PD"
+LIC_FILES_CHKSUM = "file://src/xdemos/glxgears.c;beginline=1;endline=20;md5=914225785450eff644a86c871d3ae00e \
+                    file://src/xdemos/glxdemo.c;beginline=1;endline=8;md5=b01d5ab1aee94d35b7efaa2ef48e1a06"
+
+SRC_URI = "https://mesa.freedesktop.org/archive/demos/${PV}/${BPN}-${PV}.tar.bz2 \
+           file://0001-mesa-demos-Add-missing-data-files.patch \
+           file://0004-Use-DEMOS_DATA_DIR-to-locate-data-files.patch \
+           "
+SRC_URI[sha256sum] = "cea2df0a80f09a30f635c4eb1a672bf90c5ddee0b8e77f4d70041668ef71aac1"
+
+inherit meson pkgconfig features_check
+# depends on virtual/egl, virtual/libgl ...
+REQUIRED_DISTRO_FEATURES = "opengl x11"
+
+EXTRA_OEMESON = "-Dwith-system-data-files=true"
+
+PACKAGECONFIG ?= "drm egl gles1 gles2 \
+                  ${@bb.utils.filter('DISTRO_FEATURES', 'x11 wayland', d)}"
+
+PACKAGECONFIG[drm] = "-Dlibdrm=enabled,-Dlibdrm=disabled,libdrm"
+PACKAGECONFIG[egl] = "-Degl=enabled,-Degl=disabled,virtual/egl"
+PACKAGECONFIG[gles1] = "-Dgles1=enabled,-Dgles1=disabled,virtual/libgles1"
+PACKAGECONFIG[gles2] = "-Dgles2=enabled,-Dgles2=disabled,virtual/libgles2"
+PACKAGECONFIG[glut] = "-Dwith-glut=${STAGING_EXECPREFIXDIR},,freeglut"
+PACKAGECONFIG[osmesa] = "-Dosmesa=enabled,-Dosmesa=disabled,"
+PACKAGECONFIG[wayland] = "-Dwayland=enabled,-Dwayland=disabled,virtual/libgl wayland wayland-native wayland-protocols"
+PACKAGECONFIG[x11] = "-Dx11=enabled,-Dx11=disabled,virtual/libx11 libglu"
+
+do_install:append() {
+	# it can be completely empty when all PACKAGECONFIG options are disabled
+	rmdir --ignore-fail-on-non-empty ${D}${bindir}
+
+	if [ -f ${D}${bindir}/clear ]; then
+		mv ${D}${bindir}/clear ${D}${bindir}/clear.mesa-demos
+	fi
+}

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-gl_23.2.1.bb
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa-gl_23.2.1.bb
@@ -1,0 +1,15 @@
+require mesa.inc
+
+SUMMARY += " (OpenGL only, no EGL/GLES)"
+
+PROVIDES = "virtual/libgl virtual/mesa"
+
+S = "${WORKDIR}/mesa-${PV}"
+
+TARGET_CFLAGS = "-I${STAGING_INCDIR}/drm"
+
+# At least one DRI rendering engine is required to build mesa.
+# When no X11 is available, use osmesa for the rendering engine.
+PACKAGECONFIG ??= "opengl gallium ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', 'osmesa', d)}"
+PACKAGECONFIG:class-target = "opengl gallium ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'x11', 'osmesa', d)}"
+

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa.inc
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa.inc
@@ -1,0 +1,363 @@
+SUMMARY = "A free implementation of the OpenGL API"
+DESCRIPTION = "Mesa is an open-source implementation of the OpenGL specification - \
+a system for rendering interactive 3D graphics.  \
+A variety of device drivers allows Mesa to be used in many different environments \
+ranging from software emulation to complete hardware acceleration for modern GPUs. \
+Mesa is used as part of the overall Direct Rendering Infrastructure and X.org \
+environment."
+
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://docs/license.rst;md5=63779ec98d78d823a9dc533a0735ef10"
+
+PE = "2"
+
+SRC_URI = "https://mesa.freedesktop.org/archive/mesa-${PV}.tar.xz \
+           file://0001-meson.build-check-for-all-linux-host_os-combinations.patch \
+           file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+           file://0001-gallium-Fix-build-with-llvm-17.patch \
+           file://0001-meson-Disable-cmake-dependency-detector-for-llvm.patch \
+"
+
+SRC_URI[sha256sum] = "64de0616fc2d801f929ab1ac2a4f16b3e2783c4309a724c8a259b20df8bbc1cc"
+
+UPSTREAM_CHECK_GITTAGREGEX = "mesa-(?P<pver>\d+(\.\d+)+)"
+
+#because we cannot rely on the fact that all apps will use pkgconfig,
+#make eglplatform.h independent of MESA_EGL_NO_X11_HEADER
+do_install:append() {
+  # sed can't find EGL/eglplatform.h as it doesn't get installed when glvnd enabled.
+  # So, check if EGL/eglplatform.h exists before running sed.
+  if ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'true', 'false', d)} && [ -f ${D}${includedir}/EGL/eglplatform.h ]; then
+      sed -i -e 's/^#elif defined(__unix__) && defined(EGL_NO_X11)$/#elif defined(__unix__) \&\& defined(EGL_NO_X11) || ${@bb.utils.contains('PACKAGECONFIG', 'x11', '0', '1', d)}/' ${D}${includedir}/EGL/eglplatform.h
+  fi
+}
+
+DEPENDS = "expat makedepend-native flex-native bison-native libxml2-native zlib chrpath-replacement-native python3-mako-native gettext-native"
+DEPENDS:append:class-target = " ${@bb.utils.contains('PACKAGECONFIG', 'opencl', 'mesa-native', '', d)}"
+EXTRANATIVEPATH += "chrpath-native"
+PROVIDES = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'opengl', 'virtual/libgl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'glvnd', 'virtual/libglx', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gles', 'virtual/libgles1 virtual/libgles2 virtual/libgles3', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'virtual/egl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gbm', 'virtual/libgbm', '', d)} \
+    virtual/mesa \
+    "
+
+inherit meson pkgconfig python3native gettext features_check
+
+BBCLASSEXTEND = "native nativesdk"
+
+ANY_OF_DISTRO_FEATURES = "opengl vulkan"
+
+PLATFORMS ??= "${@bb.utils.filter('PACKAGECONFIG', 'x11 wayland', d)}"
+
+# set the MESA_BUILD_TYPE to either 'release' (default) or 'debug'
+# by default the upstream mesa sources build a debug release
+# here we assume the user will want a release build by default
+MESA_BUILD_TYPE ?= "release"
+def check_buildtype(d):
+    _buildtype = d.getVar('MESA_BUILD_TYPE')
+    if _buildtype not in ['release', 'debug']:
+        bb.fatal("unknown build type (%s), please set MESA_BUILD_TYPE to either 'release' or 'debug'" % _buildtype)
+    if _buildtype == 'debug':
+        return 'debugoptimized'
+    return 'plain'
+MESON_BUILDTYPE = "${@check_buildtype(d)}"
+
+EXTRA_OEMESON = " \
+    -Dshared-glapi=enabled \
+    -Dglx-read-only-text=true \
+    -Dplatforms='${@",".join("${PLATFORMS}".split())}' \
+"
+
+EXTRA_OEMESON:append:class-target = " ${@bb.utils.contains('PACKAGECONFIG', 'opencl', '-Dintel-clc=system', '', d)}"
+EXTRA_OEMESON:append:class-native = " ${@bb.utils.contains('PACKAGECONFIG', 'opencl', '-Dintel-clc=enabled', '', d)}"
+
+def strip_comma(s):
+    return s.strip(',')
+
+PACKAGECONFIG = " \
+	gallium \
+	${@bb.utils.filter('DISTRO_FEATURES', 'x11 vulkan wayland', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm virgl', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'dri3', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'x11 vulkan', 'dri3', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'zink', '', d)} \
+	${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'video-codecs', '', d)} \
+"
+
+PACKAGECONFIG:append:class-native = "gallium-llvm r600"
+
+# "gbm" requires "opengl"
+PACKAGECONFIG[gbm] = "-Dgbm=enabled,-Dgbm=disabled"
+
+X11_DEPS = "xorgproto virtual/libx11 libxext libxxf86vm libxdamage libxfixes xrandr"
+# "x11" requires "opengl"
+PACKAGECONFIG[x11] = ",-Dglx=disabled,${X11_DEPS}"
+PACKAGECONFIG[wayland] = ",,wayland-native wayland libdrm wayland-protocols"
+
+PACKAGECONFIG[dri3] = "-Ddri3=enabled, -Ddri3=disabled, xorgproto libxshmfence"
+
+# Vulkan drivers need dri3 enabled
+# amd could be enabled as well but requires gallium-llvm with llvm >= 3.9
+VULKAN_DRIVERS = ""
+VULKAN_DRIVERS:append:x86 = ",intel"
+VULKAN_DRIVERS:append:x86-64 = ",intel"
+# i686 is a 32 bit override for mesa-native
+VULKAN_DRIVERS:append:i686 = ",intel"
+VULKAN_DRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+VULKAN_DRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'broadcom', ',broadcom', '', d)}"
+VULKAN_DRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'gallium-llvm', ',swrast', '', d)}"
+PACKAGECONFIG[vulkan] = "-Dvulkan-drivers=${@strip_comma('${VULKAN_DRIVERS}')}, -Dvulkan-drivers='',glslang-native vulkan-loader vulkan-headers"
+
+# mesa development and testing tools support, per driver
+TOOLS = ""
+TOOLS_DEPS = ""
+TOOLS:append = "${@bb.utils.contains('PACKAGECONFIG', 'etnaviv', ',etnaviv', '', d)}"
+TOOLS:append = "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+TOOLS:append = "${@bb.utils.contains('PACKAGECONFIG', 'lima', ',lima', '', d)}"
+TOOLS:append = "${@bb.utils.contains('PACKAGECONFIG', 'panfrost', ',panfrost', '', d)}"
+
+# dependencies for tools.
+TOOLS_DEPS:append = "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ' ncurses libxml2 ', '', d)}"
+
+# the fdperf tool requires libconfig (a part of meta-oe) so it needs special
+# treatment in addition to the usual 'freedreno tools'.
+PACKAGECONFIG[freedreno-fdperf] = ",,libconfig"
+
+PACKAGECONFIG[tools] = "-Dtools=${@strip_comma('${TOOLS}')}, -Dtools='', ${TOOLS_DEPS}"
+
+PACKAGECONFIG[opengl] = "-Dopengl=true, -Dopengl=false"
+PACKAGECONFIG[glvnd] = "-Dglvnd=true, -Dglvnd=false, libglvnd"
+
+# "gles" requires "opengl"
+PACKAGECONFIG[gles] = "-Dgles1=enabled -Dgles2=enabled, -Dgles1=disabled -Dgles2=disabled"
+
+# "egl" requires "opengl"
+PACKAGECONFIG[egl] = "-Degl=enabled, -Degl=disabled"
+
+# "opencl" requires libclc from meta-clang and spirv-tools from OE-Core
+OPENCL_NATIVE = "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', '-Dopencl-native=true', '', d)}"
+PACKAGECONFIG[opencl] = "-Dgallium-opencl=icd -Dopencl-spirv=true ${OPENCL_NATIVE},-Dgallium-opencl=disabled -Dopencl-spirv=false,libclc spirv-tools python3-ply-native"
+
+PACKAGECONFIG[broadcom] = ""
+PACKAGECONFIG[etnaviv] = ""
+PACKAGECONFIG[freedreno] = ""
+PACKAGECONFIG[kmsro] = ""
+PACKAGECONFIG[vc4] = ""
+PACKAGECONFIG[v3d] = ""
+PACKAGECONFIG[zink] = ""
+
+GALLIUMDRIVERS = "swrast"
+# gallium swrast was found to crash Xorg on startup in x32 qemu
+GALLIUMDRIVERS:x86-x32 = ""
+GALLIUMDRIVERS:append:x86 = ",i915,iris,crocus"
+GALLIUMDRIVERS:append:x86-64 = ",i915,iris,crocus"
+# i686 is a 32 bit override for mesa-native
+GALLIUMDRIVERS:append:i686 = ",i915,iris,crocus"
+
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'etnaviv', ',etnaviv', '', d)}"
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'kmsro', ',kmsro', '', d)}"
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'vc4', ',vc4', '', d)}"
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'v3d', ',v3d', '', d)}"
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'zink', ',zink', '', d)}"
+
+# radeonsi requires LLVM
+GALLIUMDRIVERS_RADEONSI = "${@bb.utils.contains('PACKAGECONFIG', 'r600', ',radeonsi', '', d)}"
+GALLIUMDRIVERS_LLVM = ",r300,nouveau${GALLIUMDRIVERS_RADEONSI}"
+GALLIUMDRIVERS_LLVM:append:x86 = ",svga"
+GALLIUMDRIVERS_LLVM:append:x86-64 = ",svga"
+# i686 is a 32 bit override for mesa-native
+GALLIUMDRIVERS_LLVM:append:i686 = ",svga"
+
+PACKAGECONFIG[r600] = ""
+PACKAGECONFIG[virgl] = ""
+
+GALLIUMDRIVERS:append = "${@bb.utils.contains('PACKAGECONFIG', 'gallium-llvm', '${GALLIUMDRIVERS_LLVM}', '', d)}"
+GALLIUMDRIVERS:append = "${@bb.utils.contains('PACKAGECONFIG', 'r600', ',r600', '', d)}"
+GALLIUMDRIVERS:append = "${@bb.utils.contains('PACKAGECONFIG', 'virgl', ',virgl', '', d)}"
+
+PACKAGECONFIG[gallium] = "-Dgallium-drivers=${@strip_comma('${GALLIUMDRIVERS}')}, -Dgallium-drivers='', libdrm"
+PACKAGECONFIG[gallium-llvm] = "-Dllvm=enabled -Dshared-llvm=enabled, -Dllvm=disabled, llvm llvm-native elfutils"
+PACKAGECONFIG[xa]  = "-Dgallium-xa=enabled, -Dgallium-xa=disabled"
+PACKAGECONFIG[va] = "-Dgallium-va=enabled,-Dgallium-va=disabled,libva-initial"
+PACKAGECONFIG[vdpau] = "-Dgallium-vdpau=enabled,-Dgallium-vdpau=disabled,libvdpau"
+
+PACKAGECONFIG[lima] = ""
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'lima', ',lima', '', d)}"
+
+PACKAGECONFIG[panfrost] = ""
+GALLIUMDRIVERS:append ="${@bb.utils.contains('PACKAGECONFIG', 'panfrost', ',panfrost', '', d)}"
+
+PACKAGECONFIG[vulkan-beta] = "-Dvulkan-beta=true,-Dvulkan-beta=false"
+
+PACKAGECONFIG[osmesa] = "-Dosmesa=true,-Dosmesa=false"
+
+PACKAGECONFIG[perfetto] = "-Dperfetto=true,-Dperfetto=false,libperfetto"
+
+PACKAGECONFIG[unwind] = "-Dlibunwind=enabled,-Dlibunwind=disabled,libunwind"
+
+PACKAGECONFIG[lmsensors] = "-Dlmsensors=enabled,-Dlmsensors=disabled,lmsensors"
+
+VIDEO_CODECS = "vc1dec,h264dec,h264enc,h265dec,h265enc"
+PACKAGECONFIG[video-codecs] = "-Dvideo-codecs=${@strip_comma('${VIDEO_CODECS}')}, -Dvideo-codecs=''"
+
+# llvmpipe is slow if compiled with -fomit-frame-pointer (e.g. -O2)
+FULL_OPTIMIZATION:append = " -fno-omit-frame-pointer"
+
+CFLAGS:append:armv5 = " -DMISSING_64BIT_ATOMICS"
+CFLAGS:append:armv6 = " -DMISSING_64BIT_ATOMICS"
+
+# Remove the mesa dependency on mesa-dev, as mesa is empty
+DEV_PKG_DEPENDENCY = ""
+
+# Khronos documentation says that include/GLES2/gl2ext.h can be used for
+# OpenGL ES 3 specification as well as for OpenGL ES 2.
+# There can be applications including GLES2/gl2ext.h instead of GLES3/gl3ext.h
+# meaning we should probably bring in GLES2/gl2ext.h if someone asks for
+# development package of libgles3.
+RDEPENDS:libgles3-mesa-dev += "libgles2-mesa-dev"
+
+RDEPENDS:libopencl-mesa += "${@bb.utils.contains('PACKAGECONFIG', 'opencl', 'libclc spirv-tools', '', d)}"
+
+PACKAGES =+ "libegl-mesa libegl-mesa-dev \
+             libosmesa libosmesa-dev \
+             libgl-mesa libgl-mesa-dev \
+             libglx-mesa libglx-mesa-dev \
+             libglapi libglapi-dev \
+             libgbm libgbm-dev \
+             libgles1-mesa libgles1-mesa-dev \
+             libgles2-mesa libgles2-mesa-dev \
+             libgles3-mesa libgles3-mesa-dev \
+             libopencl-mesa libopencl-mesa-dev \
+             libxatracker libxatracker-dev \
+             mesa-megadriver mesa-vulkan-drivers \
+             mesa-vdpau-drivers mesa-tools \
+            "
+
+do_install:append () {
+    # Drivers never need libtool .la files
+    rm -f ${D}${libdir}/dri/*.la
+    rm -f ${D}${libdir}/egl/*.la
+    rm -f ${D}${libdir}/gallium-pipe/*.la
+    rm -f ${D}${libdir}/gbm/*.la
+
+    # libwayland-egl has been moved to wayland 1.15+
+    rm -f ${D}${libdir}/libwayland-egl*
+    rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+}
+
+do_install:append:class-native () {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'opencl', 'true', 'false', d)}; then
+        install -d ${D}${bindir}
+        install -m0755 ${B}/src/intel/compiler/intel_clc ${D}${bindir}
+    fi
+}
+
+# For the packages that make up the OpenGL interfaces, inject variables so that
+# they don't get Debian-renamed (which would remove the -mesa suffix), and
+# RPROVIDEs/RCONFLICTs on the generic libgl name.
+python __anonymous() {
+    pkgconfig = (d.getVar('PACKAGECONFIG') or "").split()
+    suffix = ""
+    if "-native" in d.getVar("PN"):
+        suffix = "-native"
+    for p in (("egl", "libegl", "libegl1"),
+              ("opengl", "libgl", "libgl1"),
+              ("glvnd", "libglx",),
+              ("gles", "libgles1", "libglesv1-cm1"),
+              ("gles", "libgles2", "libglesv2-2"),
+              ("gles", "libgles3",),
+              ("opencl", "libopencl",)):
+        if not p[0] in pkgconfig:
+            continue
+        mlprefix = d.getVar("MLPREFIX")
+        fullp = mlprefix + p[1] + "-mesa" + suffix
+        mlprefix = d.getVar("MLPREFIX")
+        pkgs = " " + " ".join(mlprefix + x + suffix for x in p[1:])
+        d.setVar("DEBIAN_NOAUTONAME:" + fullp, "1")
+        d.appendVar("RREPLACES:" + fullp, pkgs)
+        d.appendVar("RPROVIDES:" + fullp, pkgs)
+        d.appendVar("RCONFLICTS:" + fullp, pkgs)
+
+        d.appendVar("RRECOMMENDS:" + fullp, " ${MLPREFIX}mesa-megadriver" + suffix)
+
+        # For -dev, the first element is both the Debian and original name
+        fullp = mlprefix + p[1] + "-mesa-dev" + suffix
+        pkgs = " " + mlprefix + p[1] + "-dev" + suffix
+        d.setVar("DEBIAN_NOAUTONAME:" + fullp, "1")
+        d.appendVar("RREPLACES:" + fullp, pkgs)
+        d.appendVar("RPROVIDES:" + fullp, pkgs)
+        d.appendVar("RCONFLICTS:" + fullp, pkgs)
+}
+
+python mesa_populate_packages() {
+    pkgs = ['mesa', 'mesa-dev', 'mesa-dbg']
+    for pkg in pkgs:
+        d.setVar("RPROVIDES:%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+        d.setVar("RCONFLICTS:%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+        d.setVar("RREPLACES:%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+
+    import re
+    dri_drivers_root = oe.path.join(d.getVar('PKGD'), d.getVar('libdir'), "dri")
+    if os.path.isdir(dri_drivers_root):
+        dri_pkgs = sorted(os.listdir(dri_drivers_root))
+        lib_name = d.expand("${MLPREFIX}mesa-megadriver")
+        for p in dri_pkgs:
+            m = re.match(r'^(.*)_dri\.so$', p)
+            if m:
+                pkg_name = " ${MLPREFIX}mesa-driver-%s" % legitimize_package_name(m.group(1))
+                d.appendVar("RPROVIDES:%s" % lib_name, pkg_name)
+                d.appendVar("RCONFLICTS:%s" % lib_name, pkg_name)
+                d.appendVar("RREPLACES:%s" % lib_name, pkg_name)
+
+    pipe_drivers_root = os.path.join(d.getVar('libdir'), "gallium-pipe")
+    do_split_packages(d, pipe_drivers_root, r'^pipe_(.*)\.so$', 'mesa-driver-pipe-%s', 'Mesa %s pipe driver', extra_depends='')
+}
+
+PACKAGESPLITFUNCS =+ "mesa_populate_packages"
+
+PACKAGES_DYNAMIC += "^mesa-driver-.*"
+PACKAGES_DYNAMIC:class-native = "^mesa-driver-.*-native"
+
+FILES:mesa-megadriver = "${libdir}/dri/* ${datadir}/drirc.d"
+FILES:mesa-vulkan-drivers = "${libdir}/libvulkan_*.so ${datadir}/vulkan"
+FILES:${PN}-vdpau-drivers = "${libdir}/vdpau/*.so.*"
+FILES:libegl-mesa = "${libdir}/libEGL*.so.* ${datadir}/glvnd/egl_vendor.d"
+FILES:libgbm = "${libdir}/libgbm.so.*"
+FILES:libgles1-mesa = "${libdir}/libGLESv1*.so.*"
+FILES:libgles2-mesa = "${libdir}/libGLESv2.so.*"
+FILES:libgl-mesa = "${libdir}/libGL.so.*"
+FILES:libglx-mesa = "${libdir}/libGLX*.so.*"
+FILES:libopencl-mesa = "${libdir}/libMesaOpenCL.so.* ${libdir}/gallium-pipe/*.so ${sysconfdir}/OpenCL/vendors/mesa.icd"
+FILES:libglapi = "${libdir}/libglapi.so.*"
+FILES:libosmesa = "${libdir}/libOSMesa.so.*"
+FILES:libxatracker = "${libdir}/libxatracker.so.*"
+
+FILES:${PN}-dev = "${libdir}/pkgconfig/dri.pc ${includedir}/vulkan ${libdir}/vdpau/*.so"
+FILES:libegl-mesa-dev = "${libdir}/libEGL*.* ${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
+FILES:libgbm-dev = "${libdir}/libgbm.* ${libdir}/pkgconfig/gbm.pc ${includedir}/gbm.h"
+FILES:libgl-mesa-dev = "${libdir}/libGL.* ${includedir}/GL ${libdir}/pkgconfig/gl.pc"
+FILES:libglx-mesa-dev = "${libdir}/libGLX*.*"
+FILES:libglapi-dev = "${libdir}/libglapi.*"
+FILES:libgles1-mesa-dev = "${libdir}/libGLESv1*.* ${includedir}/GLES ${libdir}/pkgconfig/glesv1*.pc"
+FILES:libgles2-mesa-dev = "${libdir}/libGLESv2.* ${includedir}/GLES2 ${libdir}/pkgconfig/glesv2.pc"
+FILES:libgles3-mesa-dev = "${includedir}/GLES3"
+FILES:libopencl-mesa-dev = "${libdir}/libMesaOpenCL.so"
+FILES:libosmesa-dev = "${libdir}/libOSMesa.* ${includedir}/GL/osmesa.h ${libdir}/pkgconfig/osmesa.pc"
+FILES:libxatracker-dev = "${libdir}/libxatracker.so ${libdir}/libxatracker.la \
+                          ${includedir}/xa_tracker.h ${includedir}/xa_composite.h ${includedir}/xa_context.h \
+                          ${libdir}/pkgconfig/xatracker.pc"
+# catch all to get all the tools and data
+FILES:${PN}-tools = "${bindir} ${datadir}"
+ALLOW_EMPTY:${PN}-tools = "1"
+
+# Fix upgrade path from mesa to mesa-megadriver
+RREPLACES:mesa-megadriver = "mesa"
+RCONFLICTS:mesa-megadriver = "mesa"
+RPROVIDES:mesa-megadriver = "mesa"

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa_23.2.1.bb
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-graphics/mesa/mesa_23.2.1.bb
@@ -1,0 +1,2 @@
+require ${BPN}.inc
+

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue/0001-Use-google-as-default-and-add-api-key.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue/0001-Use-google-as-default-and-add-api-key.patch
@@ -1,0 +1,32 @@
+From 68cfdbff39ab803d375c22bc9d9b4c582c8115a6 Mon Sep 17 00:00:00 2001
+From: Herrie <github.com@herrie.org>
+Date: Sun, 28 Feb 2016 11:39:16 +0100
+Subject: [PATCH] Use Google as default and add API key
+
+Upstream-Status: Pending
+---
+ data/geoclue.conf.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/data/geoclue.conf.in b/data/geoclue.conf.in
+index fb111de..1c56495 100644
+--- a/data/geoclue.conf.in
++++ b/data/geoclue.conf.in
+@@ -44,7 +44,7 @@ enable=true
+ 
+ # URL to the wifi geolocation service. The key can currenty be anything, just
+ # needs to be present but that is likely going to change in future.
+-url=https://location.services.mozilla.com/v1/geolocate?key=geoclue
++#url=https://location.services.mozilla.com/v1/geolocate?key=geoclue
+ 
+ # To use the Google geolocation service instead of mozilla's, simply uncomment
+ # this url while changing API_KEY to your Google API key and comment out or
+@@ -55,7 +55,7 @@ url=https://location.services.mozilla.com/v1/geolocate?key=geoclue
+ #
+ # https://developers.google.com/maps/documentation/geolocation/policies
+ #
+-#url=https://www.googleapis.com/geolocation/v1/geolocate?key=YOUR_KEY
++url=https://www.googleapis.com/geolocation/v1/geolocate?key=AIzaSyBSTvlMEfLkRzgdZbqhv7PsA2MulWjgYNs
+ 
+ # Submit data to Mozilla Location Service
+ # If set to true, geoclue will automatically submit network data to Mozilla

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue/0001-libgeoclue-don-t-try-to-use-g-ir-scanner-when-intros.patch
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue/0001-libgeoclue-don-t-try-to-use-g-ir-scanner-when-intros.patch
@@ -1,0 +1,30 @@
+From 6c434bdd31d674f85a82cb83248571813c7a37ff Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Wed, 3 May 2023 18:06:46 +0200
+Subject: [PATCH] libgeoclue: don't try to use g-ir-scanner when introspection
+ isn't enabled
+
+* it finds target g-ir-scanner, so gir is found(), but when it tries to call it, it fails:
+  http://errors.yoctoproject.org/Errors/Details/702778/
+  geoclue/2.7.0-r0/recipe-sysroot/usr/bin/g-ir-scanner-wrapper: line 5: g-ir-scanner: command not found
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+---
+Upstream-Status: Pending
+
+ libgeoclue/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libgeoclue/meson.build b/libgeoclue/meson.build
+index 5f05dad..7ed06a1 100644
+--- a/libgeoclue/meson.build
++++ b/libgeoclue/meson.build
+@@ -77,7 +77,7 @@ gir_sources = [ libgeoclue_sources,
+                 libgeoclue_headers,
+                 libgeoclue_public_api_gen_sources[1] ]
+ 
+-if gir.found()
++if gir.found() and get_option('introspection')
+   geo_gir = gnome.generate_gir(libgeoclue,
+                                sources: gir_sources,
+                                namespace: 'Geoclue',

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue_%.bbappend
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+#SRC_URI += "file://0001-Use-google-as-default-and-add-api-key.patch"
+
+# Avoid putting a dependency on modemmanager
+PACKAGECONFIG = "nmea lib"
+
+EXTRA_OEMESON += " \
+    -Ddbus-sys-dir=${sysconfdir}/dbus-1/system.d \
+    -Ddemo-agent=true \
+"
+
+DEPENDS += "libnotify"

--- a/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue_2.7.1.bb
+++ b/meta-luneos-backports/meta-luneos-backports-4.3/recipes-navigation/geoclue/geoclue_2.7.1.bb
@@ -1,0 +1,61 @@
+SUMMARY = "The Geolocation Service"
+DESCRIPTION = "Geoclue is a D-Bus service that provides location information. \
+The primary goal of the Geoclue project is to make creating location-aware applications \
+as simple as possible, while the secondary goal is to ensure that no application \
+can access location information without explicit permission from user."
+LICENSE = "GPL-2.0-or-later"
+SECTION = "console/network"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=bdfdd4986a0853eb84eeba85f9d0c4d6"
+
+DEPENDS = "glib-2.0 dbus json-glib libsoup-3.0 intltool-native"
+
+inherit meson pkgconfig gtk-doc gobject-introspection vala useradd
+
+SRCREV = "8a24f60969d4c235d9918796c38a6a9c42e10131"
+SRC_URI = "git://gitlab.freedesktop.org/geoclue/geoclue.git;protocol=https;branch=master \
+    file://0001-libgeoclue-don-t-try-to-use-g-ir-scanner-when-intros.patch \
+"
+
+S = "${WORKDIR}/git"
+
+# Without this line, package is declared a library and named libgeoclue*
+AUTO_LIBNAME_PKGS = ""
+
+PACKAGECONFIG ??= "3g modem-gps cdma nmea lib"
+PACKAGECONFIG[3g] = "-D3g-source=true,-D3g-source=false,modemmanager"
+PACKAGECONFIG[modem-gps] = "-Dmodem-gps-source=true,-Dmodem-gps-source=false,modemmanager"
+PACKAGECONFIG[cdma] = "-Dcdma-source=true,-Dcdma-source=false,modemmanager"
+PACKAGECONFIG[nmea] = "-Dnmea-source=true,-Dnmea-source=false,avahi,avahi-daemon"
+PACKAGECONFIG[lib] = "-Dlibgeoclue=true,-Dlibgeoclue=false"
+
+GTKDOC_MESON_OPTION = "gtk-doc"
+
+EXTRA_OEMESON += " \
+    -Ddbus-sys-dir=${sysconfdir}/dbus-1/system.d \
+    -Ddemo-agent=false \
+"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "--system --no-create-home --user-group --home-dir ${sysconfdir}/polkit-1 --shell /bin/nologin polkitd"
+
+do_install:append() {
+    if ${@bb.utils.contains('PACKAGECONFIG', 'modem-gps', 'true', 'false', d)}; then
+        # Fix up permissions on polkit rules.d to work with rpm4 constraints
+        chmod 700 ${D}/${datadir}/polkit-1/rules.d
+        chown polkitd:root ${D}/${datadir}/polkit-1/rules.d
+    fi
+}
+
+FILES:${PN} += " \
+    ${datadir}/dbus-1/system-services \
+    ${datadir}/polkit-1/rules.d \
+    ${libdir} \
+    ${systemd_unitdir} \
+    ${prefix}/libexec \
+"
+
+FILES:${PN}-dev += " \
+    ${datadir}/dbus-1/interfaces \
+    ${datadir}/gir-1.0 \
+"

--- a/meta-luneos/conf/layer.conf
+++ b/meta-luneos/conf/layer.conf
@@ -14,6 +14,7 @@ LAYERDEPENDS_meta-luneos = "\
   meta-luneui \
   networking-layer \
   android-layer \
+  meta-luneos-backports-4.3 \
 "
 
 SIGGEN_EXCLUDERECIPES_ABISAFE += " \


### PR DESCRIPTION
To fix issues with Geoclue 2.5.7 on all targets and Mesa with rk3399 (PPP) specifically.

@shr-project Not sure I'm doing it correctly like this? And need to add it to webos-ports-setup too right to enable the layer?