### PR TITLE
webapp-mgr.sh: Fix the File API test for Testr

### DIFF
--- a/meta-luneos/recipes-webos/wam/wam/webapp-mgr.sh.in
+++ b/meta-luneos/recipes-webos/wam/wam/webapp-mgr.sh.in
@@ -153,7 +153,7 @@ export WAM_JS_FLAGS=""
 export WAM_COMMON_SWITCHES=" \
     --accelerated-plugin-rendering-blacklist=device;drmAgent;sound;service \
     --allow-file-access-from-files \
-	--application-cache-domain-limit=$WAM_APPCACHE_DOMAINLIMIT \
+    --application-cache-domain-limit=$WAM_APPCACHE_DOMAINLIMIT \
     --application-cache-size=$WAM_APPCACHE_MAXSIZE \
     --autoplay-policy=no-user-gesture-required \
     --browser-subprocess-path=$WAM_EXE_PATH \
@@ -175,6 +175,7 @@ export WAM_COMMON_SWITCHES=" \
     --enable-neva-ime \
     --enable-threaded-compositing \
     --enable-watchdog \
+    --enable-file-api-directories-and-system \
     --force-device-scale-factor=$WAM_DEVICE_SCALE_RATIO \
     --force-gpu-mem-available-mb=$MAX_GPU_MEM_LIMIT \
     --fps-counter-layout=tl \


### PR DESCRIPTION
Adding the --enable-file-api-directories-and-system will make the File API test in Testr succeed again.