### PR TITLE
nyx-modules: Use alternative for serial number

### DIFF
--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
@@ -64,6 +64,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0007-msgid-Add-messages-for-LuneOS-modules.patch \
     file://0008-Add-LuneOS-modules-and-machine-specific-cmake-file-t.patch \
     file://0009-Add-wait-touchscreen-conf.patch \
+    file://0010-nyx-modules-Use-etc-machine-id-for-serial-number.patch \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules/0010-nyx-modules-Use-etc-machine-id-for-serial-number.patch
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules/0010-nyx-modules-Use-etc-machine-id-for-serial-number.patch
@@ -1,0 +1,29 @@
+From 34a751170ac7a2d769db67d74411d8f9d05b0425 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 30 Nov 2023 09:42:37 +0100
+Subject: [PATCH] nyx-modules: Use /etc/machine-id for serial number
+
+/sys/devices/soc0/serial_number is not available on most devices.
+
+Use /etc/machine-id instead which is available on all our targets.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [LuneOS specific]
+
+ src/device_info/device_info_generic.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/device_info/device_info_generic.c b/src/device_info/device_info_generic.c
+index 783ebfd..e53e766 100644
+--- a/src/device_info/device_info_generic.c
++++ b/src/device_info/device_info_generic.c
+@@ -64,7 +64,7 @@ static const char *const  read_bdaddr =
+     "hcitool dev 2>&1 | awk '/hci0/ {print $2}'";
+ 
+ static const char *const  DEVUID_PATH =
+-               "/sys/devices/soc0/serial_number";
++               "/etc/machine-id";
+ 
+ NYX_DECLARE_MODULE(NYX_DEVICE_DEVICE_INFO, "DeviceInfo");
+ 


### PR DESCRIPTION
Fixes: Nov 30 10:02:49 pinephonepro nyx-cmd[310]: [] [pmlog] <default-lib> NYXDEV_DEVICEID_OPEN_ERR {} Error in Opening File : /sys/devices/soc0/serial_number