### PR TITLE
webruntime: fix app_shell (browser) close request

### DIFF
--- a/meta-luneos/recipes-webos/chromium/files/0010-app_shell-override-default-OnWindowHostClose-to-clos.patch
+++ b/meta-luneos/recipes-webos/chromium/files/0010-app_shell-override-default-OnWindowHostClose-to-clos.patch
@@ -1,0 +1,43 @@
+From b2eec93a8454a920bacf2161c30e4e756f6de528 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Fri, 24 Nov 2023 19:03:44 +0000
+Subject: [PATCH] app_shell: override default OnWindowHostClose to close
+ browser on request
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+Upstream-Status: Pending
+---
+ src/ui/aura/window_tree_host_platform.cc | 4 ++++
+ src/ui/aura/window_tree_host_platform.h  | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/src/ui/aura/window_tree_host_platform.cc b/src/ui/aura/window_tree_host_platform.cc
+index eccdd6b00e..ec2f8af82f 100644
+--- a/src/ui/aura/window_tree_host_platform.cc
++++ b/src/ui/aura/window_tree_host_platform.cc
+@@ -385,6 +385,10 @@ void WindowTreeHostPlatform::DispatchEvent(ui::Event* event) {
+     event->SetHandled();
+ }
+ 
++void WindowTreeHostPlatform::OnWindowHostClose() {
++    OnCloseRequest();
++}
++
+ void WindowTreeHostPlatform::OnCloseRequest() {
+   OnHostCloseRequested();
+ }
+diff --git a/src/ui/aura/window_tree_host_platform.h b/src/ui/aura/window_tree_host_platform.h
+index 6b2b7aefc0..5ccff04823 100644
+--- a/src/ui/aura/window_tree_host_platform.h
++++ b/src/ui/aura/window_tree_host_platform.h
+@@ -111,6 +111,7 @@ class AURA_EXPORT WindowTreeHostPlatform : ///@name USE_NEVA_APPRUNTIME
+   void OnBoundsChanged(const BoundsChange& change) override;
+   void OnDamageRect(const gfx::Rect& damaged_region) override;
+   void DispatchEvent(ui::Event* event) override;
++  void OnWindowHostClose() override;
+   void OnCloseRequest() override;
+   void OnClosed() override;
+   void OnWindowStateChanged(ui::PlatformWindowState old_state,
+-- 
+2.34.1
+

--- a/meta-luneos/recipes-webos/chromium/webruntime-repo_94.inc
+++ b/meta-luneos/recipes-webos/chromium/webruntime-repo_94.inc
@@ -21,4 +21,5 @@ SRC_URI += " \
     file://0007-Update-app-shell.role.json.in-Add-trustLevel.patch \
     file://0008-palmGetResource-Fix-loading-of-local-resources.patch \
     file://0009-webossystem_injection.cc-fix-some-PalmSystem-functions.patch \
+    file://0010-app_shell-override-default-OnWindowHostClose-to-clos.patch \
 "


### PR DESCRIPTION
When Close is called on the Wayland app_shell (i.e. browser) window, it calls the PlatformWindowDelegate::OnWindowHostClose method.

However, by default, this method isn't implemented in Aura's platform window code, because closing a window doesn't always mean closing the app.

As this default code is only called in the browser's context, and not in WAM, implement it to close the whole app.