### PR TITLE
maliit-framework-webos and other fixes

### DIFF
--- a/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager.bb
+++ b/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager.bb
@@ -35,6 +35,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0009-com.webos.surfacemanager.perm.json-Add-permissions-f.patch \
     file://0010-qmldir-expose-NotificationService-component.patch \
     file://0011-Input-panel-tie-inputPanelRect-to-the-window-mask.patch \
+    file://0012-WebOSSurfaceItem-close-Wayland-client-fallback-on-Cl.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager/0012-WebOSSurfaceItem-close-Wayland-client-fallback-on-Cl.patch
+++ b/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager/0012-WebOSSurfaceItem-close-Wayland-client-fallback-on-Cl.patch
@@ -1,0 +1,36 @@
+From e90bcefab50c6297d9ab2ab99cdc5b0622e7beb2 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 25 Nov 2023 11:18:06 +0100
+Subject: [PATCH] WebOSSurfaceItem: close Wayland client fallback on Close
+ request
+
+When external native apps, like SDL apps, are started on LuneOS, they
+don't implement the webOS Wayland extension. This means no shell
+surface is created, and we have no means of closing the window.
+In this case, just request the Wayland client to close, as a fallback.
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+Upstream-Status: Pending
+---
+ modules/weboscompositor/webossurfaceitem.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/modules/weboscompositor/webossurfaceitem.cpp b/modules/weboscompositor/webossurfaceitem.cpp
+index dc696aa..caaf5fd 100644
+--- a/modules/weboscompositor/webossurfaceitem.cpp
++++ b/modules/weboscompositor/webossurfaceitem.cpp
+@@ -1067,7 +1067,10 @@ void WebOSSurfaceItem::close()
+         sendCloseToGroupItems();
+         m_shellSurface->close();
+     } else {
+-        qWarning() << "No webos shell surface exist, cannot close";
++        qWarning() << "No webos shell surface exist, will close entire client !";
++        if (surface() && surface()->client()) {
++            surface()->client()->close();
++        }
+     }
+ }
+ 
+-- 
+2.43.0
+

--- a/meta-luneos/recipes-webos/maliit-framework-webos/files/maliit-server.path
+++ b/meta-luneos/recipes-webos/maliit-framework-webos/files/maliit-server.path
@@ -1,9 +1,0 @@
-[Unit]
-Wants=maliit-server.service
-
-[Path]
-PathExists=/tmp/lsm-ready
-
-[Install]
-WantedBy=multi-user.target
-

--- a/meta-luneos/recipes-webos/maliit-framework-webos/maliit-framework-webos.bb
+++ b/meta-luneos/recipes-webos/maliit-framework-webos/maliit-framework-webos.bb
@@ -44,7 +44,6 @@ SRC_URI += " \
     file://0001-Correctly-detect-wayland-platform.patch \
     file://maliit-server.conf \
     file://maliit-server.service \
-    file://maliit-server.path \
     file://maliit-server@.service \
     file://maliit-server.sh.in \
     file://maliit-env.conf \
@@ -53,14 +52,13 @@ SRC_URI += " \
 inherit systemd
 
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE:${PN} = "maliit-server.service maliit-server@.service maliit-server.path"
+SYSTEMD_SERVICE:${PN} = "maliit-server.service"
 
 do_install:append() {
     install -d ${D}${sysconfdir}/dbus-1/system.d
     install -m 0644 ${WORKDIR}/maliit-server.conf ${D}${sysconfdir}/dbus-1/system.d/
 
     install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/maliit-server.path ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/maliit-server.service ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/maliit-server@.service ${D}${systemd_unitdir}/system/
 

--- a/meta-luneos/recipes-webos/qml-webos-framework/qml-webos-framework.bb
+++ b/meta-luneos/recipes-webos/qml-webos-framework/qml-webos-framework.bb
@@ -39,6 +39,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0006-com.webos.app.qmlrunner.role.json.in-Add-trustLevel.patch \
     file://0007-WebOSQuickWindow-make-setWindowPropery-Q_INVOKABLE.patch \
     file://0008-runner-debug-use-WEBOS_INSTALL_BINS-as-other-binarie.patch \
+    file://0009-WebOSQuickWindow-use-APP_ID-env-variable-for-appId.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/qml-webos-framework/qml-webos-framework/0009-WebOSQuickWindow-use-APP_ID-env-variable-for-appId.patch
+++ b/meta-luneos/recipes-webos/qml-webos-framework/qml-webos-framework/0009-WebOSQuickWindow-use-APP_ID-env-variable-for-appId.patch
@@ -1,0 +1,27 @@
+From d0e2ce185746eb907bd067fa12d51f23e4c53045 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 25 Nov 2023 13:39:18 +0000
+Subject: [PATCH] WebOSQuickWindow: use APP_ID env variable for appId
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+Upstream-Status: Pending
+---
+ src/common/webosquickwindow.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/common/webosquickwindow.cpp b/src/common/webosquickwindow.cpp
+index 3576d8f..ba8d29d 100644
+--- a/src/common/webosquickwindow.cpp
++++ b/src/common/webosquickwindow.cpp
+@@ -56,7 +56,7 @@ WebOSQuickWindow::WebOSQuickWindow(QWindow *parent)
+     QObject::connect(this, &WebOSQuickWindow::visibleChanged,
+                      this, &WebOSQuickWindow::updatePendingWindowProperties);
+ 
+-    const QString &id = QCoreApplication::applicationName();
++    const QString id = qEnvironmentVariable("APP_ID", QCoreApplication::applicationName());
+     m_windowProperties.insert(WP_APPID, id);
+     setWindowProperty(WP_APPID, id);
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Fix two things:
* maliit-server.path triggers maliit-server.service when lsm-ready file is present. However, as LSM depends on maliit-server, it means we'll never be able to stop the surface-manager service. In addition, maliit-server's startup is already triggered by surface-manager.service, so it's useless.
* having maliit-server@.service in SYSTEMD_SERVICE will insert it in the postrm scripts of the package. However, this is a template service, so it's incorrect. Similarly, starting it at startup is incorrect as the instance argument is mandatory. So just remove it, maliit-server@0.service will be started by maliit-server.service anyway.