### PR TITLE
sensorfw.bbappend: Use binder for sensorfw on mido-halium.

### DIFF
--- a/meta-luneos/recipes-support/sensorfw/sensorfw.bbappend
+++ b/meta-luneos/recipes-support/sensorfw/sensorfw.bbappend
@@ -12,7 +12,7 @@ EXTRA_QMAKEVARS_PRE:append:halium = "CONFIG+=autohybris "
 # Halium-9.0 devices use binder to communicate with sensors
 EXTRA_QMAKEVARS_PRE:append:hammerhead-halium = "CONFIG+=binder "
 EXTRA_QMAKEVARS_PRE:append:mako = "CONFIG+=binder "
-EXTRA_QMAKEVARS_PRE:append:mido = "CONFIG+=binder "
+EXTRA_QMAKEVARS_PRE:append:mido-halium = "CONFIG+=binder "
 EXTRA_QMAKEVARS_PRE:append:rosy = "CONFIG+=binder "
 EXTRA_QMAKEVARS_PRE:append:sagit = "CONFIG+=binder "
 EXTRA_QMAKEVARS_PRE:append:tissot = "CONFIG+=binder "


### PR DESCRIPTION
Signed-off-by: Herman van Hazendonk <github.com@herrie.org>