### PR TITLE
meta-webos-ports: Make sure all apps have a proper appId

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -99,8 +99,8 @@ RDEPENDS:${PN} = " \
   luneos-default-wallpapers \
   \
   storaged \
-  messwerk \
-  fingerterm \
+  org.webosports.app.messwerk \
+  org.mer.app.fingerterm \
   org.webosports.app.terminal \
   org.webosports.app.camera \
 "

--- a/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test/org.mer.app.sdl2_opengles1_test-appinfo.json
+++ b/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test/org.mer.app.sdl2_opengles1_test-appinfo.json
@@ -1,11 +1,11 @@
 {
-    "title": "SDL2 OpenGLES 2 Test",
-    "id": "sdl2_opengles2_test",
+    "title": "SDL2 OpenGLES 1 Test",
+    "id": "org.mer.app.sdl2_opengles1_test",
     "version": "1.0.6",
     "vendor": "Thomas Perl",
     "vendor_url": "https://github.com/thp/sdl2-opengles-test",
     "type": "native",
-    "main": "sdl2_opengles2_test",
+    "main": "sdl2_opengles1_test",
     "icon": "icon.png",
     "uiRevision": "2"
 }

--- a/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test/org.mer.app.sdl2_opengles2_test-appinfo.json
+++ b/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test/org.mer.app.sdl2_opengles2_test-appinfo.json
@@ -1,11 +1,11 @@
 {
-    "title": "SDL2 OpenGLES 1 Test",
-    "id": "sdl2_opengles1_test",
+    "title": "SDL2 OpenGLES 2 Test",
+    "id": "org.mer.app.sdl2_opengles2_test",
     "version": "1.0.6",
     "vendor": "Thomas Perl",
     "vendor_url": "https://github.com/thp/sdl2-opengles-test",
     "type": "native",
-    "main": "sdl2_opengles1_test",
+    "main": "sdl2_opengles2_test",
     "icon": "icon.png",
     "uiRevision": "2"
 }

--- a/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test_git.bb
+++ b/meta-luneos/recipes-graphics/sdl2-opengles-test/sdl2-opengles-test_git.bb
@@ -12,8 +12,8 @@ TARGETS:rpi = "sdl2_opengles2_test"
 
 PV = "1.0.6+git${SRCPV}"
 SRC_URI = "git://github.com/mer-qa/sdl2-opengles-test.git;branch=master;protocol=https \
-    file://sdl2_opengles1_test-appinfo.json \
-    file://sdl2_opengles2_test-appinfo.json"
+    file://org.mer.app.sdl2_opengles1_test-appinfo.json \
+    file://org.mer.app.sdl2_opengles2_test-appinfo.json"
 S = "${WORKDIR}/git"
 
 SRCREV = "d0a3c8806cb29e3fe9dccc162c66d42dc4ebc40e"
@@ -24,9 +24,9 @@ do_compile() {
 
 do_install() {
     for f in ${TARGETS}; do
-        install -d ${D}${webos_applicationsdir}/$f
-        install -m 0755 ${S}/$f ${D}${webos_applicationsdir}/$f/
-        install -m 0644 ${WORKDIR}/$f-appinfo.json ${D}${webos_applicationsdir}/$f/appinfo.json
+        install -d ${D}${webos_applicationsdir}/org.mer.app.$f
+        install -m 0755 ${S}/$f ${D}${webos_applicationsdir}/org.mer.app.$f/
+        install -m 0644 ${WORKDIR}/org.mer.app.$f-appinfo.json ${D}${webos_applicationsdir}/org.mer.app.$f/appinfo.json
     done
 }
 

--- a/meta-luneos/recipes-luneos/apps/org.mer.app.fingerterm.bb
+++ b/meta-luneos/recipes-luneos/apps/org.mer.app.fingerterm.bb
@@ -2,7 +2,8 @@ SUMMARY = "A terminal emulator with a custom virtual keyboard"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-PV = "1.3.6+git${SRCPV}"
+SPV = "1.3.6"
+PV = "${SPV}+git${SRCPV}"
 SRCREV = "4cfd21a3dbc83bac707828745ffdf0ebe5af768a"
 
 DEPENDS = "qtbase qtdeclarative qttools-native qt5compat"
@@ -37,7 +38,7 @@ do_install:append() {
     install -m 0644 ${S}/fingerterm.png ${D}${APP_PATH}/icon.png
 
     # Always provide same version as we have in our recipe
-    sed -i -e s:__VERSION__:${PV}:g ${D}${APP_PATH}/appinfo.json
+    sed -i -e s:__VERSION__:${SPV}:g ${D}${APP_PATH}/appinfo.json
 }
 
 FILES:${PN} += "${APP_PATH} ${datadir}/translations"

--- a/meta-luneos/recipes-luneos/apps/org.mer.app.fingerterm/appinfo.json
+++ b/meta-luneos/recipes-luneos/apps/org.mer.app.fingerterm/appinfo.json
@@ -1,5 +1,5 @@
 {
-    "id": "fingerterm",
+    "id": "org.mer.app.fingerterm",
     "title": "Fingerterm",
     "version": "__VERSION__",
     "main": "fingerterm",

--- a/meta-luneos/recipes-luneos/apps/org.webosports.app.messwerk.bb
+++ b/meta-luneos/recipes-luneos/apps/org.webosports.app.messwerk.bb
@@ -3,11 +3,11 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=783b7e40cdfb4a1344d15b1f7081af66"
 
 PV = "0.1.0+git${SRCPV}"
-SRCREV = "c55936fc81751c156a85fee3067b61fe03ea8f44"
+SRCREV = "07197b65215280626eaf4f925faeca5c4df64b48"
 
 DEPENDS = "qtbase qtdeclarative qtsensors qtpositioning"
 
-WEBOS_GIT_PARAM_BRANCH = "herrie/qt6"
+WEBOS_REPO_NAME = "messwerk"
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Not having proper appId's can cause havoc when intalling apps with Preware for example. Also LSM seems to be a bit more strict with appIds so let's define proper ones for the apps we ported from elsewhere.