### PR TITLE
Make com.webos.service.mediacontroller|bluetooth2 work on LuneOS

### DIFF
--- a/meta-luneos/recipes-connectivity/bluez5/bluez5-conf.bb
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5-conf.bb
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2023 LG Electronics, Inc.
+
+SUMMARY = "Machine specific configuration files for bluez5"
+AUTHOR = "Simon Busch <simon.busch@lge.com>"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+PV = "1.0.0"
+PR = "r0"
+
+inherit webos_machine_dep
+
+ALLOW_EMPTY:${PN} = "1"

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0001-Fix-advertise-time-out-when-default-is-set-to-zero.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0001-Fix-advertise-time-out-when-default-is-set-to-zero.patch
@@ -1,0 +1,52 @@
+From 7f7b3ad0297475f478999bb53c6322017089140b Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Wed, 11 Apr 2018 11:03:20 +0530
+Subject: [PATCH] Fix advertise time out when default is set to zero
+
+:Release Notes:
+Advertising timeout zero is ignored
+
+:Detailed Notes:
+Advertising default value for timeout parameter is zero
+so zero timing out is ignored
+
+:Testing Performed:
+Builded and tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-51859] Implement method ble/startAdvertise
+
+Change-Id: I60cb0c22991efa61a800b1483e232e42beff2da2
+---
+Upstream-Status: Pending
+
+ src/advertising.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/advertising.c b/src/advertising.c
+index 1fe371a9f..d857fd96e 100644
+--- a/src/advertising.c
++++ b/src/advertising.c
+@@ -525,13 +525,18 @@ static bool parse_local_name(DBusMessageIter *iter,
+ 	if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_STRING)
+ 		return false;
+ 
++	dbus_message_iter_get_basic(iter, &name);
++
++	if (name && !strcmp(name, "")) {
++		DBG("It's default prop name ignore");
++		return true;
++	}
++
+ 	if (client->flags & MGMT_ADV_FLAG_LOCAL_NAME) {
+ 		error("Local name already included");
+ 		return false;
+ 	}
+ 
+-	dbus_message_iter_get_basic(iter, &name);
+-
+ 	free(client->name);
+ 
+ 	/* Treat empty string the same as omitting since there is no point on

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0002-Send-disconnect-signal-on-remote-device-disconnect.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0002-Send-disconnect-signal-on-remote-device-disconnect.patch
@@ -1,0 +1,50 @@
+From 9b31ce821930ae56ea9dc6138f0b4e76d0536f18 Mon Sep 17 00:00:00 2001
+From: Vibhanshu Dhote <vibhanshu.dhote@lge.com>
+Date: Thu, 17 May 2018 18:15:48 +0530
+Subject: [PATCH] Send disconnect signal on remote device disconnect
+
+:Release Notes:
+Send disconnect signal on remote device disconnect
+
+:Detailed Notes:
+Disconnect signal not geneated when remote device is disconnected,
+required to cleanup the resources. Changes will generate the
+'RequestDisconnection' for org.bluez.Profile1 interface.
+
+:Testing Performed:
+Builded and tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-49640] Implementation of SPP profile Connect/Disconnect API in
+             Bluez Sil
+
+---
+Upstream-Status: Pending
+
+ src/profile.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/profile.c b/src/profile.c
+index e1bebf1ee..36a999c7a 100644
+--- a/src/profile.c
++++ b/src/profile.c
+@@ -727,6 +727,8 @@ static GSList *custom_props = NULL;
+ static GSList *profiles = NULL;
+ static GSList *ext_profiles = NULL;
+ 
++static int send_disconn_req(struct ext_profile *ext, struct ext_io *conn);
++
+ void btd_profile_foreach(void (*func)(struct btd_profile *p, void *data),
+ 								void *data)
+ {
+@@ -867,6 +869,8 @@ drop:
+ 			btd_service_disconnecting_complete(conn->service, 0);
+ 	}
+ 
++	send_disconn_req(ext, conn);
++
+ 	ext->conns = g_slist_remove(ext->conns, conn);
+ 	ext_io_destroy(conn);
+ 	return FALSE;

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0003-Fetching-device-type-like-BLE-BREDR-from-bluez.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0003-Fetching-device-type-like-BLE-BREDR-from-bluez.patch
@@ -1,0 +1,68 @@
+From 7084f0e9638e0c90f50c0cabe6d15ea92cd60298 Mon Sep 17 00:00:00 2001
+From: "vijaya.sundaram" <vijaya.sundaram@lge.com>
+Date: Fri, 1 Jun 2018 11:43:15 +0530
+Subject: [PATCH] Fetching device type like BLE, BREDR from bluez
+
+:Release Notes:
+Fetch device type property BLE, BRE/DR
+
+:Detailed Notes:
+Fetching Device type like ble, bredr to use and display as property
+
+:Testing Performed:
+device/getStatus luna command for device type property as ble, bredr
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-58422] GAP functionality type of device like BLE, BREDR
+             not working, always Unknown
+
+---
+Upstream-Status: Pending
+
+ src/device.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/src/device.c b/src/device.c
+index 9a4f2ce45..c21fcaa76 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -206,6 +206,7 @@ struct btd_device {
+ 	char		name[MAX_NAME_LENGTH + 1];
+ 	char		*alias;
+ 	uint32_t	class;
++	uint32_t	devicetype;
+ 	uint16_t	vendor_src;
+ 	uint16_t	vendor;
+ 	uint16_t	product;
+@@ -964,6 +965,21 @@ static gboolean dev_property_get_class(const GDBusPropertyTable *property,
+ 	return TRUE;
+ }
+ 
++static gboolean property_get_device_type(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct btd_device *device = data;
++
++	if (device->bdaddr_type == BDADDR_BREDR)
++		device->devicetype = BT_MODE_BREDR;
++	else if (device->bdaddr_type == BDADDR_LE_RANDOM || device->bdaddr_type == BDADDR_LE_PUBLIC)
++		device->devicetype = BT_MODE_LE;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT32, &device->devicetype);
++
++	return TRUE;
++}
++
+ static gboolean get_appearance(const GDBusPropertyTable *property, void *data,
+ 							uint16_t *appearance)
+ {
+@@ -2961,6 +2977,7 @@ static const GDBusMethodTable device_methods[] = {
+ static const GDBusPropertyTable device_properties[] = {
+ 	{ "Address", "s", dev_property_get_address },
+ 	{ "AddressType", "s", property_get_address_type },
++	{ "DeviceType", "u", property_get_device_type },
+ 	{ "Name", "s", dev_property_get_name, NULL, dev_property_exists_name },
+ 	{ "Alias", "s", dev_property_get_alias, dev_property_set_alias },
+ 	{ "Class", "u", dev_property_get_class, NULL,

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0004-Fix-Gatt-connect-when-device-address-type-is-BDADDR_.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0004-Fix-Gatt-connect-when-device-address-type-is-BDADDR_.patch
@@ -1,0 +1,77 @@
+From 1c436e8b0c6acc38830f93d7f94686bdd3117cc5 Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Sun, 22 Jul 2018 18:59:45 +0530
+Subject: [PATCH] Fix Gatt connect when device address type is BDADDR_LE_PUBLIC
+
+:Release Notes:
+Fix Gatt connect when device address type is BDADDR_LE_PUBLIC
+
+:Detailed Notes:
+Gatt connect is failing when device address type is BDADDR_LE_PUBLIC
+added new method for gatt connect,so that connect behavior is kept same
+When remote RPI device configured as peripheral(connectable is true),
+address type is BDADDR_LE_PUBLIC in this case
+select_conn_bearer function retruns BDADDR_BREDR, for this type it tries
+to connect to BR_EDR profiles and fails.
+
+:Testing Performed:
+Builded and Tested gatt connect from RPI to RPI
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-62865] com.webos.bluetooth2 : gatt/connect is unstable
+
+Change-Id: I46a3a5fa56d055c54ed16167d6dc2a14ad473615
+---
+Upstream-Status: Pending
+
+ src/device.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/src/device.c b/src/device.c
+index c21fcaa76..a3c51c0f5 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -2366,6 +2366,33 @@ static DBusMessage *dev_connect(DBusConnection *conn, DBusMessage *msg,
+ 	return connect_profiles(dev, bdaddr_type, msg, NULL);
+ }
+ 
++static DBusMessage *dev_connect_gatt(DBusConnection *conn, DBusMessage *msg,
++							void *user_data)
++{
++	struct btd_device *dev = user_data;
++
++	int err;
++
++	if (dev->le_state.connected)
++		return dbus_message_new_method_return(msg);
++
++	btd_device_set_temporary(dev, false);
++
++	if (dev->disable_auto_connect) {
++		dev->disable_auto_connect = FALSE;
++		device_set_auto_connect(dev, TRUE);
++	}
++
++	err = device_connect_le(dev);
++	if (err < 0)
++		return btd_error_failed(msg, strerror(-err));
++
++	dev->connect = dbus_message_ref(msg);
++
++	return NULL;
++
++}
++
+ static DBusMessage *connect_profile(DBusConnection *conn, DBusMessage *msg,
+ 							void *user_data)
+ {
+@@ -2965,6 +2992,7 @@ static DBusMessage *cancel_pairing(DBusConnection *conn, DBusMessage *msg,
+ static const GDBusMethodTable device_methods[] = {
+ 	{ GDBUS_ASYNC_METHOD("Disconnect", NULL, NULL, dev_disconnect) },
+ 	{ GDBUS_ASYNC_METHOD("Connect", NULL, NULL, dev_connect) },
++	{ GDBUS_ASYNC_METHOD("ConnectGatt", NULL, NULL, dev_connect_gatt) },
+ 	{ GDBUS_ASYNC_METHOD("ConnectProfile", GDBUS_ARGS({ "UUID", "s" }),
+ 						NULL, connect_profile) },
+ 	{ GDBUS_ASYNC_METHOD("DisconnectProfile", GDBUS_ARGS({ "UUID", "s" }),

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0005-Use-system-bus-instead-of-session-for-obexd.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0005-Use-system-bus-instead-of-session-for-obexd.patch
@@ -1,0 +1,181 @@
+From 46c4e89c27b9a6b434d74ce1e53aa5ad312edf16 Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Thu, 15 Nov 2018 11:08:44 +0530
+Subject: [PATCH] Use system bus instead of session for obexd
+
+:Release Notes:
+Use system bus instead of session for obexd
+
+:Detailed Notes:
+Multi user is not supported in webos rpi
+so using system bus instead of session bus for obexd
+
+:Testing Performed:
+Builded and Tested
+Tested with obexctl command line tool, all commands are working fine
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-66305] Modify bluez to use system bus instead of session bus
+             for obexd
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ obexd/client/ftp.c      |  3 ++-
+ obexd/client/map.c      |  2 +-
+ obexd/client/opp.c      |  2 +-
+ obexd/client/pbap.c     |  2 +-
+ obexd/client/session.c  |  2 +-
+ obexd/client/sync.c     |  2 +-
+ obexd/plugins/pcsuite.c |  2 +-
+ obexd/src/manager.c     |  2 +-
+ src/bluetooth.conf      | 12 ++++++++++++
+ tools/obexctl.c         |  2 +-
+ 10 files changed, 22 insertions(+), 9 deletions(-)
+
+diff --git a/obexd/client/ftp.c b/obexd/client/ftp.c
+index 160e0636a..f492965b2 100644
+--- a/obexd/client/ftp.c
++++ b/obexd/client/ftp.c
+@@ -463,7 +463,8 @@ int ftp_init(void)
+ 
+ 	DBG("");
+ 
+-	conn = dbus_bus_get(DBUS_BUS_SESSION, NULL);
++	conn = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
++
+ 	if (!conn)
+ 		return -EIO;
+ 
+diff --git a/obexd/client/map.c b/obexd/client/map.c
+index 74828cddb..ea3d25629 100644
+--- a/obexd/client/map.c
++++ b/obexd/client/map.c
+@@ -2063,7 +2063,7 @@ int map_init(void)
+ 
+ 	DBG("");
+ 
+-	conn = dbus_bus_get(DBUS_BUS_SESSION, NULL);
++	conn = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 	if (!conn)
+ 		return -EIO;
+ 
+diff --git a/obexd/client/opp.c b/obexd/client/opp.c
+index 90d0c0c8e..369e9e91c 100644
+--- a/obexd/client/opp.c
++++ b/obexd/client/opp.c
+@@ -178,7 +178,7 @@ int opp_init(void)
+ 
+ 	DBG("");
+ 
+-	conn = dbus_bus_get(DBUS_BUS_SESSION, NULL);
++	conn = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 	if (!conn)
+ 		return -EIO;
+ 
+diff --git a/obexd/client/pbap.c b/obexd/client/pbap.c
+index 1ed8c68ec..3af55440b 100644
+--- a/obexd/client/pbap.c
++++ b/obexd/client/pbap.c
+@@ -1302,7 +1302,7 @@ int pbap_init(void)
+ 
+ 	DBG("");
+ 
+-	conn = dbus_bus_get(DBUS_BUS_SESSION, NULL);
++	conn = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 	if (!conn)
+ 		return -EIO;
+ 
+diff --git a/obexd/client/session.c b/obexd/client/session.c
+index 7d8ebb04e..884013b75 100644
+--- a/obexd/client/session.c
++++ b/obexd/client/session.c
+@@ -583,7 +583,7 @@ struct obc_session *obc_session_create(const char *source,
+ 	if (driver == NULL)
+ 		return NULL;
+ 
+-	conn = dbus_bus_get(DBUS_BUS_SESSION, NULL);
++	conn = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 	if (conn == NULL)
+ 		return NULL;
+ 
+diff --git a/obexd/client/sync.c b/obexd/client/sync.c
+index 92faf4434..c1147897c 100644
+--- a/obexd/client/sync.c
++++ b/obexd/client/sync.c
+@@ -224,7 +224,7 @@ int sync_init(void)
+ 
+ 	DBG("");
+ 
+-	conn = dbus_bus_get(DBUS_BUS_SESSION, NULL);
++	conn = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 	if (!conn)
+ 		return -EIO;
+ 
+diff --git a/obexd/plugins/pcsuite.c b/obexd/plugins/pcsuite.c
+index f5a9d9ae8..88f412aba 100644
+--- a/obexd/plugins/pcsuite.c
++++ b/obexd/plugins/pcsuite.c
+@@ -322,7 +322,7 @@ static gboolean send_backup_dbus_message(const char *oper,
+ 
+ 	file_size = size ? *size : 0;
+ 
+-	conn = g_dbus_setup_bus(DBUS_BUS_SESSION, NULL, NULL);
++	conn = g_dbus_setup_bus(DBUS_BUS_SYSTEM, NULL, NULL);
+ 
+ 	if (conn == NULL)
+ 		return FALSE;
+diff --git a/obexd/src/manager.c b/obexd/src/manager.c
+index 01741fe62..f1fa9fa43 100644
+--- a/obexd/src/manager.c
++++ b/obexd/src/manager.c
+@@ -486,7 +486,7 @@ gboolean manager_init(void)
+ 
+ 	dbus_error_init(&err);
+ 
+-	connection = g_dbus_setup_bus(DBUS_BUS_SESSION, OBEXD_SERVICE, &err);
++	connection = g_dbus_setup_bus(DBUS_BUS_SYSTEM, OBEXD_SERVICE, &err);
+ 	if (connection == NULL) {
+ 		if (dbus_error_is_set(&err) == TRUE) {
+ 			fprintf(stderr, "%s\n", err.message);
+diff --git a/src/bluetooth.conf b/src/bluetooth.conf
+index b6c614908..f8879c8bb 100644
+--- a/src/bluetooth.conf
++++ b/src/bluetooth.conf
+@@ -21,10 +21,22 @@
+     <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
+     <allow send_interface="org.freedesktop.DBus.Properties"/>
+     <allow send_interface="org.mpris.MediaPlayer2.Player"/>
++    <allow own="org.bluez.obex"/>
++    <allow send_destination="org.bluez.obex"/>
++    <allow send_interface="org.bluez.obex.Agent1"/>
++    <allow send_interface="org.bluez.obex.Client1"/>
++    <allow send_interface="org.bluez.obex.Session1"/>
++    <allow send_interface="org.bluez.obex.Transfer1"/>
++    <allow send_interface="org.bluez.obex.ObjectPush1"/>
++    <allow send_interface="org.bluez.obex.PhonebookAccess1"/>
++    <allow send_interface="org.bluez.obex.Synchronization1"/>
++    <allow send_interface="org.bluez.obex.MessageAccess1"/>
++    <allow send_interface="org.bluez.obex.Message1"/>
+   </policy>
+ 
+   <policy context="default">
+     <allow send_destination="org.bluez"/>
++    <allow send_destination="org.bluez.obex"/>
+   </policy>
+ 
+ </busconfig>
+diff --git a/tools/obexctl.c b/tools/obexctl.c
+index 56a76915c..8678b86c9 100644
+--- a/tools/obexctl.c
++++ b/tools/obexctl.c
+@@ -2154,7 +2154,7 @@ int main(int argc, char *argv[])
+ 	bt_shell_set_menu(&main_menu);
+ 	bt_shell_set_prompt(PROMPT_OFF);
+ 
+-	dbus_conn = g_dbus_setup_bus(DBUS_BUS_SESSION, NULL, NULL);
++	dbus_conn = g_dbus_setup_bus(DBUS_BUS_SYSTEM, NULL, NULL);
+ 
+ 	client = g_dbus_client_new(dbus_conn, "org.bluez.obex",
+ 							"/org/bluez/obex");

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0006-Implementation-to-get-connected-profiles-uuids.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0006-Implementation-to-get-connected-profiles-uuids.patch
@@ -1,0 +1,125 @@
+From 163333cd51ea3dd9f5f7bd44310b7c4e385865a0 Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Tue, 22 Jan 2019 23:25:18 +0530
+Subject: [PATCH] Implementation to get connected profiles uuids
+
+:Release Notes:
+Implementation to get connected profiles uuids
+
+:Detailed Notes:
+Modified device.c to get connected profiles uuids
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-69336] Implement AVRCP/Connect Disconnect for blueooth-sil-bluez
+
+Change-Id: I72834cc9b4bdd8f086565dc9a2a41006f758ad39
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ src/device.c | 50 +++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 49 insertions(+), 1 deletion(-)
+
+diff --git a/src/device.c b/src/device.c
+index a3c51c0f5..fea01d20a 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -215,6 +215,7 @@ struct btd_device {
+ 	char		*modalias;
+ 	struct btd_adapter	*adapter;
+ 	GSList		*uuids;
++	GSList		*connected_uuids;
+ 	GSList		*primaries;		/* List of primary services */
+ 	GSList		*services;		/* List of btd_service */
+ 	GSList		*pending;		/* Pending services */
+@@ -996,6 +997,28 @@ static gboolean get_appearance(const GDBusPropertyTable *property, void *data,
+ 	return FALSE;
+ }
+ 
++static gboolean dev_property_get_connected_uuids(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct btd_device *dev = data;
++	DBusMessageIter entry;
++	GSList *l;
++
++	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
++				DBUS_TYPE_STRING_AS_STRING, &entry);
++
++	if (dev->connected_uuids) {
++		l = dev->connected_uuids;
++		for (; l != NULL; l = l->next)
++			dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING,
++								&l->data);
++	}
++
++	dbus_message_iter_close_container(iter, &entry);
++
++	return TRUE;
++}
++
+ static gboolean dev_property_exists_appearance(
+ 			const GDBusPropertyTable *property, void *data)
+ {
+@@ -1893,8 +1916,14 @@ static void device_profile_connected(struct btd_device *dev,
+ 
+ 	DBG("%s %s (%d)", profile->name, strerror(-err), -err);
+ 
+-	if (!err)
++	if (!err) {
+ 		btd_device_set_temporary(dev, false);
++		dev->connected_uuids = g_slist_insert_sorted(dev->connected_uuids,
++													g_strdup(profile->remote_uuid),
++													bt_uuid_strcmp);
++		g_dbus_emit_property_changed(dbus_conn, dev->path,
++									DEVICE_INTERFACE, "ConnectedUUIDS");
++	}
+ 
+ 	if (dev->pending == NULL)
+ 		goto done;
+@@ -2417,6 +2446,14 @@ static DBusMessage *connect_profile(DBusConnection *conn, DBusMessage *msg,
+ static void device_profile_disconnected(struct btd_device *dev,
+ 					struct btd_profile *profile, int err)
+ {
++	DBG("%s %s (%d)", profile->name, strerror(-err), -err);
++	if (!err) {
++		if (dev->connected_uuids)
++		dev->connected_uuids = g_slist_remove (dev->connected_uuids, profile->remote_uuid);
++		g_dbus_emit_property_changed(dbus_conn, dev->path,
++						DEVICE_INTERFACE, "ConnectedUUIDS");
++	}
++
+ 	if (!dev->disconnect)
+ 		return;
+ 
+@@ -3022,6 +3059,7 @@ static const GDBusPropertyTable device_properties[] = {
+ 	{ "RSSI", "n", dev_property_get_rssi, NULL, dev_property_exists_rssi },
+ 	{ "Connected", "b", dev_property_get_connected },
+ 	{ "UUIDs", "as", dev_property_get_uuids },
++	{ "ConnectedUUIDS", "as", dev_property_get_connected_uuids },
+ 	{ "Modalias", "s", dev_property_get_modalias, NULL,
+ 						dev_property_exists_modalias },
+ 	{ "Adapter", "o", dev_property_get_adapter },
+@@ -3129,8 +3167,18 @@ void device_remove_connection(struct btd_device *device, uint8_t bdaddr_type,
+ 	if (!state->connected)
+ 		return;
+ 
++	DBG("");
++
+ 	state->connected = false;
+ 	state->initiator = false;
++
++	if (device->connected_uuids) {
++		g_slist_free (device->connected_uuids);
++		device->connected_uuids = NULL;
++		g_dbus_emit_property_changed(dbus_conn, device->path,
++						DEVICE_INTERFACE, "ConnectedUUIDS");
++	}
++
+ 	device->general_connect = FALSE;
+ 
+ 	device_set_svc_refreshed(device, false);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0007-recievePassThrough-commad-support-required-for-webos.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0007-recievePassThrough-commad-support-required-for-webos.patch
@@ -1,0 +1,190 @@
+From 76f3a04a8135315944af66b322bb646d66b6366c Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Sun, 13 Jan 2019 13:35:55 +0530
+Subject: [PATCH] recievePassThrough commad support required for webos
+
+:Release Notes:
+recievePassThrough commad support required for webos
+
+:Detailed Notes:
+bluez not supporting recievePassThrough throught properties,
+instead directly injecting uinput events
+As luna command is required to be supported so
+added as properties so that this can read from bluetooth-bluez-sil
+
+:Testing Performed:
+Builded and tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-49637] Implement avrcp/receivePassThroughCommand for blueooth-sil-bluez
+
+Change-Id: I9c07aa27f242247b5c3df85e0b3605d2ba055cad
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/avctp.c |  5 ++++
+ src/device.c           | 57 +++++++++++++++++++++++++++++++++++++++++-
+ src/device.h           |  2 ++
+ 3 files changed, 63 insertions(+), 1 deletion(-)
+
+diff --git a/profiles/audio/avctp.c b/profiles/audio/avctp.c
+index 6f64f162b..b002470f9 100644
+--- a/profiles/audio/avctp.c
++++ b/profiles/audio/avctp.c
+@@ -406,6 +406,7 @@ static size_t handle_panel_passthrough(struct avctp *session,
+ 
+ 		DBG("AV/C: %s %s", key_map[i].name, status);
+ 
++		recieve_passThrough_commands(session->device, key_map[i].name, status);
+ 		key_quirks = session->key_quirks[key_map[i].avc];
+ 
+ 		if (key_quirks & QUIRK_NO_RELEASE) {
+@@ -421,9 +422,13 @@ static size_t handle_panel_passthrough(struct avctp *session,
+ 		}
+ 
+ 		if (pressed)
++		{
+ 			handle_press(session, key_map[i].uinput);
++		}
+ 		else
++		{
+ 			handle_release(session, key_map[i].uinput);
++		}
+ 
+ 		break;
+ 	}
+diff --git a/src/device.c b/src/device.c
+index fea01d20a..2eef2a8cf 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -170,6 +170,11 @@ enum {
+ 	WAKE_FLAG_DISABLED,
+ };
+ 
++struct key_code {
++	const char* key;
++	const char* state;
++};
++
+ struct btd_device {
+ 	int ref_count;
+ 
+@@ -275,6 +280,8 @@ struct btd_device {
+ 	time_t		name_resolve_failed_time;
+ 
+ 	int8_t		volume;
++
++	struct key_code passththough_key;
+ };
+ 
+ static const uint16_t uuid_list[] = {
+@@ -1407,6 +1414,18 @@ dev_property_manufacturer_data_exist(const GDBusPropertyTable *property,
+ 	return bt_ad_has_manufacturer_data(device->ad, NULL);
+ }
+ 
++static gboolean
++dev_property_key_code_exist(const GDBusPropertyTable *property,
++								void *data)
++{
++	struct btd_device *device = data;
++
++	if (device->passththough_key.key == NULL)
++		return false;
++	else 
++		return true;
++}
++
+ static void append_service_data(void *data, void *user_data)
+ {
+ 	struct bt_ad_service_data *sd = data;
+@@ -1425,13 +1444,13 @@ dev_property_get_service_data(const GDBusPropertyTable *property,
+ 	struct btd_device *device = data;
+ 	DBusMessageIter dict;
+ 
++
+ 	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
+ 					DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+ 					DBUS_TYPE_STRING_AS_STRING
+ 					DBUS_TYPE_VARIANT_AS_STRING
+ 					DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
+ 					&dict);
+-
+ 	bt_ad_foreach_service_data(device->ad, append_service_data, &dict);
+ 
+ 	dbus_message_iter_close_container(iter, &dict);
+@@ -1439,6 +1458,28 @@ dev_property_get_service_data(const GDBusPropertyTable *property,
+ 	return TRUE;
+ }
+ 
++static gboolean dev_property_get_key_code(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct btd_device *dev = data;
++	const char* key_code = dev->passththough_key.key;
++	const char *state = dev->passththough_key.state;
++
++	DBusMessageIter dict;
++	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
++					DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
++					DBUS_TYPE_UINT16_AS_STRING
++					DBUS_TYPE_VARIANT_AS_STRING
++					DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
++					&dict);
++
++	dict_append_array(&dict, key_code, DBUS_TYPE_BYTE, &state, strlen(state) + 1);
++
++	dbus_message_iter_close_container(iter, &dict);
++
++	return TRUE;
++}
++
+ static gboolean
+ dev_property_service_data_exist(const GDBusPropertyTable *property,
+ 								void *data)
+@@ -2037,6 +2078,15 @@ void device_set_manufacturer_data(struct btd_device *dev, GSList *list,
+ 	g_slist_foreach(list, add_manufacturer_data, dev);
+ }
+ 
++void recieve_passThrough_commands(struct btd_device *dev, const char* code, const char* state)
++{
++		dev->passththough_key.state = state;
++		dev->passththough_key.key = code;
++
++		g_dbus_emit_property_changed(dbus_conn, dev->path,
++					DEVICE_INTERFACE, "KeyCode");
++}
++
+ static void add_service_data(void *data, void *user_data)
+ {
+ 	struct eir_sd *sd = data;
+@@ -3065,6 +3115,8 @@ static const GDBusPropertyTable device_properties[] = {
+ 	{ "Adapter", "o", dev_property_get_adapter },
+ 	{ "ManufacturerData", "a{qv}", dev_property_get_manufacturer_data,
+ 				NULL, dev_property_manufacturer_data_exist },
++	{ "KeyCode", "a{sv}", dev_property_get_key_code,
++				NULL, dev_property_key_code_exist},
+ 	{ "ServiceData", "a{sv}", dev_property_get_service_data,
+ 				NULL, dev_property_service_data_exist },
+ 	{ "TxPower", "n", dev_property_get_tx_power, NULL,
+@@ -4037,6 +4089,9 @@ static struct btd_device *device_new(struct btd_adapter *adapter,
+ 	device->adapter = adapter;
+ 	device->temporary = true;
+ 
++	device->passththough_key.state = NULL;
++	device->passththough_key.key = NULL;
++
+ 	device->db_id = gatt_db_register(device->db, gatt_service_added,
+ 					gatt_service_removed, device, NULL);
+ 
+diff --git a/src/device.h b/src/device.h
+index d7f886224..b7a5aaa98 100644
+--- a/src/device.h
++++ b/src/device.h
+@@ -186,3 +186,5 @@ void btd_device_cleanup(void);
+ 
+ void btd_device_set_volume(struct btd_device *dev, int8_t volume);
+ int8_t btd_device_get_volume(struct btd_device *dev);
++
++void recieve_passThrough_commands(struct btd_device *dev, const char* code, const char* state);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0008-Added-dbus-signal-for-MediaPlayRequest.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0008-Added-dbus-signal-for-MediaPlayRequest.patch
@@ -1,0 +1,123 @@
+From 49fb6333df5255cf3b4aba4d26c1b141b08945d7 Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Wed, 30 Jan 2019 15:17:11 +0530
+Subject: [PATCH] Added dbus signal for MediaPlayRequest
+
+:Release Notes:
+Added dbus signal for MediaPlayRequest and MediaMetaRequest
+
+:Detailed Notes:
+SIL needs information about MediaPlayRequest and MediaMetaRequest
+so added above signals to inform about request to SIL
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-73147] Implement avrcp/awaitMediaMetaDataRequest
+
+Change-Id: Ib225395809a3b53f1c494ac4e21beabc47f7f906
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/avrcp.c |  2 ++
+ profiles/audio/media.c |  2 +-
+ src/device.c           | 24 +++++++++++++++++++++++-
+ src/device.h           |  3 +++
+ 4 files changed, 29 insertions(+), 2 deletions(-)
+
+diff --git a/profiles/audio/avrcp.c b/profiles/audio/avrcp.c
+index 80f34c7a7..1b3e6090a 100644
+--- a/profiles/audio/avrcp.c
++++ b/profiles/audio/avrcp.c
+@@ -1240,6 +1240,7 @@ static uint8_t avrcp_handle_get_element_attributes(struct avrcp *session,
+ 		 */
+ 		attr_ids = player_list_metadata(player);
+ 		len = g_list_length(attr_ids);
++		media_metadata_request(session->dev);
+ 	} else {
+ 		unsigned int i;
+ 		for (i = 0, len = 0, attr_ids = NULL; i < nattr; i++) {
+@@ -1503,6 +1504,7 @@ static uint8_t avrcp_handle_get_play_status(struct avrcp *session,
+ 
+ 	pdu->params_len = cpu_to_be16(9);
+ 
++	media_play_request(session->dev);
+ 	return AVC_CTYPE_STABLE;
+ }
+ 
+diff --git a/profiles/audio/media.c b/profiles/audio/media.c
+index c5d8ab14e..97c453021 100644
+--- a/profiles/audio/media.c
++++ b/profiles/audio/media.c
+@@ -1229,7 +1229,7 @@ static uint32_t media_player_get_position(void *user_data)
+ 	sec = (uint32_t) timedelta;
+ 	msec = (uint32_t) ((timedelta - sec) * 1000);
+ 
+-	return mp->position + sec * 1000 + msec;
++	return mp->position;
+ }
+ 
+ static uint32_t media_player_get_duration(void *user_data)
+diff --git a/src/device.c b/src/device.c
+index 2eef2a8cf..275f4a9a6 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -2087,6 +2087,22 @@ void recieve_passThrough_commands(struct btd_device *dev, const char* code, cons
+ 					DEVICE_INTERFACE, "KeyCode");
+ }
+ 
++void media_play_request(struct btd_device *dev)
++{
++	DBG("");
++	g_dbus_emit_signal(dbus_conn, dev->path,
++				DEVICE_INTERFACE, "MediaPlayRequest",
++				DBUS_TYPE_INVALID);
++}
++
++void media_metadata_request(struct btd_device *dev)
++{
++	DBG("");
++	g_dbus_emit_signal(dbus_conn, dev->path,
++			DEVICE_INTERFACE, "MediaMetaRequest",
++			DBUS_TYPE_INVALID);
++}
++
+ static void add_service_data(void *data, void *user_data)
+ {
+ 	struct eir_sd *sd = data;
+@@ -3076,6 +3092,12 @@ static DBusMessage *cancel_pairing(DBusConnection *conn, DBusMessage *msg,
+ 	return dbus_message_new_method_return(msg);
+ }
+ 
++static const GDBusSignalTable device_avrcp_media_request_signal[] = {
++	{ GDBUS_SIGNAL("MediaPlayRequest", NULL) },
++	{ GDBUS_SIGNAL("MediaMetaRequest", NULL) },
++	{ }
++};
++
+ static const GDBusMethodTable device_methods[] = {
+ 	{ GDBUS_ASYNC_METHOD("Disconnect", NULL, NULL, dev_disconnect) },
+ 	{ GDBUS_ASYNC_METHOD("Connect", NULL, NULL, dev_connect) },
+@@ -4078,7 +4100,7 @@ static struct btd_device *device_new(struct btd_adapter *adapter,
+ 
+ 	if (g_dbus_register_interface(dbus_conn,
+ 					device->path, DEVICE_INTERFACE,
+-					device_methods, NULL,
++					device_methods, device_avrcp_media_request_signal,
+ 					device_properties, device,
+ 					device_free) == FALSE) {
+ 		error("Unable to register device interface for %s", address);
+diff --git a/src/device.h b/src/device.h
+index b7a5aaa98..fe2387fb3 100644
+--- a/src/device.h
++++ b/src/device.h
+@@ -188,3 +188,6 @@ void btd_device_set_volume(struct btd_device *dev, int8_t volume);
+ int8_t btd_device_get_volume(struct btd_device *dev);
+ 
+ void recieve_passThrough_commands(struct btd_device *dev, const char* code, const char* state);
++
++void media_play_request(struct btd_device *dev);
++void media_metadata_request(struct btd_device *dev);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0009-avrcp-getting-remote-device-features-list.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0009-avrcp-getting-remote-device-features-list.patch
@@ -1,0 +1,208 @@
+From 06d8a4416ed5d2c19e4b6d08c1bae8c6ca758d97 Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Tue, 5 Feb 2019 18:10:55 +0530
+Subject: [PATCH] avrcp getting remote device features list
+
+:Release Notes:
+avrcp getting remote device features list
+
+:Detailed Notes:
+bluetooth-sil-bluez5 needs information on avrcp device feature list
+So added properties for controller features and target features
+to device interface
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-73148] Implement avrcp/internal/getRemoteFeatures
+
+Change-Id: I93393e5955c745c4df3eaddf6661177410ad3a7d
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/avrcp.c | 15 ++++++++++
+ src/device.c           | 68 ++++++++++++++++++++++++++++++++++++++++++
+ src/device.h           |  5 ++++
+ 3 files changed, 88 insertions(+)
+
+diff --git a/profiles/audio/avrcp.c b/profiles/audio/avrcp.c
+index 1b3e6090a..61478e913 100644
+--- a/profiles/audio/avrcp.c
++++ b/profiles/audio/avrcp.c
+@@ -4152,9 +4152,16 @@ static void target_init(struct avrcp *session)
+ 				(1 << AVRCP_EVENT_TRACK_REACHED_END) |
+ 				(1 << AVRCP_EVENT_SETTINGS_CHANGED);
+ 
++	if (target->version < 0x0103)
++		return;
++
++	set_avrcp_feature(session->dev, REMOTE_DEVICE_AVRCP_FEATURE_METADATA, false);
++
+ 	if (target->version < 0x0104)
+ 		return;
+ 
++	set_avrcp_feature(session->dev, REMOTE_DEVICE_AVRCP_FEATURE_ABSOLUTE_VOLUME, false);
++
+ 	session->supported_events |=
+ 				(1 << AVRCP_EVENT_ADDRESSED_PLAYER_CHANGED) |
+ 				(1 << AVRCP_EVENT_AVAILABLE_PLAYERS_CHANGED) |
+@@ -4167,6 +4174,8 @@ static void target_init(struct avrcp *session)
+ 	if (!(target->features & AVRCP_FEATURE_BROWSING))
+ 		return;
+ 
++	set_avrcp_feature(session->dev, REMOTE_DEVICE_AVRCP_FEATURE_BROWSE, false);
++
+ 	avrcp_connect_browsing(session);
+ }
+ 
+@@ -4197,14 +4206,20 @@ static void controller_init(struct avrcp *session)
+ 	if (controller->version < 0x0103)
+ 		return;
+ 
++	set_avrcp_feature(session->dev, REMOTE_DEVICE_AVRCP_FEATURE_METADATA, true);
++
+ 	avrcp_get_capabilities(session);
+ 
+ 	if (controller->version < 0x0104)
+ 		return;
+ 
++	set_avrcp_feature(session->dev, REMOTE_DEVICE_AVRCP_FEATURE_ABSOLUTE_VOLUME, true);
++
+ 	if (!(controller->features & AVRCP_FEATURE_BROWSING))
+ 		return;
+ 
++	set_avrcp_feature(session->dev, REMOTE_DEVICE_AVRCP_FEATURE_BROWSE, true);
++
+ 	avrcp_connect_browsing(session);
+ }
+ 
+diff --git a/src/device.c b/src/device.c
+index 275f4a9a6..3cad84e37 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -282,6 +282,8 @@ struct btd_device {
+ 	int8_t		volume;
+ 
+ 	struct key_code passththough_key;
++	uint8_t		avrcp_ct_features;
++	uint8_t		avrcp_tg_features;
+ };
+ 
+ static const uint16_t uuid_list[] = {
+@@ -1480,6 +1482,46 @@ static gboolean dev_property_get_key_code(const GDBusPropertyTable *property,
+ 	return TRUE;
+ }
+ 
++static gboolean dev_property_get_avrcp_ct_feature(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct btd_device *device = data;
++	uint8_t features = device->avrcp_ct_features;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_BYTE, &features);
++	DBG("features %d", features);
++	return TRUE;
++}
++
++static gboolean dev_property_get_avrcp_tg_feature(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct btd_device *device = data;
++	uint8_t features = device->avrcp_tg_features;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_BYTE, &features);
++	DBG("features %d", features);
++	return TRUE;
++}
++
++static gboolean
++dev_property_avrcp_ct_feature_exist(const GDBusPropertyTable *property,
++								void *data)
++{
++	struct btd_device *device = data;
++
++	return device->avrcp_ct_features;
++}
++
++static gboolean
++dev_property_avrcp_tg_feature_exist(const GDBusPropertyTable *property,
++								void *data)
++{
++	struct btd_device *device = data;
++
++	return device->avrcp_tg_features;
++}
++
+ static gboolean
+ dev_property_service_data_exist(const GDBusPropertyTable *property,
+ 								void *data)
+@@ -2103,6 +2145,25 @@ void media_metadata_request(struct btd_device *dev)
+ 			DBUS_TYPE_INVALID);
+ }
+ 
++void set_avrcp_feature(struct btd_device *dev, uint8_t feature, bool is_controller)
++{
++	DBG("setting feature %x", feature);
++	if (is_controller)
++	{
++		dev->avrcp_ct_features |= feature;
++		DBG("avrcp_features controller %x", dev->avrcp_ct_features);
++		g_dbus_emit_property_changed(dbus_conn, dev->path,
++					DEVICE_INTERFACE, "AvrcpCTFeatures");
++	}
++	else
++	{
++		dev->avrcp_tg_features |= feature;
++		DBG("avrcp_features target %x", dev->avrcp_tg_features);
++		g_dbus_emit_property_changed(dbus_conn, dev->path,
++					DEVICE_INTERFACE, "AvrcpTGFeatures");
++	}
++}
++
+ static void add_service_data(void *data, void *user_data)
+ {
+ 	struct eir_sd *sd = data;
+@@ -3139,6 +3200,10 @@ static const GDBusPropertyTable device_properties[] = {
+ 				NULL, dev_property_manufacturer_data_exist },
+ 	{ "KeyCode", "a{sv}", dev_property_get_key_code,
+ 				NULL, dev_property_key_code_exist},
++	{ "AvrcpCTFeatures", "y", dev_property_get_avrcp_ct_feature,
++				NULL, dev_property_avrcp_ct_feature_exist},
++	{ "AvrcpTGFeatures", "y", dev_property_get_avrcp_tg_feature,
++				NULL, dev_property_avrcp_tg_feature_exist},
+ 	{ "ServiceData", "a{sv}", dev_property_get_service_data,
+ 				NULL, dev_property_service_data_exist },
+ 	{ "TxPower", "n", dev_property_get_tx_power, NULL,
+@@ -4114,6 +4179,9 @@ static struct btd_device *device_new(struct btd_adapter *adapter,
+ 	device->passththough_key.state = NULL;
+ 	device->passththough_key.key = NULL;
+ 
++	device->avrcp_ct_features = 0;
++	device->avrcp_tg_features = 0;
++
+ 	device->db_id = gatt_db_register(device->db, gatt_service_added,
+ 					gatt_service_removed, device, NULL);
+ 
+diff --git a/src/device.h b/src/device.h
+index fe2387fb3..a3ee4279c 100644
+--- a/src/device.h
++++ b/src/device.h
+@@ -10,6 +10,10 @@
+  */
+ 
+ #define DEVICE_INTERFACE	"org.bluez.Device1"
++#define REMOTE_DEVICE_AVRCP_FEATURE_NONE			0x00
++#define REMOTE_DEVICE_AVRCP_FEATURE_METADATA		0x01
++#define REMOTE_DEVICE_AVRCP_FEATURE_ABSOLUTE_VOLUME	0x02
++#define REMOTE_DEVICE_AVRCP_FEATURE_BROWSE		0x04
+ 
+ struct btd_device;
+ 
+@@ -191,3 +195,4 @@ void recieve_passThrough_commands(struct btd_device *dev, const char* code, cons
+ 
+ void media_play_request(struct btd_device *dev);
+ void media_metadata_request(struct btd_device *dev);
++void set_avrcp_feature(struct btd_device *dev, uint8_t feature, bool is_controller);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0010-Fix-volume-property-not-able-to-set.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0010-Fix-volume-property-not-able-to-set.patch
@@ -1,0 +1,40 @@
+From 762ead4c8d565ada8022e9d544963522fa70de8b Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Mon, 21 Jan 2019 12:44:19 +0530
+Subject: [PATCH] Fix volume property not able to set
+
+:Release Notes:
+Fix volume property not able to set
+
+:Detailed Notes:
+volume is initialized to -1 so volume_exists
+function is always returning false and not able to set
+this property
+
+:Testing Performed:
+Built and tested
+
+:Issues Addressed:
+[PLAT-86691] Implement avrcp/setAbsoluteVolume supporting multiple
+             Adapters
+
+Change-Id: I183357a5de4b95a6e02d39d9d51c4af715bf0a54
+---
+Upstream-Status: Pending
+
+ profiles/audio/transport.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/profiles/audio/transport.c b/profiles/audio/transport.c
+index 5848e4019..19a39af47 100644
+--- a/profiles/audio/transport.c
++++ b/profiles/audio/transport.c
+@@ -810,7 +810,7 @@ static int media_transport_init_source(struct media_transport *transport)
+ 	transport->data = a2dp;
+ 	transport->destroy = destroy_a2dp;
+ 
+-	a2dp->volume = -1;
++	a2dp->volume = 0;
+ 	transport->sink_watch = sink_add_state_cb(service, sink_state_changed,
+ 								transport);
+ 

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0011-Fix-volume-level-notification-not-appearing-after-12.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0011-Fix-volume-level-notification-not-appearing-after-12.patch
@@ -1,0 +1,71 @@
+From 9048d00c3e742f7cfc43a31fb0dce2537ad02956 Mon Sep 17 00:00:00 2001
+From: Sameer Mulla <sameer.mulla@lge.com>
+Date: Tue, 10 Dec 2019 16:15:43 +0530
+Subject: [PATCH] Fix volume level notification not appearing after 127
+
+:Release Notes:
+Fix volume level notification not appearing after 127
+
+:Detailed Notes:
+Even volume level should be notified even its same
+value as previous incase it reached lower value 0
+or upper value 127, so that UI can be updated that
+max or min volume is reached
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-97324] There is an environment where avrcp / getRemoteVolume
+             does not return.
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/media.c     | 4 ++--
+ profiles/audio/transport.c | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/profiles/audio/media.c b/profiles/audio/media.c
+index 97c453021..7f1ff346b 100644
+--- a/profiles/audio/media.c
++++ b/profiles/audio/media.c
+@@ -1244,8 +1244,8 @@ static void media_player_set_volume(int8_t volume, struct btd_device *dev,
+ {
+ 	struct media_player *mp = user_data;
+ 
+-	if (mp->volume == volume)
+-		return;
++	/*if (mp->volume == volume)
++		return;*/
+ 
+ 	mp->volume = volume;
+ }
+diff --git a/profiles/audio/transport.c b/profiles/audio/transport.c
+index 19a39af47..769fffdd3 100644
+--- a/profiles/audio/transport.c
++++ b/profiles/audio/transport.c
+@@ -656,8 +656,8 @@ static void set_volume(const GDBusPropertyTable *property,
+ 	g_dbus_pending_property_success(id);
+ 
+ 	volume = (int8_t)arg;
+-	if (a2dp->volume == volume)
+-		return;
++	/*if (a2dp->volume == volume)
++		return;*/
+ 
+ 	notify = transport->source_watch ? true : false;
+ 	if (notify) {
+@@ -932,8 +932,8 @@ void media_transport_update_volume(struct media_transport *transport,
+ 		return;
+ 
+ 	/* Check if volume really changed */
+-	if (a2dp->volume == volume)
+-		return;
++	/*if (a2dp->volume == volume)
++		return;*/
+ 
+ 	a2dp->volume = volume;
+ 

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0012-Support-enabling-avdtp-delayReport.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0012-Support-enabling-avdtp-delayReport.patch
@@ -1,0 +1,353 @@
+From 9052c6a17f1a27a7f516850a167b51ce83806872 Mon Sep 17 00:00:00 2001
+From: "sameer.mulla" <sameer.mulla@lge.com>
+Date: Thu, 4 Jun 2020 04:49:48 +0000
+Subject: [PATCH] Support enabling avdtp delayReport
+
+:Release Notes:
+Support enabling avdtp delayReport
+
+:Detailed Notes:
+Support enabling avdtp delayReport
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-98273] Implement AVDTP delay report interface
+
+---
+Upstream-Status: Pending
+
+ profiles/audio/a2dp.c  |  8 +++++++
+ profiles/audio/a2dp.h  |  1 +
+ profiles/audio/avdtp.c |  5 ++++
+ profiles/audio/avdtp.h |  1 +
+ profiles/audio/media.c | 17 ++++++++++++++
+ profiles/audio/media.h |  2 ++
+ src/adapter.c          | 52 ++++++++++++++++++++++++++++++++++++++++++
+ src/adapter.h          |  3 +++
+ src/btd.h              |  1 +
+ src/main.c             | 11 +++++++++
+ src/main.conf          |  3 +++
+ 11 files changed, 104 insertions(+)
+
+diff --git a/profiles/audio/a2dp.c b/profiles/audio/a2dp.c
+index 276512208..fb6c9f680 100644
+--- a/profiles/audio/a2dp.c
++++ b/profiles/audio/a2dp.c
+@@ -2390,6 +2390,14 @@ found:
+ 	return avdtp_ref(chan->session);
+ }
+ 
++void a2dp_sep_set_delay_reporting(struct a2dp_sep *sep, bool delay_reporting)
++{
++       DBG("");
++       DBG("delay_reporting %d",delay_reporting);
++       sep->delay_reporting = delay_reporting;
++       avdtp_local_sep_set_delay_report(sep->lsep, delay_reporting);
++}
++
+ static void connect_cb(GIOChannel *io, GError *err, gpointer user_data)
+ {
+ 	struct a2dp_channel *chan = user_data;
+diff --git a/profiles/audio/a2dp.h b/profiles/audio/a2dp.h
+index 615b641c9..af67ee6ee 100644
+--- a/profiles/audio/a2dp.h
++++ b/profiles/audio/a2dp.h
+@@ -77,6 +77,7 @@ gboolean a2dp_cancel(unsigned int id);
+ gboolean a2dp_sep_lock(struct a2dp_sep *sep, struct avdtp *session);
+ gboolean a2dp_sep_unlock(struct a2dp_sep *sep, struct avdtp *session);
+ struct avdtp_stream *a2dp_sep_get_stream(struct a2dp_sep *sep);
++void a2dp_sep_set_delay_reporting(struct a2dp_sep *sep, bool delay_reporting);
+ struct btd_device *a2dp_setup_get_device(struct a2dp_setup *setup);
+ const char *a2dp_setup_remote_path(struct a2dp_setup *setup);
+ struct avdtp *a2dp_avdtp_get(struct btd_device *device);
+diff --git a/profiles/audio/avdtp.c b/profiles/audio/avdtp.c
+index 10ef380d4..4280c007c 100644
+--- a/profiles/audio/avdtp.c
++++ b/profiles/audio/avdtp.c
+@@ -469,6 +469,11 @@ static gboolean try_send(int sk, void *data, size_t len)
+ 	return TRUE;
+ }
+ 
++void avdtp_local_sep_set_delay_report(struct avdtp_local_sep *lsep, bool delay_reporting)
++{
++       lsep->delay_reporting = delay_reporting;
++}
++
+ static gboolean avdtp_send(struct avdtp *session, uint8_t transaction,
+ 				uint8_t message_type, uint8_t signal_id,
+ 				void *data, size_t len)
+diff --git a/profiles/audio/avdtp.h b/profiles/audio/avdtp.h
+index 102a2603e..b167f2dab 100644
+--- a/profiles/audio/avdtp.h
++++ b/profiles/audio/avdtp.h
+@@ -311,3 +311,4 @@ struct avdtp_server *avdtp_get_server(struct avdtp_local_sep *lsep);
+ struct avdtp *avdtp_new(GIOChannel *chan, struct btd_device *device,
+ 							struct queue *lseps);
+ uint16_t avdtp_get_version(struct avdtp *session);
++void avdtp_local_sep_set_delay_report(struct avdtp_local_sep *lsep, bool delay_reporting);
+diff --git a/profiles/audio/media.c b/profiles/audio/media.c
+index 7f1ff346b..617763982 100644
+--- a/profiles/audio/media.c
++++ b/profiles/audio/media.c
+@@ -120,6 +120,19 @@ struct media_player {
+ 
+ static GSList *adapters = NULL;
+ 
++void media_set_delay_reporting(struct media_adapter *media_adapter, bool delay_reporting)
++{
++       GSList *l;
++       for (l = media_adapter->endpoints; l; l = l->next) {
++               struct media_endpoint *endpoint = l->data;
++
++               if ((strcasecmp(endpoint->uuid, "0000110a-0000-1000-8000-00805f9b34fb") == 0) || (strcasecmp(endpoint->uuid, "0000110b-0000-1000-8000-00805f9b34fb") == 0))
++               {
++                       a2dp_sep_set_delay_reporting(endpoint->sep, delay_reporting);
++               }
++       }
++}
++
+ static void endpoint_request_free(struct endpoint_request *request)
+ {
+ 	if (request->call)
+@@ -807,6 +820,9 @@ static struct media_endpoint *media_endpoint_create(struct media_adapter *adapte
+ 	}
+ 
+ 	endpoint->adapter = adapter;
++       delay_reporting = btd_adapter_get_delay_reporting(adapter->btd_adapter);
++
++       DBG("delay_reporting %d", delay_reporting);
+ 
+ 	if (strcasecmp(uuid, A2DP_SOURCE_UUID) == 0)
+ 		succeeded = endpoint_init_a2dp_source(endpoint,
+@@ -2427,6 +2443,7 @@ int media_register(struct btd_adapter *btd_adapter)
+ 		return -1;
+ 	}
+ 
++	set_media_adapter(btd_adapter, adapter);
+ 	adapters = g_slist_append(adapters, adapter);
+ 
+ 	return 0;
+diff --git a/profiles/audio/media.h b/profiles/audio/media.h
+index 96bea9db4..e9d10fd3c 100644
+--- a/profiles/audio/media.h
++++ b/profiles/audio/media.h
+@@ -10,6 +10,7 @@
+  */
+ 
+ struct media_endpoint;
++struct media_adapter;
+ 
+ typedef void (*media_endpoint_cb_t) (struct media_endpoint *endpoint,
+ 					void *ret, int size, void *user_data);
+@@ -22,3 +23,4 @@ const char *media_endpoint_get_uuid(struct media_endpoint *endpoint);
+ uint8_t media_endpoint_get_codec(struct media_endpoint *endpoint);
+ 
+ int8_t media_player_get_device_volume(struct btd_device *device);
++void media_set_delay_reporting(struct media_adapter* adapter, bool delay_reporting);
+diff --git a/src/adapter.c b/src/adapter.c
+index b159d2135..9ebcf6368 100644
+--- a/src/adapter.c
++++ b/src/adapter.c
+@@ -67,6 +67,7 @@
+ #include "adv_monitor.h"
+ #include "eir.h"
+ #include "battery.h"
++#include "profiles/audio/media.h"
+ 
+ #define MODE_OFF		0x00
+ #define MODE_CONNECTABLE	0x01
+@@ -271,6 +272,9 @@ struct btd_adapter {
+ 	bool filtered_discovery;	/* we are doing filtered discovery */
+ 	bool no_scan_restart_delay;	/* when this flag is set, restart scan
+ 					 * without delay */
++        bool delay_report;
++
++        struct media_adapter *media_adapter;
+ 	uint8_t discovery_type;		/* current active discovery type */
+ 	uint8_t discovery_enable;	/* discovery enabled/disabled */
+ 	bool discovery_suspended;	/* discovery has been suspended */
+@@ -330,6 +334,11 @@ typedef enum {
+ 	ADAPTER_AUTHORIZE_CHECK_CONNECTED
+ } adapter_authorize_type;
+ 
++void set_media_adapter(struct btd_adapter *adapter, struct media_adapter *media_adapter)
++{
++       adapter->media_adapter = media_adapter;
++}
++
+ static struct btd_adapter *btd_adapter_lookup(uint16_t index)
+ {
+ 	GList *list;
+@@ -532,6 +541,8 @@ static void store_adapter_info(struct btd_adapter *adapter)
+ 
+ 	g_key_file_set_boolean(key_file, "General", "Discoverable",
+ 							discoverable);
++        g_key_file_set_boolean(key_file, "General", "DelayReport",
++                                                       adapter->delay_report);
+ 
+ 	if (adapter->discoverable_timeout != btd_opts.discovto)
+ 		g_key_file_set_integer(key_file, "General",
+@@ -3312,6 +3323,30 @@ static gboolean property_get_roles(const GDBusPropertyTable *property,
+ 
+ 	return TRUE;
+ }
++static gboolean property_get_delay_report_feature(const GDBusPropertyTable *property, DBusMessageIter *iter, void *user_data)
++{
++       struct btd_adapter *adapter = user_data;
++       dbus_bool_t delayReportingFeature = adapter->delay_report;
++
++       dbus_message_iter_append_basic(iter, DBUS_TYPE_BOOLEAN, &delayReportingFeature);
++
++       return TRUE;
++}
++
++static void property_set_delay_report_feature(const GDBusPropertyTable *property, DBusMessageIter *iter, GDBusPendingPropertySet id, void *user_data)
++{
++       struct btd_adapter *adapter = user_data;
++       dbus_bool_t enable;
++       dbus_message_iter_get_basic(iter, &enable);
++
++       DBG("DelayReport %d", enable);
++       g_dbus_pending_property_success(id);
++       adapter->delay_report = enable;
++       store_adapter_info(adapter);
++       media_set_delay_reporting(adapter->media_adapter, adapter->delay_report);
++       g_dbus_emit_property_changed(dbus_conn, adapter->path, ADAPTER_INTERFACE, "DelayReport");
++       return;
++}
+ 
+ static void property_append_experimental(void *data, void *user_data)
+ {
+@@ -3714,6 +3749,7 @@ static const GDBusPropertyTable adapter_properties[] = {
+ 	{ "Roles", "as", property_get_roles },
+ 	{ "ExperimentalFeatures", "as", property_get_experimental, NULL,
+ 					property_experimental_exits },
++        { "DelayReport", "b", property_get_delay_report_feature, property_set_delay_report_feature },
+ 	{ }
+ };
+ 
+@@ -5091,6 +5127,11 @@ bool btd_adapter_get_bredr(struct btd_adapter *adapter)
+ 	return false;
+ }
+ 
++bool btd_adapter_get_delay_reporting(struct btd_adapter *adapter)
++{
++       return adapter->delay_report;
++}
++
+ struct btd_gatt_database *btd_adapter_get_database(struct btd_adapter *adapter)
+ {
+ 	if (!adapter)
+@@ -6617,6 +6658,15 @@ static void load_config(struct btd_adapter *adapter)
+ 		gerr = NULL;
+ 	}
+ 
++       /* Get delay report */
++       adapter->delay_report = g_key_file_get_boolean(key_file,
++                                       "General", "DelayReport", &gerr);
++       if (gerr) {
++               adapter->delay_report = btd_opts.delay_report;
++               g_error_free(gerr);
++               gerr = NULL;
++       }
++
+ 	g_key_file_free(key_file);
+ }
+ 
+@@ -6649,6 +6699,7 @@ static struct btd_adapter *btd_adapter_new(uint16_t index)
+ 						btd_opts.did_version);
+ 	adapter->discoverable_timeout = btd_opts.discovto;
+ 	adapter->pairable_timeout = btd_opts.pairto;
++        adapter->delay_report = btd_opts.delay_report;
+ 
+ 	DBG("System name: %s", adapter->system_name);
+ 	DBG("Major class: %u", adapter->major_class);
+@@ -6656,6 +6707,7 @@ static struct btd_adapter *btd_adapter_new(uint16_t index)
+ 	DBG("Modalias: %s", adapter->modalias);
+ 	DBG("Discoverable timeout: %u seconds", adapter->discoverable_timeout);
+ 	DBG("Pairable timeout: %u seconds", adapter->pairable_timeout);
++	DBG("DelayReport %d", adapter->delay_report);
+ 
+ 	adapter->auths = g_queue_new();
+ 	adapter->exps = queue_new();
+diff --git a/src/adapter.h b/src/adapter.h
+index b09044edd..d327c69b8 100644
+--- a/src/adapter.h
++++ b/src/adapter.h
+@@ -26,6 +26,7 @@
+ struct btd_adapter;
+ struct btd_device;
+ struct queue;
++struct media_adapter;
+ 
+ struct btd_adapter *btd_adapter_get_default(void);
+ bool btd_adapter_is_default(struct btd_adapter *adapter);
+@@ -69,6 +70,8 @@ bool btd_adapter_get_powered(struct btd_adapter *adapter);
+ bool btd_adapter_get_connectable(struct btd_adapter *adapter);
+ bool btd_adapter_get_discoverable(struct btd_adapter *adapter);
+ bool btd_adapter_get_bredr(struct btd_adapter *adapter);
++bool btd_adapter_get_delay_reporting(struct btd_adapter *adapter);
++void set_media_adapter(struct btd_adapter *adapter, struct media_adapter *media_adapter);
+ 
+ struct btd_gatt_database *btd_adapter_get_database(struct btd_adapter *adapter);
+ 
+diff --git a/src/btd.h b/src/btd.h
+index c02b2691e..68d5ccd4a 100644
+--- a/src/btd.h
++++ b/src/btd.h
+@@ -115,6 +115,7 @@ struct btd_opts {
+ 	gboolean	refresh_discovery;
+ 	gboolean	experimental;
+ 	struct queue	*kernel;
++	gboolean	delay_report;
+ 
+ 	uint16_t	did_source;
+ 	uint16_t	did_vendor;
+diff --git a/src/main.c b/src/main.c
+index 1d357161f..b120a3de3 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -80,6 +80,7 @@ static const char *supported_options[] = {
+ 	"MaxControllers"
+ 	"MultiProfile",
+ 	"FastConnectable",
++        "DelayReport",
+ 	"Privacy",
+ 	"JustWorksRepairing",
+ 	"TemporaryTimeout",
+@@ -881,6 +882,16 @@ static void parse_config(GKeyFile *config)
+ 		btd_opts.name_request_retry_delay = val;
+ 	}
+ 
++        boolean = g_key_file_get_boolean(config, "General",
++                                               "DelayReport", &err);
++        if (err)
++                g_clear_error(&err);
++        else
++        {
++                DBG("DelayReport=%d", boolean);
++                btd_opts.delay_report = boolean;
++        }
++
+ 	str = g_key_file_get_string(config, "GATT", "Cache", &err);
+ 	if (err) {
+ 		DBG("%s", err->message);
+diff --git a/src/main.conf b/src/main.conf
+index 2796f155e..0c6af35fe 100644
+--- a/src/main.conf
++++ b/src/main.conf
+@@ -69,6 +69,9 @@
+ # 'false'.
+ #FastConnectable = false
+ 
++# DelayReport will enable delay reporting
++DelayReport = true
++
+ # Default privacy setting.
+ # Enables use of private address.
+ # Possible values for LE mode: "off", "network/on", "device"

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0013-Implementation-to-get-connectedUuid-s-in-case-of-inc.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0013-Implementation-to-get-connectedUuid-s-in-case-of-inc.patch
@@ -1,0 +1,44 @@
+From 0db13b98a43f4b473f20a4b6356b392b01b6f5e4 Mon Sep 17 00:00:00 2001
+From: Rakes Pani <rakes.pani@lge.com>
+Date: Mon, 6 Apr 2020 12:14:43 +0530
+Subject: [PATCH] Implementation to get connectedUuid's in case of incoming
+ connection
+
+:Release Notes:
+Implementation to get connectedUuid's in case of incoming connection
+
+:Detailed Notes:
+Modified device.c to update connectedUuid
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-102289] Implement connect for A2DP_SINK
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ src/device.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/device.c b/src/device.c
+index 3cad84e37..d8a00a50f 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -7102,9 +7102,11 @@ static void service_state_changed(struct btd_service *service,
+ 				new_state == BTD_SERVICE_STATE_DISCONNECTING)
+ 		return;
+ 
+-	if (old_state == BTD_SERVICE_STATE_CONNECTING)
++	if ((old_state == BTD_SERVICE_STATE_CONNECTING) || 
++		(old_state == BTD_SERVICE_STATE_DISCONNECTED))
+ 		device_profile_connected(device, profile, err);
+-	else if (old_state == BTD_SERVICE_STATE_DISCONNECTING)
++	else if ((old_state == BTD_SERVICE_STATE_DISCONNECTING)||
++		 (old_state == BTD_SERVICE_STATE_CONNECTED))
+ 		device_profile_disconnected(device, profile, err);
+ }
+ 

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0014-Fix-for-updating-connected-uuids-when-profile-is-dis.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0014-Fix-for-updating-connected-uuids-when-profile-is-dis.patch
@@ -1,0 +1,41 @@
+From 49d6eda0e997100ff60b5114f404e4ebb7f04fdd Mon Sep 17 00:00:00 2001
+From: "ramya.hegde" <ramya.hegde@lge.com>
+Date: Tue, 14 Apr 2020 15:28:07 +0530
+Subject: [PATCH] Fix for updating connected uuids when profile is disconnected
+
+:Release Notes:
+Fix to remove uuid of the profile disconnected from connectedUuids list
+
+:Detailed Notes:
+Modified device.c to update connectedUuid in device_profile_disconnected function
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-102923] Implement disconnect to AVRCP target
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ src/device.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/device.c b/src/device.c
+index d8a00a50f..e02c9d87b 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -2576,7 +2576,10 @@ static void device_profile_disconnected(struct btd_device *dev,
+ 	DBG("%s %s (%d)", profile->name, strerror(-err), -err);
+ 	if (!err) {
+ 		if (dev->connected_uuids)
+-		dev->connected_uuids = g_slist_remove (dev->connected_uuids, profile->remote_uuid);
++		{
++			GSList *temp = g_slist_find_custom(dev->connected_uuids, g_strdup(profile->remote_uuid), bt_uuid_strcmp);
++			dev->connected_uuids = g_slist_delete_link(dev->connected_uuids, temp);
++		}
+ 		g_dbus_emit_property_changed(dbus_conn, dev->path,
+ 						DEVICE_INTERFACE, "ConnectedUUIDS");
+ 	}

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0015-Fix-device-getStatus-not-updated-when-unpaired.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0015-Fix-device-getStatus-not-updated-when-unpaired.patch
@@ -1,0 +1,52 @@
+From 9afbc88068ac0db2aee075dd7c96e5c9c5670e5a Mon Sep 17 00:00:00 2001
+From: Sameer Mulla <sameer.mulla@lge.com>
+Date: Mon, 27 Apr 2020 11:56:21 +0530
+Subject: [PATCH] Fix device/getStatus not updated when unpaired
+
+:Release Notes:
+Fix device/getStatus not updated when remote device is upaired
+
+:Detailed Notes:
+hfp/getStatus is not updated properly in below scenario
+pair and connect remote smartphone, then unpair device
+still it shows as connected because connectedRole in bluetooth2 service
+device/getStatus is not updated
+Root cause is buez5 side connectedUuid are updates with all
+profiles connected. This commit fixes above scenario
+
+:Testing Performed:
+Builded and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-102335] Test and fix hfp/getStatus for multiple adapter
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ src/device.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/device.c b/src/device.c
+index e02c9d87b..efb55a22d 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -1999,13 +1999,13 @@ static void device_profile_connected(struct btd_device *dev,
+ 
+ 	DBG("%s %s (%d)", profile->name, strerror(-err), -err);
+ 
+-	if (!err) {
++	if (!err && btd_device_is_connected(dev)) {
+ 		btd_device_set_temporary(dev, false);
+ 		dev->connected_uuids = g_slist_insert_sorted(dev->connected_uuids,
+-													g_strdup(profile->remote_uuid),
+-													bt_uuid_strcmp);
++							     g_strdup(profile->remote_uuid),
++							     bt_uuid_strcmp);
+ 		g_dbus_emit_property_changed(dbus_conn, dev->path,
+-									DEVICE_INTERFACE, "ConnectedUUIDS");
++					     DEVICE_INTERFACE, "ConnectedUUIDS");
+ 	}
+ 
+ 	if (dev->pending == NULL)

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0016-Set-default-pairing-capability-as-NoInputNoOutput.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0016-Set-default-pairing-capability-as-NoInputNoOutput.patch
@@ -1,0 +1,24 @@
+From 5a05defa821e458824bdfaf9ee6019849e687554 Mon Sep 17 00:00:00 2001
+From: "sungmok.shin" <sungmok.shin@lge.com>
+Date: Mon, 20 Apr 2020 19:24:45 +0900
+Subject: [PATCH] Set default pairing capability as "NoInputNoOutput"
+
+---
+Upstream-Status: Pending
+
+ src/agent.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/agent.c b/src/agent.c
+index 7d66cf50d..849a527c8 100644
+--- a/src/agent.c
++++ b/src/agent.c
+@@ -979,7 +979,7 @@ static DBusMessage *register_agent(DBusConnection *conn,
+ 						DBUS_TYPE_INVALID) == FALSE)
+ 		return btd_error_invalid_args(msg);
+ 
+-	cap = parse_io_capability(capability);
++	cap = parse_io_capability("NoInputNoOutput");
+ 	if (cap == IO_CAPABILITY_INVALID)
+ 		return btd_error_invalid_args(msg);
+ 

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0017-AVRCP-getting-supported-notification-events.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0017-AVRCP-getting-supported-notification-events.patch
@@ -1,0 +1,93 @@
+From 6fbb9d13f15635271529c508ba5a82ab5245b61f Mon Sep 17 00:00:00 2001
+From: "ramya.hegde" <ramya.hegde@lge.com>
+Date: Mon, 11 May 2020 15:54:12 +0530
+Subject: [PATCH] AVRCP getting supported notification events
+
+:Release Notes:
+AVRCP getting supported notification events
+
+:Detailed Notes:
+Added property for supported notification events for controller
+in device interface
+
+:Testing Performed:
+Built and Tested
+
+:QA Notes:
+
+:Issues Addressed:
+[PLAT-102247] [AVRCP CT] Implement
+              avrcp/internal/getSupportedNotificationEvents
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/avrcp.c |  1 +
+ src/device.c           | 21 +++++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/profiles/audio/avrcp.c b/profiles/audio/avrcp.c
+index 61478e913..ff9d9f97d 100644
+--- a/profiles/audio/avrcp.c
++++ b/profiles/audio/avrcp.c
+@@ -3992,6 +3992,7 @@ static gboolean avrcp_get_capabilities_resp(struct avctp *conn, uint8_t code,
+ 			break;
+ 		}
+ 	}
++	set_avrcp_ct_supported_events(session->dev, events);
+ 
+ 	if (!session->controller || !session->controller->player)
+ 		return FALSE;
+diff --git a/src/device.c b/src/device.c
+index efb55a22d..6a18c3451 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -284,6 +284,7 @@ struct btd_device {
+ 	struct key_code passththough_key;
+ 	uint8_t		avrcp_ct_features;
+ 	uint8_t		avrcp_tg_features;
++	uint16_t	avrcp_ct_supported_events;
+ };
+ 
+ static const uint16_t uuid_list[] = {
+@@ -1482,6 +1483,17 @@ static gboolean dev_property_get_key_code(const GDBusPropertyTable *property,
+ 	return TRUE;
+ }
+ 
++static gboolean dev_property_avrcp_ct_get_supported_events(const GDBusPropertyTable* property,
++	DBusMessageIter* iter, void* data)
++{
++	struct btd_device* device = data;
++	uint16_t supportedEvents = device->avrcp_ct_supported_events;
++
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_UINT16, &supportedEvents);
++	DBG("supportedEvents %d", supportedEvents);
++	return TRUE;
++}
++
+ static gboolean dev_property_get_avrcp_ct_feature(const GDBusPropertyTable *property,
+ 					DBusMessageIter *iter, void *data)
+ {
+@@ -2164,6 +2176,14 @@ void set_avrcp_feature(struct btd_device *dev, uint8_t feature, bool is_controll
+ 	}
+ }
+ 
++void set_avrcp_ct_supported_events(struct btd_device* dev, uint16_t supportedEvents)
++{
++	dev->avrcp_ct_supported_events = supportedEvents;
++	DBG("avrcp_ct supported events %x", dev->avrcp_ct_supported_events);
++	g_dbus_emit_property_changed(dbus_conn, dev->path,
++		DEVICE_INTERFACE, "AvrcpCTSupportedEvents");
++}
++
+ static void add_service_data(void *data, void *user_data)
+ {
+ 	struct eir_sd *sd = data;
+@@ -3207,6 +3227,7 @@ static const GDBusPropertyTable device_properties[] = {
+ 				NULL, dev_property_avrcp_ct_feature_exist},
+ 	{ "AvrcpTGFeatures", "y", dev_property_get_avrcp_tg_feature,
+ 				NULL, dev_property_avrcp_tg_feature_exist},
++	{ "AvrcpCTSupportedEvents", "q", dev_property_avrcp_ct_get_supported_events, NULL, NULL },
+ 	{ "ServiceData", "a{sv}", dev_property_get_service_data,
+ 				NULL, dev_property_service_data_exist },
+ 	{ "TxPower", "n", dev_property_get_tx_power, NULL,

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0018-Modified-MapInstanceName-MapInstanceProperties-parsi.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0018-Modified-MapInstanceName-MapInstanceProperties-parsi.patch
@@ -1,0 +1,289 @@
+From 9336709205cbd1d67f01cc0e841579013c4d254b Mon Sep 17 00:00:00 2001
+From: Rakes Pani <rakes.pani@lge.com>
+Date: Tue, 14 Jul 2020 10:37:18 +0900
+Subject: [PATCH] Modified MapInstanceName & MapInstanceProperties parsing and
+ type
+
+:Release Notes:
+Modified MapInstanceName & MapInstanceProperties parsing
+logic and MapInstanceProperties data type
+
+:Detailed Notes:
+New Properties MapIncatnceName and MapInstanceProperties
+Persistency of this properties is also done.
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-107882] Implement BlueZ API support for MAP connection support
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ src/device.c | 168 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 167 insertions(+), 1 deletion(-)
+
+diff --git a/src/device.c b/src/device.c
+index 6a18c3451..f6635fb13 100644
+--- a/src/device.c
++++ b/src/device.c
+@@ -220,6 +220,8 @@ struct btd_device {
+ 	char		*modalias;
+ 	struct btd_adapter	*adapter;
+ 	GSList		*uuids;
++        GSList          *mapInstances;
++        GSList          *mapInstancePropoerties;
+ 	GSList		*connected_uuids;
+ 	GSList		*primaries;		/* List of primary services */
+ 	GSList		*services;		/* List of btd_service */
+@@ -408,6 +410,7 @@ static gboolean store_device_info_cb(gpointer user_data)
+ 	char *str;
+ 	char class[9];
+ 	char **uuids = NULL;
++	char **mapInstances = NULL;
+ 	gsize length = 0;
+ 
+ 	device->store_id = 0;
+@@ -476,6 +479,35 @@ static gboolean store_device_info_cb(gpointer user_data)
+ 		g_key_file_remove_key(key_file, "General", "Services", NULL);
+ 	}
+ 
++        if (device->mapInstances) {
++               GSList *l;
++               int i;
++
++               mapInstances = g_new0(char *, g_slist_length(device->mapInstances) + 1);
++               for (i = 0, l = device->mapInstances; l; l = g_slist_next(l), i++)
++                       mapInstances[i] = l->data;
++               g_key_file_set_string_list(key_file, "General", "MapInstances",
++                                               (const char **)mapInstances, i);
++        } else {
++               g_key_file_remove_key(key_file, "General", "MapInstances", NULL);
++        }
++
++        if (device->mapInstancePropoerties) {
++               GSList *l = NULL;
++               int i;
++               gint mapProperties[g_slist_length(device->mapInstancePropoerties)];
++               for (i = 0, l = device->mapInstancePropoerties; l; l = g_slist_next(l), i++)
++               {
++                       int *p = (int *)l->data;
++                       DBG("Storing %d", *p);
++                       mapProperties[i] = *p;
++               }
++               g_key_file_set_integer_list(key_file, "General", "MapProperties",
++                                               mapProperties, i);
++        } else {
++               g_key_file_remove_key(key_file, "General", "MapProperties", NULL);
++        }
++
+ 	if (device->vendor_src) {
+ 		g_key_file_set_integer(key_file, "DeviceID", "Source",
+ 					device->vendor_src);
+@@ -506,6 +538,7 @@ static gboolean store_device_info_cb(gpointer user_data)
+ 
+ 	g_key_file_free(key_file);
+ 	g_free(uuids);
++	g_free(mapInstances);
+ 
+ 	return FALSE;
+ }
+@@ -775,6 +808,10 @@ static void device_free(gpointer user_data)
+ 	g_slist_free_full(device->uuids, g_free);
+ 	g_slist_free_full(device->primaries, g_free);
+ 	g_slist_free_full(device->svc_callbacks, svc_dev_remove);
++        if(device->mapInstances)
++               g_slist_free_full(device->mapInstances, g_free);
++        if(device->mapInstancePropoerties)
++        g_slist_free_full(device->mapInstancePropoerties, g_free);
+ 
+ 	/* Reset callbacks since the device is going to be freed */
+ 	gatt_db_unregister(device->db, device->db_id);
+@@ -1343,6 +1380,46 @@ static gboolean dev_property_get_uuids(const GDBusPropertyTable *property,
+ 	return TRUE;
+ }
+ 
++static gboolean dev_property_get_mapInstances(const GDBusPropertyTable *property,
++                                       DBusMessageIter *iter, void *data)
++{
++       struct btd_device *dev = data;
++       DBusMessageIter entry;
++       GSList *l;
++
++       dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
++                               DBUS_TYPE_STRING_AS_STRING, &entry);
++
++       l = dev->mapInstances;
++       for (; l != NULL; l = l->next)
++               dbus_message_iter_append_basic(&entry, DBUS_TYPE_STRING,
++                                                       &l->data);
++
++       dbus_message_iter_close_container(iter, &entry);
++
++       return TRUE;
++}
++
++static gboolean dev_property_get_mapInstanceProperties(const GDBusPropertyTable *property,
++                                       DBusMessageIter *iter, void *data)
++{
++       struct btd_device *dev = data;
++       DBusMessageIter entry;
++       GSList *l;
++
++       dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
++                               DBUS_TYPE_INT32_AS_STRING, &entry);
++
++       l = dev->mapInstancePropoerties;
++       for (; l != NULL; l = l->next)
++               dbus_message_iter_append_basic(&entry, DBUS_TYPE_INT32,
++                                                       l->data);
++
++       dbus_message_iter_close_container(iter, &entry);
++
++       return TRUE;
++}
++
+ static gboolean dev_property_get_modalias(const GDBusPropertyTable *property,
+ 					DBusMessageIter *iter, void *data)
+ {
+@@ -3242,6 +3319,8 @@ static const GDBusPropertyTable device_properties[] = {
+ 	{ "WakeAllowed", "b", dev_property_get_wake_allowed,
+ 				dev_property_set_wake_allowed,
+ 				dev_property_wake_allowed_exist },
++        { "MapInstances", "as", dev_property_get_mapInstances },
++        { "MapInstanceProperties", "ai", dev_property_get_mapInstanceProperties },
+ 	{ }
+ };
+ 
+@@ -3562,6 +3641,32 @@ static void load_services(struct btd_device *device, char **uuids)
+ 	g_strfreev(uuids);
+ }
+ 
++static void load_map_instances(struct btd_device *device, char **instanceNames)
++{
++       char **instanceName;
++
++       for (instanceName = instanceNames; *instanceName; instanceName++) {
++               if (g_slist_find(device->mapInstances, *instanceName))
++                       continue;
++
++               device->mapInstances = g_slist_append (device->mapInstances,
++                                                       g_strdup(*instanceName));
++       }
++
++       g_strfreev(instanceNames);
++}
++
++static void load_map_properties(struct btd_device *device, int *instanceProperties, gsize len)
++{
++       for (int i = 0; i < len; i++) {
++               DBG("load_map_properties %d ", instanceProperties[i]);
++               int *instanceProperty = (int *)malloc(sizeof(int));
++               *instanceProperty = instanceProperties[i];
++               device->mapInstancePropoerties = g_slist_append(device->mapInstancePropoerties, instanceProperty);
++       }
++       g_free(instanceProperties);
++}
++
+ static void convert_info(struct btd_device *device, GKeyFile *key_file)
+ {
+ 	char filename[PATH_MAX];
+@@ -3614,7 +3719,7 @@ static void load_info(struct btd_device *device, const char *local,
+ 	gboolean store_needed = FALSE;
+ 	gboolean blocked;
+ 	gboolean wake_allowed;
+-	char **uuids;
++	char **uuids, **mapInstances;
+ 	int source, vendor, product, version;
+ 	char **techno, **t;
+ 
+@@ -3710,6 +3815,23 @@ next:
+ 		device->bredr_state.svc_resolved = true;
+ 	}
+ 
++       /* Load MAP instances */
++        mapInstances =  g_key_file_get_string_list(key_file, "General", "MapInstances",
++                                               NULL, NULL);
++
++        if (mapInstances) {
++                load_map_instances(device, mapInstances);
++        }
++
++        /* Load MAP instance Properties */
++        int *mapInstanceProperties;
++        gsize length = 0;
++        mapInstanceProperties =  g_key_file_get_integer_list(key_file, "General", "MapProperties",
++                                                &length, NULL);
++        if (mapInstanceProperties) {
++                load_map_properties(device, mapInstanceProperties, length);
++        }
++
+ 	/* Load device id */
+ 	source = g_key_file_get_integer(key_file, "DeviceID", "Source", NULL);
+ 	if (source) {
+@@ -4988,6 +5110,29 @@ static int update_record(struct browse_req *req, const char *uuid,
+ 	return 0;
+ }
+ 
++static int update_mapInstanceName(struct browse_req *req, const char *instanceName)
++{
++       GSList *l;
++
++       /* Check if UUID is duplicated */
++       l = g_slist_find(req->device->mapInstances, instanceName);
++       if (l == NULL) {
++               req->device->mapInstances = g_slist_append(req->device->mapInstances,
++                                                       g_strdup(instanceName));
++               return 0;
++       }
++       return -EALREADY;
++}
++
++static int update_mapInstanceProperties(struct browse_req *req, uint8_t supportedMessageType)
++{
++       int *p = (int *)malloc(sizeof(int));
++       *p = supportedMessageType;
++       req->device->mapInstancePropoerties = g_slist_append(req->device->mapInstancePropoerties,
++                                                       p);
++       return 0;
++}
++
+ static void update_bredr_services(struct browse_req *req, sdp_list_t *recs)
+ {
+ 	struct btd_device *device = req->device;
+@@ -5045,6 +5190,23 @@ static void update_bredr_services(struct browse_req *req, sdp_list_t *recs)
+ 		if (!profile_uuid)
+ 			continue;
+ 
++                if (bt_uuid_strcmp(profile_uuid, OBEX_MAS_UUID) == 0) {
++                        sdp_data_t *mapInstanceData;
++                        DBG("MAS Profile");
++                        mapInstanceData = sdp_data_get(rec, 0x0100);
++                        /* PSM must be odd and lsb of upper byte must be 0 */
++                        if (mapInstanceData != NULL)
++                        {
++                                DBG("instance Name %s " ,mapInstanceData->val.str);
++                                if(update_mapInstanceName(req,mapInstanceData->val.str) == 0)
++                                {
++                                        mapInstanceData = sdp_data_get(rec, SDP_ATTR_SUPPORTED_MESSAGE_TYPES);
++                                        DBG("instance Properties %d " ,mapInstanceData->val.uint8);
++                                        update_mapInstanceProperties(req,mapInstanceData->val.uint8);
++                                }
++                        }
++                }
++
+ 		if (bt_uuid_strcmp(profile_uuid, PNP_UUID) == 0) {
+ 			uint16_t source, vendor, product, version;
+ 			sdp_data_t *pdlist;
+@@ -5223,6 +5385,10 @@ static void search_cb(sdp_list_t *recs, int err, gpointer user_data)
+ 	/* Propagate services changes */
+ 	g_dbus_emit_property_changed(dbus_conn, req->device->path,
+ 						DEVICE_INTERFACE, "UUIDs");
++        g_dbus_emit_property_changed(dbus_conn, req->device->path,
++                                                DEVICE_INTERFACE, "MapInstances");
++        g_dbus_emit_property_changed(dbus_conn, req->device->path,
++                                                DEVICE_INTERFACE, "MapInstanceProperties");
+ 
+ send_reply:
+ 	/* If SDP search failed during an ongoing connection request, we should

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0019-Enabled-EMAIL-support-based-on-MAPInstance-Name-Modi.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0019-Enabled-EMAIL-support-based-on-MAPInstance-Name-Modi.patch
@@ -1,0 +1,329 @@
+From 9cb46738bbc32fbdb04488e56af02d2c02da3421 Mon Sep 17 00:00:00 2001
+From: Rakes Pani <rakes.pani@lge.com>
+Date: Wed, 3 Jun 2020 18:08:39 +0530
+Subject: [PATCH] Enabled EMAIL support based on MAPInstance Name Modified
+ ObexCtl to support modified API Modified ObexCtl to support lsFolder
+
+:Release Notes:
+    Added MAP connection based on instanceName
+
+:Detailed Notes:
+    Added MAP connection based on instanceName
+    ObexCtl to support modified API Modified ObexCtl to support lsFolder
+
+:QA Notes:
+    NA
+
+:Issues Addressed:
+    [PLAT-107882] Implement BlueZ API support for MAP connection support
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ obexd/client/bluetooth.c | 21 ++++++++++++++++++---
+ obexd/client/manager.c   | 10 ++++++----
+ obexd/client/map.c       | 17 +++++++++++++++++
+ obexd/client/session.c   |  9 ++++++++-
+ obexd/client/session.h   |  1 +
+ obexd/client/transport.h |  2 +-
+ tools/obexctl.c          | 13 +++++++++++--
+ 7 files changed, 62 insertions(+), 11 deletions(-)
+
+diff --git a/obexd/client/bluetooth.c b/obexd/client/bluetooth.c
+index ca2c023fb..c197fe8aa 100644
+--- a/obexd/client/bluetooth.c
++++ b/obexd/client/bluetooth.c
+@@ -44,6 +44,7 @@ struct bluetooth_session {
+ 	sdp_record_t *sdp_record;
+ 	GIOChannel *io;
+ 	char *service;
++	char *instanceName;
+ 	obc_transport_func func;
+ 	void *user_data;
+ };
+@@ -178,6 +179,17 @@ static void search_callback(uint8_t type, uint16_t status,
+ 		if (data != NULL && (data->val.uint16 & 0x0101) == 0x0001)
+ 			ch = data->val.uint16;
+ 
++		data = sdp_data_get(rec, 0x0100);
++		/* PSM must be odd and lsb of upper byte must be 0 */
++		if (data != NULL)
++		{
++			DBG("instance Name %s " ,data->val.str);
++			if(session->instanceName)
++			DBG("instance Name %s " ,session->instanceName);
++			if (session->instanceName && !g_str_has_prefix(data->val.str,session->instanceName))
++				ch = 0;
++		}
++			
+ 		/* Cache the sdp record associated with the service that we
+ 		 * attempt to connect. This allows reading its application
+ 		 * specific service attributes. */
+@@ -362,12 +374,14 @@ static int session_connect(struct bluetooth_session *session)
+ 	DBG("session %p", session);
+ 
+ 	if (session->port > 0) {
++		DBG("serviceconnect for PSM Value %d ",session->port);
+ 		session->io = transport_connect(&session->src, &session->dst,
+ 							session->port,
+ 							transport_callback,
+ 							session);
+ 		err = (session->io == NULL) ? -EINVAL : 0;
+ 	} else {
++		DBG("serviceconnect for sdp");
+ 		session->sdp = service_connect(&session->src, &session->dst,
+ 						service_callback, session);
+ 		err = (session->sdp == NULL) ? -ENOMEM : 0;
+@@ -377,14 +391,14 @@ static int session_connect(struct bluetooth_session *session)
+ }
+ 
+ static guint bluetooth_connect(const char *source, const char *destination,
+-				const char *service, uint16_t port,
++				const char *service, const char *instanceName, uint16_t port,
+ 				obc_transport_func func, void *user_data)
+ {
+ 	struct bluetooth_session *session;
+ 	static guint id = 0;
+ 
+-	DBG("src %s dest %s service %s port %u",
+-				source, destination, service, port);
++	DBG("src %s dest %s service %s instanceName %s port %u",
++				source, destination, service,instanceName, port);
+ 
+ 	if (destination == NULL)
+ 		return 0;
+@@ -397,6 +411,7 @@ static guint bluetooth_connect(const char *source, const char *destination,
+ 	session->func = func;
+ 	session->port = port;
+ 	session->user_data = user_data;
++	session->instanceName = g_strdup(instanceName);
+ 
+ 	str2ba(destination, &session->dst);
+ 	str2ba(source, &session->src);
+diff --git a/obexd/client/manager.c b/obexd/client/manager.c
+index 75f1bfb04..dde5b3e82 100644
+--- a/obexd/client/manager.c
++++ b/obexd/client/manager.c
+@@ -107,7 +107,7 @@ done:
+ }
+ 
+ static int parse_device_dict(DBusMessageIter *iter,
+-		const char **source, const char **target, uint8_t *channel)
++		const char **source, const char **target, uint8_t *channel, const char **instanceName)
+ {
+ 	while (dbus_message_iter_get_arg_type(iter) == DBUS_TYPE_DICT_ENTRY) {
+ 		DBusMessageIter entry, value;
+@@ -125,6 +125,8 @@ static int parse_device_dict(DBusMessageIter *iter,
+ 				dbus_message_iter_get_basic(&value, source);
+ 			else if (g_str_equal(key, "Target") == TRUE)
+ 				dbus_message_iter_get_basic(&value, target);
++			else if (g_str_equal(key, "InstanceName") == TRUE)
++				dbus_message_iter_get_basic(&value, instanceName);
+ 			break;
+ 		case DBUS_TYPE_BYTE:
+ 			if (g_str_equal(key, "Channel") == TRUE)
+@@ -158,7 +160,7 @@ static DBusMessage *create_session(DBusConnection *connection,
+ 	DBusMessageIter iter, dict;
+ 	struct obc_session *session;
+ 	struct send_data *data;
+-	const char *source = NULL, *dest = NULL, *target = NULL;
++	const char *source = NULL, *dest = NULL, *target = NULL ,*inStanceName = NULL;
+ 	uint8_t channel = 0;
+ 
+ 	dbus_message_iter_init(message, &iter);
+@@ -175,7 +177,7 @@ static DBusMessage *create_session(DBusConnection *connection,
+ 
+ 	dbus_message_iter_recurse(&iter, &dict);
+ 
+-	parse_device_dict(&dict, &source, &target, &channel);
++	parse_device_dict(&dict, &source, &target, &channel,&inStanceName);
+ 	if (dest == NULL || target == NULL)
+ 		return g_dbus_create_error(message,
+ 				ERROR_INTERFACE ".InvalidArguments", NULL);
+@@ -188,7 +190,7 @@ static DBusMessage *create_session(DBusConnection *connection,
+ 	data->connection = dbus_connection_ref(connection);
+ 	data->message = dbus_message_ref(message);
+ 
+-	session = obc_session_create(source, dest, target, channel,
++	session = obc_session_create(source, dest, target,inStanceName, channel,
+ 					dbus_message_get_sender(message),
+ 					create_callback, data);
+ 	if (session != NULL) {
+diff --git a/obexd/client/map.c b/obexd/client/map.c
+index ea3d25629..2eb2c17a6 100644
+--- a/obexd/client/map.c
++++ b/obexd/client/map.c
+@@ -1582,6 +1582,19 @@ static DBusMessage *map_list_filter_fields(DBusConnection *connection,
+ 	return reply;
+ }
+ 
++static DBusMessage *map_list_supported_message_types(DBusConnection *connection,
++					DBusMessage *message, void *user_data)
++{
++	DBG("");
++	struct map_data *map = user_data;
++	DBusMessage *reply;
++	uint8_t message_types = map->supported_message_types;
++	reply = dbus_message_new_method_return(message);
++	dbus_message_append_args(reply, DBUS_TYPE_BYTE,
++				&message_types, DBUS_TYPE_INVALID);
++	return reply;
++}
++
+ static void update_inbox_cb(struct obc_session *session,
+ 				struct obc_transfer *transfer,
+ 				GError *err, void *user_data)
+@@ -1818,6 +1831,10 @@ static const GDBusMethodTable map_methods[] = {
+ 			GDBUS_ARGS({ "transfer", "o" },
+ 						{ "properties", "a{sv}" }),
+ 			map_push_message) },
++	{ GDBUS_METHOD("ListSupportedMessageType",
++			NULL,
++			GDBUS_ARGS({ "types", "y" }),
++			map_list_supported_message_types) },
+ 	{ }
+ };
+ 
+diff --git a/obexd/client/session.c b/obexd/client/session.c
+index 884013b75..0bfed30b3 100644
+--- a/obexd/client/session.c
++++ b/obexd/client/session.c
+@@ -87,6 +87,7 @@ struct obc_session {
+ 	int refcount;
+ 	char *source;
+ 	char *destination;
++	char *inStanceName;
+ 	uint8_t channel;
+ 	struct obc_transport *transport;
+ 	struct obc_driver *driver;
+@@ -541,7 +542,7 @@ static int session_connect(struct obc_session *session,
+ 	}
+ 
+ 	session->id = transport->connect(session->source, session->destination,
+-					driver->uuid, session->channel,
++					driver->uuid,session->inStanceName, session->channel,
+ 					transport_func, callback);
+ 	if (session->id == 0) {
+ 		obc_session_unref(callback->session);
+@@ -557,6 +558,7 @@ static int session_connect(struct obc_session *session,
+ struct obc_session *obc_session_create(const char *source,
+ 						const char *destination,
+ 						const char *service,
++						const char *instanceName,
+ 						uint8_t channel,
+ 						const char *owner,
+ 						session_callback_t function,
+@@ -597,6 +599,7 @@ struct obc_session *obc_session_create(const char *source,
+ 	session->conn = conn;
+ 	session->source = g_strdup(source);
+ 	session->destination = g_strdup(destination);
++	//session->inStanceName = g_strdup(instanceName);
+ 	session->channel = channel;
+ 	session->queue = g_queue_new();
+ 	session->folder = g_strdup("/");
+@@ -605,6 +608,7 @@ struct obc_session *obc_session_create(const char *source,
+ 		obc_session_set_owner(session, owner, owner_disconnected);
+ 
+ proceed:
++	session->inStanceName = g_strdup(instanceName);
+ 	if (session_connect(session, function, user_data) < 0) {
+ 		obc_session_unref(session);
+ 		return NULL;
+@@ -613,6 +617,9 @@ proceed:
+ 	DBG("session %p transport %s driver %s", session,
+ 			session->transport->name, session->driver->service);
+ 
++	DBG("session %p source %s destination %s", session,
++			session->source, session->destination);
++
+ 	return session;
+ }
+ 
+diff --git a/obexd/client/session.h b/obexd/client/session.h
+index 2c646df1a..5e200e40d 100644
+--- a/obexd/client/session.h
++++ b/obexd/client/session.h
+@@ -21,6 +21,7 @@ typedef void (*session_callback_t) (struct obc_session *session,
+ struct obc_session *obc_session_create(const char *source,
+ 						const char *destination,
+ 						const char *service,
++						const char *instanceName,
+ 						uint8_t channel,
+ 						const char *owner,
+ 						session_callback_t function,
+diff --git a/obexd/client/transport.h b/obexd/client/transport.h
+index e1f1a5c53..43164c522 100644
+--- a/obexd/client/transport.h
++++ b/obexd/client/transport.h
+@@ -14,7 +14,7 @@ typedef void (*obc_transport_func)(GIOChannel *io, GError *err,
+ struct obc_transport {
+ 	const char *name;
+ 	guint (*connect) (const char *source, const char *destination,
+-				const char *service, uint16_t port,
++				const char *service,const char *instanceName, uint16_t port,
+ 				obc_transport_func func, void *user_data);
+ 	int (*getpacketopt) (GIOChannel *io, int *tx_mtu, int *rx_mtu);
+ 	void (*disconnect) (guint id);
+diff --git a/tools/obexctl.c b/tools/obexctl.c
+index 8678b86c9..3efff7ddf 100644
+--- a/tools/obexctl.c
++++ b/tools/obexctl.c
+@@ -115,6 +115,7 @@ struct connect_args {
+ 	char *dev;
+ 	char *target;
+ 	uint8_t channel;
++	char *instanceName;
+ };
+ 
+ static void connect_args_free(void *data)
+@@ -143,6 +144,8 @@ static void connect_setup(DBusMessageIter *iter, void *user_data)
+ 	if (args->target)
+ 		g_dbus_dict_append_entry(&dict, "Target",
+ 					DBUS_TYPE_STRING, &args->target);
++	g_dbus_dict_append_entry(&dict, "InstanceName",
++					DBUS_TYPE_STRING, &args->instanceName);
+ 
+ 	if (args->channel)
+ 		g_dbus_dict_append_entry(&dict, "Channel",
+@@ -156,6 +159,7 @@ static void cmd_connect(int argc, char *argv[])
+ 	struct connect_args *args;
+ 	const char *target = "opp";
+ 	int channel = 0;
++	const char *instanceName = "";
+ 
+ 	if (!client) {
+ 		bt_shell_printf("Client proxy not available\n");
+@@ -175,10 +179,14 @@ static void cmd_connect(int argc, char *argv[])
+ 		}
+ 	}
+ 
++	if (argc > 4)
++		instanceName = argv[4];
++
+ 	args = g_new0(struct connect_args, 1);
+ 	args->dev = g_strdup(argv[1]);
+ 	args->target = g_strdup(target);
+ 	args->channel = channel;
++	args->instanceName = g_strdup(instanceName);
+ 
+ 	if (g_dbus_proxy_method_call(client, "CreateSession", connect_setup,
+ 			connect_reply, args, connect_args_free) == FALSE) {
+@@ -1846,7 +1854,7 @@ static void cmd_mkdir(int argc, char *argv[])
+ static const struct bt_shell_menu main_menu = {
+ 	.name = "main",
+ 	.entries = {
+-	{ "connect",      "<dev> [uuid] [channel]", cmd_connect,
++	{ "connect",      "<dev> [uuid] [channel] [instanceName]", cmd_connect,
+ 						"Connect session" },
+ 	{ "disconnect",   "[session]", cmd_disconnect, "Disconnect session",
+ 						session_generator },
+@@ -1867,7 +1875,8 @@ static const struct bt_shell_menu main_menu = {
+ 	{ "pull",	  "<file>",   cmd_pull,
+ 					"Pull Vobject & stores in file" },
+ 	{ "cd",           "<path>",   cmd_cd, "Change current folder" },
+-	{ "ls",           "<options>", cmd_ls, "List current folder" },
++	{ "ls",           "<options>", cmd_ls, "List current folder Items" },
++	{ "lsFolder",           NULL, cmd_ls, "List current folder" },
+ 	{ "cp",          "<source file> <destination file>",   cmd_cp,
+ 				"Copy source file to destination file" },
+ 	{ "mv",          "<source file> <destination file>",   cmd_mv,

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0020-Disabling-DB-Hash-for-Gatt.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0020-Disabling-DB-Hash-for-Gatt.patch
@@ -1,0 +1,59 @@
+From 6977994366e9391ee1b7d7423ce057898d6e9af4 Mon Sep 17 00:00:00 2001
+From: Vibhanshu Dhote <vibhanshu.dhote@lge.com>
+Date: Tue, 28 Jul 2020 16:04:27 +0530
+Subject: [PATCH] Disabling DB Hash for Gatt
+
+:Release Notes:
+Disabling DB Hash for Gatt for Bluez 5.54
+
+:Detailed Notes:
+Disabling DB Hash for Gatt for Bluez 5.54 version
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-107885] Analyze and Adopt the changes for BlueZ 5.54 apis for
+              GATT profile
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ src/gatt-database.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/gatt-database.c b/src/gatt-database.c
+index cf651b5f5..9812c3157 100644
+--- a/src/gatt-database.c
++++ b/src/gatt-database.c
+@@ -1191,11 +1191,13 @@ static void db_hash_read_cb(struct gatt_db_attribute *attrib,
+ 
+ 	hash = gatt_db_get_hash(database->db);
+ 
+-	gatt_db_attribute_read_result(attrib, id, 0, hash, 16);
++	if(gatt_db_attribute_read_result(attrib, id, 0, hash, 16))
++		DBG("Database Hash read 1");
+ 
+ 	if (!get_dst_info(att, &bdaddr, &bdaddr_type))
+ 		return;
+ 
++	DBG("Database Hash read 2");
+ 	state = find_device_state(database, &bdaddr, bdaddr_type);
+ 	if (state)
+ 		state->change_aware = true;
+@@ -1251,6 +1253,7 @@ static void populate_gatt_service(struct btd_gatt_database *database)
+ 	gatt_db_attribute_set_fixed_length(database->cli_feat, CLI_FEAT_SIZE);
+ 
+ 	/* Only expose database hash chrc if supported */
++/*
+ 	if (gatt_db_hash_support(database->db)) {
+ 		bt_uuid16_create(&uuid, GATT_CHARAC_DB_HASH);
+ 		database->db_hash = gatt_db_service_add_characteristic(service,
+@@ -1258,6 +1261,7 @@ static void populate_gatt_service(struct btd_gatt_database *database)
+ 				db_hash_read_cb, NULL, database);
+ 		gatt_db_attribute_set_fixed_length(database->db_hash, 16);
+ 	}
++*/
+ 
+ 	/* Only enable EATT if there is a socket listening */
+ 	if (database->eatt_io) {

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0021-Added-Notification-property-in-org.bluez.obex.Messag.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0021-Added-Notification-property-in-org.bluez.obex.Messag.patch
@@ -1,0 +1,311 @@
+From b6fe529764b1e78d4a8fceea2d124816a577687e Mon Sep 17 00:00:00 2001
+From: Rakes Pani <rakes.pani@lge.com>
+Date: Fri, 7 Aug 2020 18:32:03 +0530
+Subject: [PATCH] Added Notification property in org.bluez.obex.MessageAccess1
+
+:Release Notes:
+Added Notification property in org.bluez.obex.MessageAccess1
+
+:Detailed Notes:
+New Properties Notification is added for MAP.
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-107891] Implement BlueZ API for getMessageNotificationEvent
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ doc/obex-api.txt   |  48 ++++++++++++++
+ obexd/client/map.c | 153 ++++++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 198 insertions(+), 3 deletions(-)
+
+diff --git a/doc/obex-api.txt b/doc/obex-api.txt
+index f39355af0..85301dcda 100644
+--- a/doc/obex-api.txt
++++ b/doc/obex-api.txt
+@@ -799,6 +799,54 @@ Filter:		uint16 Offset:
+ 			Possible values: True for high priority or False for
+ 			non-high priority
+ 
++Properties dict Notification [readonly]
++
++			Notification data contains list of below property
++
++			String ObjectPath :
++
++				Object path of the message.
++
++			string EventType :
++
++				Notification Event Type.
++
++				Possible values : "NewMessage" , "DeliverySuccess",
++				"SendingSuccess", "DeliveryFailure", "SendingFailure",
++				"MessageDeleted", "MessageShift".
++
++			string Folder :
++
++				Folder which the message belongs to.
++
++			string Type :
++
++				Message type
++
++				Possible values: "email", "sms-gsm",
++				"sms-cdma" and "mms"
++
++			string Subject :
++
++				Message subject, only available for "NewMessage".
++
++			string Timestamp :
++
++				Message timestamp, only available for "NewMessage".
++
++			string Sender :
++
++				Message sender name, only available for "NewMessage".
++
++			string OldFolder :
++
++				Folder which message is shifted, only available for
++				"MessageShift".
++
++			boolean Priority:
++
++				Message Priority, only available for "NewMessage"
++
+ Message hierarchy
+ =================
+ 
+diff --git a/obexd/client/map.c b/obexd/client/map.c
+index 2eb2c17a6..ada9377b8 100644
+--- a/obexd/client/map.c
++++ b/obexd/client/map.c
+@@ -85,12 +85,25 @@ static const char * const filter_list[] = {
+ #define STATUS_DELETE 1
+ #define FILLER_BYTE 0x30
+ 
++struct map_notification {
++	char *eventType;
++	char *path;
++	char *folder;
++	char *old_folder;
++	char *msg_type;
++	char *datetime;
++	char *subject;
++	char *sender_name;
++	gboolean priority;
++};
++
+ struct map_data {
+ 	struct obc_session *session;
+ 	GHashTable *messages;
+ 	int16_t mas_instance_id;
+ 	uint8_t supported_message_types;
+ 	uint32_t supported_features;
++	struct map_notification *notification;
+ };
+ 
+ struct pending_request {
+@@ -420,6 +433,20 @@ static void map_msg_free(void *data)
+ 	g_free(msg);
+ }
+ 
++static void map_notification_free(void *data)
++{
++	struct map_notification *notification = data;
++
++	g_free(notification->eventType);
++	g_free(notification->path);
++	g_free(notification->subject);
++	g_free(notification->folder);
++	g_free(notification->old_folder);
++	g_free(notification->datetime);
++	g_free(notification->sender_name);
++	g_free(notification->msg_type);
++}
++
+ static DBusMessage *map_msg_get(DBusConnection *connection,
+ 					DBusMessage *message, void *user_data)
+ {
+@@ -1849,6 +1876,62 @@ static void map_msg_remove(void *data)
+ 	g_free(path);
+ }
+ 
++static void update_event_type(struct map_data *map, struct map_event *event)
++{
++	switch (event->type) {
++	case MAP_ET_NEW_MESSAGE:
++		map->notification->eventType = g_strdup("NewMessage");
++		break;
++	case MAP_ET_DELIVERY_SUCCESS:
++		map->notification->eventType = g_strdup("DeliverySuccess");
++		break;
++	case MAP_ET_SENDING_SUCCESS:
++		map->notification->eventType = g_strdup("SendingSuccess");
++		break;
++	case MAP_ET_DELIVERY_FAILURE:
++		map->notification->eventType = g_strdup("DeliveryFailure");
++		break;
++	case MAP_ET_SENDING_FAILURE:
++		map->notification->eventType = g_strdup("SendingFailure");
++		break;
++	case MAP_ET_MESSAGE_DELETED:
++		map->notification->eventType = g_strdup("MessageDeleted");
++		break;
++	case MAP_ET_MESSAGE_SHIFT:
++		map->notification->eventType = g_strdup("MessageShift");
++		break;
++	case MAP_ET_MEMORY_FULL:
++	case MAP_ET_MEMORY_AVAILABLE:
++	default:
++		break;
++	}
++}
++
++static void map_update_notification(struct map_data *map,
++							struct map_event *event, struct map_msg *msg)
++{
++	if(map->notification)
++	{
++		map_notification_free(map->notification);
++		update_event_type(map, event);
++		map->notification->path = g_strdup_printf("%s",msg->path);
++		map->notification->folder = g_strdup(event->folder);
++		map->notification->sender_name = g_strdup(event->sender_name);
++		map->notification->subject = g_strdup(event->subject);
++		map->notification->msg_type = g_strdup(msg->type);
++		map->notification->datetime = g_strdup(event->datetime);
++		map->notification->old_folder = g_strdup(event->old_folder);
++		if(event->priority)
++		{
++			map->notification->priority = FALSE;
++			if(!strcasecmp(event->priority, "yes"))
++				map->notification->priority = TRUE;
++		}
++		g_dbus_emit_property_changed(conn, obc_session_get_path(map->session), MAP_INTERFACE,
++									"Notification");
++	}
++}
++
+ static void map_handle_new_message(struct map_data *map,
+ 							struct map_event *event)
+ {
+@@ -1859,7 +1942,15 @@ static void map_handle_new_message(struct map_data *map,
+ 	if (msg)
+ 		g_hash_table_remove(map->messages, &event->handle);
+ 
+-	map_msg_create(map, event->handle, event->folder, event->msg_type);
++	msg = map_msg_create(map, event->handle, event->folder, event->msg_type);
++	if (msg)
++	{
++		msg->subject = g_strdup(event->subject);
++		msg->sender = g_strdup(event->sender_name);
++		msg->timestamp = g_strdup(event->datetime);
++		if(event->priority)
++			parse_priority(msg,event->priority);
++	}
+ }
+ 
+ static void map_handle_status_changed(struct map_data *map,
+@@ -1880,6 +1971,8 @@ static void map_handle_status_changed(struct map_data *map,
+ 
+ 	g_dbus_emit_property_changed(conn, msg->path, MAP_MSG_INTERFACE,
+ 								"Status");
++
++	map_update_notification(map, event, msg);
+ }
+ 
+ static void map_handle_folder_changed(struct map_data *map,
+@@ -1903,6 +1996,8 @@ static void map_handle_folder_changed(struct map_data *map,
+ 
+ 	g_dbus_emit_property_changed(conn, msg->path, MAP_MSG_INTERFACE,
+ 								"Folder");
++
++	map_update_notification(map, event, msg);
+ }
+ 
+ static void map_handle_notification(struct map_event *event, void *user_data)
+@@ -1945,6 +2040,49 @@ static void map_handle_notification(struct map_event *event, void *user_data)
+ 	}
+ }
+ 
++static gboolean map_get_msg_notification(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct map_data *map = data;
++
++	if(!map->notification)
++		return FALSE;
++
++	DBusMessageIter dict;
++	dbus_message_iter_open_container(iter, DBUS_TYPE_ARRAY,
++					DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
++					DBUS_TYPE_STRING_AS_STRING
++					DBUS_TYPE_VARIANT_AS_STRING
++					DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
++					&dict);
++
++	g_dbus_dict_append_entry(&dict, "ObjectPath", DBUS_TYPE_STRING, &map->notification->path);
++	g_dbus_dict_append_entry(&dict, "EventType", DBUS_TYPE_STRING, &map->notification->eventType);
++	g_dbus_dict_append_entry(&dict, "Folder", DBUS_TYPE_STRING, &map->notification->folder);
++	g_dbus_dict_append_entry(&dict, "Type", DBUS_TYPE_STRING, &map->notification->msg_type);
++
++	if(!g_strcmp0(map->notification->eventType,"NewMessage"))
++	{
++		g_dbus_dict_append_entry(&dict, "Subject", DBUS_TYPE_STRING, &map->notification->subject);
++		g_dbus_dict_append_entry(&dict, "Timestamp", DBUS_TYPE_STRING, &map->notification->datetime);
++		g_dbus_dict_append_entry(&dict, "Sender", DBUS_TYPE_STRING, &map->notification->sender_name);
++		g_dbus_dict_append_entry(&dict, "Priority", DBUS_TYPE_BOOLEAN, &map->notification->priority);
++	}
++	else if (!g_strcmp0(map->notification->eventType,"MessageShift"))
++	{
++		g_dbus_dict_append_entry(&dict, "OldFolder", DBUS_TYPE_STRING, &map->notification->old_folder);
++	}
++
++	dbus_message_iter_close_container(iter, &dict);
++
++	return TRUE;
++}
++
++static const GDBusPropertyTable map_properties[] = {
++	{ "Notification", "a{sv}", map_get_msg_notification },
++	{ }
++};
++
+ static bool set_notification_registration(struct map_data *map, bool status)
+ {
+ 	struct obc_transfer *transfer;
+@@ -1992,6 +2130,8 @@ static void map_free(void *data)
+ 
+ 	obc_session_unref(map->session);
+ 	g_hash_table_unref(map->messages);
++	map_notification_free(map->notification);
++	g_free(map->notification);
+ 	g_free(map);
+ }
+ 
+@@ -2044,10 +2184,17 @@ static int map_probe(struct obc_session *session)
+ 
+ 	DBG("%s, instance id %d", path, map->mas_instance_id);
+ 
+-	set_notification_registration(map, true);
++	if(set_notification_registration(map, true)){
++		map->notification = g_try_new0(struct map_notification, 1);
++		if(!map->notification)
++		{
++			map_free(map);
++			return -ENOMEM;
++		}
++	}
+ 
+ 	if (!g_dbus_register_interface(conn, path, MAP_INTERFACE, map_methods,
+-					NULL, NULL, map, map_free)) {
++					NULL, map_properties, map, map_free)) {
+ 		map_free(map);
+ 
+ 		return -ENOMEM;

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0022-Added-MessageHandle-property-in-org.bluez.obex.Trans.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0022-Added-MessageHandle-property-in-org.bluez.obex.Trans.patch
@@ -1,0 +1,194 @@
+From ae93a4c8f6d3557f400b1de27f837f06e5a18632 Mon Sep 17 00:00:00 2001
+From: Rakes Pani <rakes.pani@lge.com>
+Date: Mon, 10 Aug 2020 13:27:14 +0530
+Subject: [PATCH] Added MessageHandle property in org.bluez.obex.Transfer1
+
+:Release Notes:
+Added MessageHandle property in org.bluez.obex.Transfer1
+
+:Detailed Notes:
+Added MessageHandle property in org.bluez.obex.Transfer1.
+This property will be available for map pushmessage API.
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-107873] Add MessageHandle for pushMessage transfer in Bluez5
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ gobex/gobex-transfer.c  | 10 ++++++---
+ gobex/gobex.h           |  7 ++++--
+ obexd/client/transfer.c | 48 +++++++++++++++++++++++++++++++++++++++--
+ 3 files changed, 58 insertions(+), 7 deletions(-)
+
+diff --git a/gobex/gobex-transfer.c b/gobex/gobex-transfer.c
+index c94d018b2..e93cf79d6 100644
+--- a/gobex/gobex-transfer.c
++++ b/gobex/gobex-transfer.c
+@@ -38,6 +38,7 @@ struct transfer {
+ 
+ 	GObexDataProducer data_producer;
+ 	GObexDataConsumer data_consumer;
++	GObexPutFirstResponseFunc first_response;
+ 	GObexFunc complete_func;
+ 
+ 	gpointer user_data;
+@@ -215,6 +216,8 @@ static void transfer_response(GObex *obex, GError *err, GObexPacket *rsp,
+ 	}
+ 
+ 	if (transfer->opcode == G_OBEX_OP_PUT) {
++		if(transfer->first_response)
++			transfer->first_response(obex, &err, rsp, transfer->user_data);
+ 		req = g_obex_packet_new(transfer->opcode, FALSE,
+ 							G_OBEX_HDR_INVALID);
+ 		g_obex_packet_add_body(req, put_get_data, transfer);
+@@ -259,8 +262,8 @@ static struct transfer *transfer_new(GObex *obex, guint8 opcode,
+ }
+ 
+ guint g_obex_put_req_pkt(GObex *obex, GObexPacket *req,
+-			GObexDataProducer data_func, GObexFunc complete_func,
+-			gpointer user_data, GError **err)
++			GObexDataProducer data_func, GObexPutFirstResponseFunc resp_func,
++			GObexFunc complete_func, gpointer user_data, GError **err)
+ {
+ 	struct transfer *transfer;
+ 
+@@ -271,6 +274,7 @@ guint g_obex_put_req_pkt(GObex *obex, GObexPacket *req,
+ 
+ 	transfer = transfer_new(obex, G_OBEX_OP_PUT, complete_func, user_data);
+ 	transfer->data_producer = data_func;
++	transfer->first_response = resp_func;
+ 
+ 	g_obex_packet_add_body(req, put_get_data, transfer);
+ 
+@@ -300,7 +304,7 @@ guint g_obex_put_req(GObex *obex, GObexDataProducer data_func,
+ 							first_hdr_id, args);
+ 	va_end(args);
+ 
+-	return g_obex_put_req_pkt(obex, req, data_func, complete_func,
++	return g_obex_put_req_pkt(obex, req, data_func, NULL,complete_func,
+ 							user_data, err);
+ }
+ 
+diff --git a/gobex/gobex.h b/gobex/gobex.h
+index f16e4426c..434beecf8 100644
+--- a/gobex/gobex.h
++++ b/gobex/gobex.h
+@@ -28,6 +28,9 @@ typedef void (*GObexRequestFunc) (GObex *obex, GObexPacket *req,
+ 							gpointer user_data);
+ typedef void (*GObexResponseFunc) (GObex *obex, GError *err, GObexPacket *rsp,
+ 							gpointer user_data);
++typedef void (*GObexPutFirstResponseFunc) (GObex *obex, GError *err, GObexPacket *rsp,
++							gpointer user_data);
++
+ 
+ gboolean g_obex_send(GObex *obex, GObexPacket *pkt, GError **err);
+ 
+@@ -93,8 +96,8 @@ guint g_obex_put_req(GObex *obex, GObexDataProducer data_func,
+ 			GError **err, guint first_hdr_id, ...);
+ 
+ guint g_obex_put_req_pkt(GObex *obex, GObexPacket *req,
+-			GObexDataProducer data_func, GObexFunc complete_func,
+-			gpointer user_data, GError **err);
++			GObexDataProducer data_func,GObexPutFirstResponseFunc resp_func,
++			GObexFunc complete_func, gpointer user_data, GError **err);
+ 
+ guint g_obex_get_req(GObex *obex, GObexDataConsumer data_func,
+ 			GObexFunc complete_func, gpointer user_data,
+diff --git a/obexd/client/transfer.c b/obexd/client/transfer.c
+index a7a85a0c0..55184f944 100644
+--- a/obexd/client/transfer.c
++++ b/obexd/client/transfer.c
+@@ -67,6 +67,7 @@ struct obc_transfer {
+ 	char *filename;		/* Transfer file location */
+ 	char *name;		/* Transfer object name */
+ 	char *type;		/* Transfer object type */
++	char *messageHandle;		/* Transfer object type */
+ 	int fd;
+ 	guint req;
+ 	guint xfer;
+@@ -378,6 +379,25 @@ static gboolean get_session(const GDBusPropertyTable *property,
+ 
+ 	dbus_message_iter_append_basic(iter, DBUS_TYPE_OBJECT_PATH,
+ 							&transfer->session);
++	return TRUE;
++}
++
++static gboolean messageHandle_exists(const GDBusPropertyTable *property, void *data)
++{
++	struct obc_transfer *transfer = data;
++
++	return transfer->messageHandle != NULL;
++}
++
++static gboolean get_messageHandle(const GDBusPropertyTable *property,
++					DBusMessageIter *iter, void *data)
++{
++	struct obc_transfer *transfer = data;
++
++	if (transfer->messageHandle == NULL)
++		return FALSE;
++	DBG("%s",transfer->messageHandle);
++	dbus_message_iter_append_basic(iter, DBUS_TYPE_STRING, &transfer->messageHandle);
+ 
+ 	return TRUE;
+ }
+@@ -397,6 +417,7 @@ static const GDBusPropertyTable obc_transfer_properties[] = {
+ 	{ "Filename", "s", get_filename, NULL, filename_exists },
+ 	{ "Transferred", "t", get_transferred, NULL, transferred_exists },
+ 	{ "Session", "o", get_session },
++	{ "MessageHandle", "s", get_messageHandle, NULL , messageHandle_exists },
+ 	{ }
+ };
+ 
+@@ -448,6 +469,7 @@ static void obc_transfer_free(struct obc_transfer *transfer)
+ 	g_free(transfer->type);
+ 	g_free(transfer->session);
+ 	g_free(transfer->path);
++	g_free(transfer->messageHandle);
+ 	g_free(transfer);
+ }
+ 
+@@ -673,6 +695,28 @@ static void xfer_complete(GObex *obex, GError *err, gpointer user_data)
+ 		callback->func(transfer, err, callback->data);
+ }
+ 
++static void get_first_put_response(GObex *obex, GError *err, GObexPacket *rsp,
++							gpointer user_data)
++{
++	struct obc_transfer *transfer = user_data;
++	guint8 rspcode;
++	GObexHeader *hdr;
++	gboolean final;
++	rspcode = g_obex_packet_get_operation(rsp, &final);
++	if (rspcode == G_OBEX_RSP_CONTINUE) {
++		hdr = g_obex_packet_get_header(rsp, G_OBEX_HDR_NAME);
++		if (hdr) {
++			const char *name;
++			g_obex_header_get_unicode(hdr, &name);
++			uint64_t handle = strtoull(name, NULL, 16);
++			transfer->messageHandle = g_strdup_printf("message%"PRIu64,handle);
++			DBG("%s", transfer->messageHandle);
++			g_dbus_emit_property_changed(transfer->conn, transfer->path,
++						TRANSFER_INTERFACE, "MessageHandle");
++		}
++	}
++}
++
+ static void get_xfer_progress_first(GObex *obex, GError *err, GObexPacket *rsp,
+ 							gpointer user_data)
+ {
+@@ -871,8 +915,8 @@ static gboolean transfer_start_put(struct obc_transfer *transfer, GError **err)
+ 	}
+ 
+ 	transfer->xfer = g_obex_put_req_pkt(transfer->obex, req,
+-					put_xfer_progress, xfer_complete,
+-					transfer, err);
++					put_xfer_progress, get_first_put_response,
++					xfer_complete,transfer, err);
+ 	if (transfer->xfer == 0)
+ 		return FALSE;
+ 

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0023-Create-Message-interface-for-sent-message-related-no.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0023-Create-Message-interface-for-sent-message-related-no.patch
@@ -1,0 +1,75 @@
+From 16b74e72a9cd3140c14c6d1cad11647cafadd87c Mon Sep 17 00:00:00 2001
+From: Rakes Pani <rakes.pani@lge.com>
+Date: Mon, 10 Aug 2020 16:21:17 +0530
+Subject: [PATCH] Create Message interface for sent message related
+ notification
+
+:Release Notes:
+Create Message interface for sent message related notification
+
+:Detailed Notes:
+If message object is not present , when sent message related
+event is received from MSE , create Message object
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-107873] Add MessageHandle for pushMessage transfer in Bluez5
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ obexd/client/map.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/obexd/client/map.c b/obexd/client/map.c
+index ada9377b8..713de34c2 100644
+--- a/obexd/client/map.c
++++ b/obexd/client/map.c
+@@ -1938,6 +1938,7 @@ static void map_handle_new_message(struct map_data *map,
+ 	struct map_msg *msg;
+ 
+ 	msg = g_hash_table_lookup(map->messages, &event->handle);
++
+ 	/* New message event can be used if a new message replaces an old one */
+ 	if (msg)
+ 		g_hash_table_remove(map->messages, &event->handle);
+@@ -1953,6 +1954,17 @@ static void map_handle_new_message(struct map_data *map,
+ 	}
+ }
+ 
++static void map_handle_sent_message(struct map_data *map,
++							struct map_event *event)
++{
++	struct map_msg *msg;
++
++	msg = g_hash_table_lookup(map->messages, &event->handle);
++
++	if(msg == NULL)
++		msg = map_msg_create(map, event->handle, event->folder, event->msg_type);
++}
++
+ static void map_handle_status_changed(struct map_data *map,
+ 							struct map_event *event,
+ 							const char *status)
+@@ -2016,15 +2028,19 @@ static void map_handle_notification(struct map_event *event, void *user_data)
+ 		map_handle_status_changed(map, event, "notification");
+ 		break;
+ 	case MAP_ET_DELIVERY_SUCCESS:
++		map_handle_sent_message(map, event);
+ 		map_handle_status_changed(map, event, "delivery-success");
+ 		break;
+ 	case MAP_ET_SENDING_SUCCESS:
++		map_handle_sent_message(map, event);
+ 		map_handle_status_changed(map, event, "sending-success");
+ 		break;
+ 	case MAP_ET_DELIVERY_FAILURE:
++		map_handle_sent_message(map, event);
+ 		map_handle_status_changed(map, event, "delivery-failure");
+ 		break;
+ 	case MAP_ET_SENDING_FAILURE:
++		map_handle_sent_message(map, event);
+ 		map_handle_status_changed(map, event, "sending-failure");
+ 		break;
+ 	case MAP_ET_MESSAGE_DELETED:

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0024-AVRCP-addToNowPlaying-return-error-when-player-not-s.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0024-AVRCP-addToNowPlaying-return-error-when-player-not-s.patch
@@ -1,0 +1,92 @@
+From c50b0fcaadcbb13d7126cd8ff9abb98debf4c963 Mon Sep 17 00:00:00 2001
+From: "ramya.hegde" <ramya.hegde@lge.com>
+Date: Tue, 11 Aug 2020 15:18:43 +0530
+Subject: [PATCH] AVRCP addToNowPlaying return error when player not supports
+
+:Release Notes:
+Fix for addToNowPlaying when player does not support the
+feature
+
+:Detailed Notes:
+Added check if the player supports addToNowPlaying before
+sending the command to target device
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-110696] Analyze and fix addToNowPlaying support in
+              bluez5 stack
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/avrcp.c  |  3 +++
+ profiles/audio/player.c | 13 ++++++++++++-
+ profiles/audio/player.h |  1 +
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/profiles/audio/avrcp.c b/profiles/audio/avrcp.c
+index ff9d9f97d..85db0883a 100644
+--- a/profiles/audio/avrcp.c
++++ b/profiles/audio/avrcp.c
+@@ -2901,6 +2901,9 @@ static void avrcp_player_parse_features(struct avrcp_player *player,
+ 	if (features[7] & 0x10)
+ 		media_player_set_searchable(mp, true);
+ 
++	if (features[7] & 0x20)
++		media_player_set_add_to_now_playing(mp, true);
++
+ 	if (features[8] & 0x02) {
+ 		media_player_create_folder(mp, "/NowPlaying",
+ 						PLAYER_FOLDER_TYPE_MIXED, 0);
+diff --git a/profiles/audio/player.c b/profiles/audio/player.c
+index c995697fe..13ac07f28 100644
+--- a/profiles/audio/player.c
++++ b/profiles/audio/player.c
+@@ -75,6 +75,7 @@ struct media_player {
+ 	char			*subtype;	/* Player subtype */
+ 	bool			browsable;	/* Player browsing feature */
+ 	bool			searchable;	/* Player searching feature */
++	bool			addToNowPlaying; /* Player addToNowPlaying feature */
+ 	struct media_folder	*scope;		/* Player current scope */
+ 	struct media_folder	*folder;	/* Player current folder */
+ 	struct media_folder	*search;	/* Player search folder */
+@@ -1510,6 +1511,16 @@ bool media_player_get_browsable(struct media_player *mp)
+ 	return mp->browsable;
+ }
+ 
++void media_player_set_add_to_now_playing(struct media_player *mp, bool enabled)
++{
++	if (mp->addToNowPlaying == enabled)
++		return;
++
++	DBG("%s", enabled ? "true" : "false");
++
++	mp->addToNowPlaying = enabled;
++}
++
+ void media_player_set_searchable(struct media_player *mp, bool enabled)
+ {
+ 	if (mp->searchable == enabled)
+@@ -1613,7 +1624,7 @@ static DBusMessage *media_item_add_to_nowplaying(DBusConnection *conn,
+ 	struct player_callback *cb = mp->cb;
+ 	int err;
+ 
+-	if (!item->playable || !cb->cbs->play_item)
++	if (!item->playable || !cb->cbs->add_to_nowplaying || !mp->addToNowPlaying)
+ 		return btd_error_not_supported(msg);
+ 
+ 	err = cb->cbs->add_to_nowplaying(mp, item->path, item->uid,
+diff --git a/profiles/audio/player.h b/profiles/audio/player.h
+index 74fb7d771..25c1ebf58 100644
+--- a/profiles/audio/player.h
++++ b/profiles/audio/player.h
+@@ -80,6 +80,7 @@ void media_player_set_subtype(struct media_player *mp, const char *subtype);
+ void media_player_set_name(struct media_player *mp, const char *name);
+ void media_player_set_browsable(struct media_player *mp, bool enabled);
+ bool media_player_get_browsable(struct media_player *mp);
++void media_player_set_add_to_now_playing(struct media_player *mp, bool enabled);
+ void media_player_set_searchable(struct media_player *mp, bool enabled);
+ void media_player_set_folder(struct media_player *mp, const char *path,
+ 								uint32_t items);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0025-AVRCP-MediaItem-object-path-fix.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0025-AVRCP-MediaItem-object-path-fix.patch
@@ -1,0 +1,101 @@
+From 2c8891c770a2dfeec8b81983ec6e9405f836f96d Mon Sep 17 00:00:00 2001
+From: "ramya.hegde" <ramya.hegde@lge.com>
+Date: Tue, 3 Nov 2020 11:32:38 +0530
+Subject: [PATCH] AVRCP MediaItem object path fix
+
+:Release Notes:
+AVRCP MediaItem object path fix
+
+:Detailed Notes:
+Object path cannot have spaces in them. So replacing the spaces
+with '_' if any in the object path.
+
+:Testing Performed:
+Built and Tested
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-124915] Calling AVRCP search API results in
+              icom.webos.service.bluetooth2 crash
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ profiles/audio/player.c | 38 +++++++++++++++++++++++++++++++++-----
+ 1 file changed, 33 insertions(+), 5 deletions(-)
+
+diff --git a/profiles/audio/player.c b/profiles/audio/player.c
+index 13ac07f28..2151e1bca 100644
+--- a/profiles/audio/player.c
++++ b/profiles/audio/player.c
+@@ -711,6 +711,12 @@ void media_player_search_complete(struct media_player *mp, int ret)
+ 	if (search == NULL) {
+ 		search = g_new0(struct media_folder, 1);
+ 		search->item = media_player_create_subfolder(mp, "search", 0);
++		if (!search->item)
++		{
++			g_free(search);
++			reply = btd_error_failed(folder->msg, strerror(-ret));
++			goto done;
++		}
+ 		mp->search = search;
+ 		mp->folders = g_slist_prepend(mp->folders, search);
+ 	}
+@@ -1850,6 +1856,17 @@ void media_item_set_playable(struct media_item *item, bool value)
+ 					MEDIA_ITEM_INTERFACE, "Playable");
+ }
+ 
++static void replaceCharacter(char *str, char srcChar, char destChar)
++{
++    for (int i = 0; str[i]; i++)
++	{
++		if (str[i] == srcChar)
++		{
++			str[i] = destChar;
++		}
++	}
++}
++
+ static struct media_item *media_folder_create_item(struct media_player *mp,
+ 						struct media_folder *folder,
+ 						const char *name,
+@@ -1858,6 +1875,7 @@ static struct media_item *media_folder_create_item(struct media_player *mp,
+ {
+ 	struct media_item *item;
+ 	const char *strtype;
++	char *folderName = NULL;
+ 
+ 	item = media_folder_find_item(folder, uid);
+ 	if (item != NULL)
+@@ -1872,14 +1890,24 @@ static struct media_item *media_folder_create_item(struct media_player *mp,
+ 	item = g_new0(struct media_item, 1);
+ 	item->player = mp;
+ 	item->uid = uid;
+-
+-	if (!uid && name[0] == '/')
+-		item->path = g_strdup_printf("%s%s", mp->path, name);
++	folderName = g_strdup(name);
++
++	if (!uid && folderName[0] == '/')
++	{
++		/* Spaces are not allowed in the object path. So replace all the
++		 * spaces with '_' */
++		if (strstr(folderName, " "))
++		{
++			replaceCharacter(folderName, ' ', '_');
++		}
++		item->path = g_strdup_printf("%s%s", mp->path, folderName);
++	}
+ 	else
+ 		item->path = g_strdup_printf("%s/item%" PRIu64 "",
+-						folder->item->path, uid);
++									 folder->item->path, uid);
+ 
+-	item->name = g_strdup(name);
++	item->name = g_strdup(folderName);
++	g_free(folderName);
+ 	item->type = type;
+ 	item->folder_type = PLAYER_FOLDER_TYPE_INVALID;
+ 

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0026-Revert-a2dp-Add-reverse-discovery.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0026-Revert-a2dp-Add-reverse-discovery.patch
@@ -1,0 +1,63 @@
+From bb79f1fd3219339b80eb940eb03416af87c67c94 Mon Sep 17 00:00:00 2001
+From: Sameer Mulla <sameer.mulla@lge.com>
+Date: Thu, 12 Nov 2020 15:04:36 +0530
+Subject: [PATCH] Revert "a2dp: Add reverse discovery"
+
+This reverts commit 02877c5e98b81655c0a369c5cffbf975b431ec7a.
+
+:Release Notes:
+This reverts commit 02877c5e98b81655c0a369c5cffbf975b431ec7a
+
+:Detailed Notes:
+reverse discovery failing to connect to remote a2dp profile
+first time and reverse discovery is not mandatory procedure as
+specification so reverting commit of bluez 5.54 of reverse discovery
+
+:Testing Performed:
+Builded and Tested
+
+:Issues Addressed:
+[PLAT-124140] Audio heard from phone instead of lineout earphone
+
+:QA Notes:
+NA
+
+---
+Upstream-Status: Pending
+
+ profiles/audio/a2dp.c | 14 +-------------
+ 1 file changed, 1 insertion(+), 13 deletions(-)
+
+diff --git a/profiles/audio/a2dp.c b/profiles/audio/a2dp.c
+index fb6c9f680..26a7450e3 100644
+--- a/profiles/audio/a2dp.c
++++ b/profiles/audio/a2dp.c
+@@ -633,12 +633,6 @@ static gboolean endpoint_match_codec_ind(struct avdtp *session,
+ 	return TRUE;
+ }
+ 
+-static void reverse_discover(struct avdtp *session, GSList *seps, int err,
+-							void *user_data)
+-{
+-	DBG("err %d", err);
+-}
+-
+ static gboolean endpoint_setconf_ind(struct avdtp *session,
+ 						struct avdtp_local_sep *sep,
+ 						struct avdtp_stream *stream,
+@@ -694,14 +688,8 @@ static gboolean endpoint_setconf_ind(struct avdtp *session,
+ 						setup_ref(setup),
+ 						endpoint_setconf_cb,
+ 						a2dp_sep->user_data);
+-		if (ret == 0) {
+-			/* Attempt to reverse discover if there are no remote
+-			 * SEPs.
+-			 */
+-			if (queue_isempty(setup->chan->seps))
+-				a2dp_discover(session, reverse_discover, NULL);
++		if (ret == 0)
+ 			return TRUE;
+-		}
+ 
+ 		setup_unref(setup);
+ 		setup->err = g_new(struct avdtp_error, 1);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0027-Add-support-for-meshd-to-use-RAW-channel.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0027-Add-support-for-meshd-to-use-RAW-channel.patch
@@ -1,0 +1,262 @@
+From 2842f40516317da8f71401910995da7d31139fc9 Mon Sep 17 00:00:00 2001
+From: "ramya.hegde" <ramya.hegde@lge.com>
+Date: Mon, 25 Jan 2021 16:27:58 +0530
+Subject: [PATCH] Add support for meshd to use RAW channel
+
+:Release Notes:
+Add support for meshd to use RAW channel
+
+:Detailed Notes:
+Add support for meshd to use RAW channel so that
+bluetooth-meshd and bluetoothd can run in parallel
+
+:Testing Performed:
+Built and tested
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-123995] Analyze bluetooth-meshd and bluetoothd
+              working together
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ mesh/bluetooth-mesh.service.in |  3 ++-
+ mesh/main.c                    | 14 ++++++++----
+ mesh/mesh-io-generic.c         | 38 +++++++++++++++++++++++++------
+ mesh/mesh-io.h                 |  4 ++++
+ mesh/mesh-mgmt.c               | 41 +++++++++++++++++++++++++++++++++-
+ mesh/mesh-mgmt.h               |  1 +
+ 6 files changed, 88 insertions(+), 13 deletions(-)
+
+diff --git a/mesh/bluetooth-mesh.service.in b/mesh/bluetooth-mesh.service.in
+index c8afbf53e..ee65ce485 100644
+--- a/mesh/bluetooth-mesh.service.in
++++ b/mesh/bluetooth-mesh.service.in
+@@ -5,7 +5,8 @@ ConditionPathIsDirectory=/sys/class/bluetooth
+ [Service]
+ Type=dbus
+ BusName=org.bluez.mesh
+-ExecStart=@pkglibexecdir@/bluetooth-meshd
++ExecStart=@pkglibexecdir@/bluetooth-meshd --nodetach --use_raw
++Capabilities=cap_net_admin,cap_net_bind_service
+ NotifyAccess=main
+ LimitNPROC=1
+ ProtectHome=true
+diff --git a/mesh/main.c b/mesh/main.c
+index dd99c3085..c68530faf 100644
+--- a/mesh/main.c
++++ b/mesh/main.c
+@@ -36,6 +36,7 @@ static const char *storage_dir;
+ static const char *mesh_conf_fname;
+ static enum mesh_io_type io_type;
+ static void *io_opts;
++bool use_raw = false;
+ 
+ static const struct option main_options[] = {
+ 	{ "io",		required_argument,	NULL, 'i' },
+@@ -44,6 +45,7 @@ static const struct option main_options[] = {
+ 	{ "nodetach",	no_argument,		NULL, 'n' },
+ 	{ "debug",	no_argument,		NULL, 'd' },
+ 	{ "dbus-debug",	no_argument,		NULL, 'b' },
++	{ "use_raw",	no_argument,		NULL, 'r' },
+ 	{ "help",	no_argument,		NULL, 'h' },
+ 	{ }
+ };
+@@ -138,10 +140,11 @@ static void signal_handler(uint32_t signo, void *user_data)
+ static bool parse_io(const char *optarg, enum mesh_io_type *type, void **opts)
+ {
+ 	if (strstr(optarg, "generic") == optarg) {
+-		int *index = l_new(int, 1);
+-
++		struct mesh_io_opts *m_io_opts = l_new(struct mesh_io_opts, 1);
++		int *index = &(m_io_opts->index);
++		m_io_opts->use_raw = use_raw;
++		*opts = m_io_opts;
+ 		*type = MESH_IO_TYPE_GENERIC;
+-		*opts = index;
+ 
+ 		optarg += strlen("generic");
+ 		if (!*optarg) {
+@@ -204,7 +207,7 @@ int main(int argc, char *argv[])
+ 	for (;;) {
+ 		int opt;
+ 
+-		opt = getopt_long(argc, argv, "u:i:s:c:ndbh", main_options,
++		opt = getopt_long(argc, argv, "u:i:s:c:ndbhr", main_options,
+ 									NULL);
+ 		if (opt < 0)
+ 			break;
+@@ -239,6 +242,9 @@ int main(int argc, char *argv[])
+ 		case 'b':
+ 			dbus_debug = true;
+ 			break;
++		case 'r':
++			use_raw = true;
++			break;
+ 		case 'h':
+ 			usage();
+ 			status = EXIT_SUCCESS;
+diff --git a/mesh/mesh-io-generic.c b/mesh/mesh-io-generic.c
+index 2d7ef261e..40cf0e521 100644
+--- a/mesh/mesh-io-generic.c
++++ b/mesh/mesh-io-generic.c
+@@ -40,6 +40,7 @@ struct mesh_io_private {
+ 	uint16_t interval;
+ 	bool sending;
+ 	bool active;
++	bool use_raw;
+ };
+ 
+ struct pvt_rx_reg {
+@@ -259,8 +260,11 @@ static void configure_hci(struct mesh_io_private *io)
+ 
+ 	/* TODO: Move to suitable place. Set suitable masks */
+ 	/* Reset Command */
+-	bt_hci_send(io->hci, BT_HCI_CMD_RESET, NULL, 0, hci_generic_callback,
+-								NULL, NULL);
++	if (!(io->use_raw)) {
++		/* Reset Command in case of user channel */
++		bt_hci_send(io->hci, BT_HCI_CMD_RESET, NULL, 0, hci_generic_callback,
++									NULL, NULL);
++	}
+ 
+ 	/* Read local supported commands */
+ 	bt_hci_send(io->hci, BT_HCI_CMD_READ_LOCAL_COMMANDS, NULL, 0,
+@@ -392,10 +396,26 @@ static void hci_init(void *user_data)
+ 		bt_hci_unref(io->pvt->hci);
+ 	}
+ 
+-	io->pvt->hci = bt_hci_new_user_channel(io->pvt->index);
+-	if (!io->pvt->hci) {
++	if (io->pvt->use_raw)
++	{
++		l_debug("Use HCI RAW channel");
++
++		/* Power up HCI device */
++		uint16_t mode = 0x01;
++		if (!set_powered(mode, io->pvt->index))
++			return;
++
++		io->pvt->hci = bt_hci_new_raw_device(io->pvt->index);
++	}
++	else
++	{
++		l_debug("Use HCI USER channel");
++		io->pvt->hci = bt_hci_new_user_channel(io->pvt->index);
++	}
++	if (!io->pvt->hci)
++	{
+ 		l_error("Failed to start mesh io (hci %u): %s", io->pvt->index,
+-							strerror(errno));
++				strerror(errno));
+ 		result = false;
+ 	}
+ 
+@@ -436,7 +456,10 @@ static bool dev_init(struct mesh_io *io, void *opts,
+ 		return false;
+ 
+ 	io->pvt = l_new(struct mesh_io_private, 1);
+-	io->pvt->index = *(int *)opts;
++	struct mesh_io_opts *io_opts;
++	io_opts = (struct mesh_io_opts *)opts;
++	io->pvt->index = io_opts->index;
++	io->pvt->use_raw = io_opts->use_raw;
+ 
+ 	io->pvt->rx_regs = l_queue_new();
+ 	io->pvt->tx_pkts = l_queue_new();
+@@ -847,7 +870,8 @@ static bool recv_register(struct mesh_io *io, const uint8_t *filter,
+ 	if (l_queue_find(pvt->rx_regs, find_active, NULL))
+ 		active = true;
+ 
+-	if (!already_scanning || pvt->active != active) {
++	//if (!already_scanning || pvt->active != active)
++	{
+ 		pvt->active = active;
+ 		cmd.enable = 0x00;	/* Disable scanning */
+ 		cmd.filter_dup = 0x00;	/* Report duplicates */
+diff --git a/mesh/mesh-io.h b/mesh/mesh-io.h
+index 80ef3fa3e..fdf5eb6b1 100644
+--- a/mesh/mesh-io.h
++++ b/mesh/mesh-io.h
+@@ -30,6 +30,10 @@ struct mesh_io_recv_info {
+ 	uint8_t chan;
+ 	int8_t rssi;
+ };
++struct mesh_io_opts {
++	int index;
++	bool use_raw;
++};
+ 
+ struct mesh_io_send_info {
+ 	enum mesh_io_timing_type type;
+diff --git a/mesh/mesh-mgmt.c b/mesh/mesh-mgmt.c
+index 754093dbc..7e039498c 100644
+--- a/mesh/mesh-mgmt.c
++++ b/mesh/mesh-mgmt.c
+@@ -43,6 +43,45 @@ static void process_read_info_req(void *data, void *user_data)
+ 	reg->cb(index, reg->user_data);
+ }
+ 
++static void set_powered_complete(uint8_t status, uint16_t length,
++                                        const void *param, void *user_data)
++{
++	int index = L_PTR_TO_UINT(user_data);
++	uint32_t settings;
++
++	if (status != MGMT_STATUS_SUCCESS) {
++		l_error("Failed to set powered: %s (0x%02x)",
++						mgmt_errstr(status), status);
++		return;
++	}
++
++	settings = l_get_le32(param);
++
++	if (!(settings & MGMT_SETTING_POWERED)) {
++		l_error("Controller is not powered");
++                return;
++        }
++
++	l_debug("set powered success on index %d", index);
++	/** <TO-DO> update current settings of adapter */
++}
++
++bool set_powered(uint16_t mode, int index)
++{
++	struct mgmt_mode cp;
++
++	memset(&cp, 0, sizeof(cp));
++	cp.val = mode;
++
++	/** <TO-DO> check current settings of adapter */
++	if (mgmt_send(mgmt_mesh, MGMT_OP_SET_POWERED, index, sizeof(cp), &cp,
++				set_powered_complete, L_UINT_TO_PTR(index), NULL) > 0)
++
++		return true;
++
++	return false;
++}
++
+ static void read_info_cb(uint8_t status, uint16_t length,
+ 					const void *param, void *user_data)
+ {
+@@ -71,7 +110,7 @@ static void read_info_cb(uint8_t status, uint16_t length,
+ 
+ 	if (current_settings & MGMT_SETTING_POWERED) {
+ 		l_info("Controller hci %u is in use", index);
+-		return;
++		//return;
+ 	}
+ 
+ 	if (!(supported_settings & MGMT_SETTING_LE)) {
+diff --git a/mesh/mesh-mgmt.h b/mesh/mesh-mgmt.h
+index 90ac14e73..1fdb25646 100644
+--- a/mesh/mesh-mgmt.h
++++ b/mesh/mesh-mgmt.h
+@@ -12,3 +12,4 @@
+ typedef void (*mesh_mgmt_read_info_func_t)(int index, void *user_data);
+ 
+ bool mesh_mgmt_list(mesh_mgmt_read_info_func_t cb, void *user_data);
++bool set_powered(uint16_t mode, int index);

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/0028-Enable-mesh-fixed-ell-undefined-symbol-error.patch
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/0028-Enable-mesh-fixed-ell-undefined-symbol-error.patch
@@ -1,0 +1,40 @@
+From c5b7cb2aa745e73fdd44369baab9b6b732c90c30 Mon Sep 17 00:00:00 2001
+From: "shoyeb.khan" <shoyeb.khan@lge.com>
+Date: Wed, 27 Jan 2021 03:34:27 +0530
+Subject: [PATCH] Enable mesh & fixed ell undefined symbol error
+
+:Release Notes:
+Enable mesh with Bluez 5.55 in WebOS OSE
+
+:Detailed Notes:
+Enabled mesh in Bluez 5.55 and fixed ell
+undefined symbol error
+
+:Testing Performed:
+Builded and tested
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[PLAT-131628] Enable mesh with Bluez 5.55 in WebOS OSE
+
+---
+Upstream-Status: Inappropriate [webos specific]
+
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 1ad6398e1..d61ad70b6 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -675,7 +675,7 @@ ell/internal: Makefile
+ 		fi \
+ 	done > $@
+ 
+-ell/ell.h: Makefile
++ell/ell_h: Makefile
+ 	$(AM_V_at)echo -n > $@
+ 	$(AM_V_GEN)for f in $(ell_headers) ; do \
+ 		echo "#include <$$f>" >> $@ ; \

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/blacklistbtusb.conf
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/blacklistbtusb.conf
@@ -1,0 +1,20 @@
+# @@@LICENSE
+#
+#      Copyright (c) 2020-2023 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# LICENSE@@@
+
+# Do not load the 'btusb' module on boot.
+blacklist btusb

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/brcm43438.service
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/brcm43438.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Broadcom BCM43438 bluetooth HCI
+ConditionPathIsDirectory=/proc/device-tree/soc/gpio@7e200000/bt_pins
+Before=bluetooth.service
+After=dev-ttyAMA0.device
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/hciattach -n /dev/ttyAMA0 bcm43xx 460800 noflow -
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/main.conf
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/main.conf
@@ -1,0 +1,97 @@
+[General]
+
+# Default adaper name
+# Defaults to 'BlueZ X.YZ'
+#Name = BlueZ
+
+# Default device class. Only the major and minor device class bits are
+# considered. Defaults to '0x000000'.
+#Class = 0x000100
+
+# How long to stay in discoverable mode before going back to non-discoverable
+# The value is in seconds. Default is 180, i.e. 3 minutes.
+# 0 = disable timer, i.e. stay discoverable forever
+#DiscoverableTimeout = 0
+
+# How long to stay in pairable mode before going back to non-discoverable
+# The value is in seconds. Default is 0.
+# 0 = disable timer, i.e. stay pairable forever
+#PairableTimeout = 0
+
+# Automatic connection for bonded devices driven by platform/user events.
+# If a platform plugin uses this mechanism, automatic connections will be
+# enabled during the interval defined below. Initially, this feature
+# intends to be used to establish connections to ATT channels. Default is 60.
+#AutoConnectTimeout = 60
+
+# Use vendor id source (assigner), vendor, product and version information for
+# DID profile support. The values are separated by ":" and assigner, VID, PID
+# and version.
+# Possible vendor id source values: bluetooth, usb (defaults to usb)
+#DeviceID = bluetooth:1234:5678:abcd
+
+# Do reverse service discovery for previously unknown devices that connect to
+# us. This option is really only needed for qualification since the BITE tester
+# doesn't like us doing reverse SDP for some test cases (though there could in
+# theory be other useful purposes for this too). Defaults to 'true'.
+#ReverseServiceDiscovery = true
+
+# Enable name resolving after inquiry. Set it to 'false' if you don't need
+# remote devices name and want shorter discovery cycle. Defaults to 'true'.
+#NameResolving = true
+
+# Enable runtime persistency of debug link keys. Default is false which
+# makes debug link keys valid only for the duration of the connection
+# that they were created for.
+#DebugKeys = false
+
+# Restricts all controllers to the specified transport. Default value
+# is "dual", i.e. both BR/EDR and LE enabled (when supported by the HW).
+# Possible values: "dual", "bredr", "le"
+#ControllerMode = dual
+
+# Enables Multi Profile Specification support. This allows to specify if
+# system supports only Multiple Profiles Single Device (MPSD) configuration
+# or both Multiple Profiles Single Device (MPSD) and Multiple Profiles Multiple
+# Devices (MPMD) configurations.
+# Possible values: "off", "single", "multiple"
+#MultiProfile = off
+
+# Permanently enables the Fast Connectable setting for adapters that
+# support it. When enabled other devices can connect faster to us,
+# however the tradeoff is increased power consumptions. This feature
+# will fully work only on kernel version 4.1 and newer. Defaults to
+# 'false'.
+#FastConnectable = false
+
+# Delay reporting feature enable or disable
+DelayReport = true
+
+# Specify the policy to the JUST-WORKS repairing initiated by peer
+# Possible values: "never", "confirm", "always"
+# Defaults to "never"
+JustWorksRepairing = always
+
+[Policy]
+
+# The ReconnectUUIDs defines the set of remote services that should try
+# to be reconnected to in case of a link loss (link supervision
+# timeout). The policy plugin should contain a sane set of values by
+# default, but this list can be overridden here. By setting the list to
+# empty the reconnection feature gets disabled.
+#ReconnectUUIDs=00001112-0000-1000-8000-00805f9b34fb, 0000111f-0000-1000-8000-00805f9b34fb, 0000110a-0000-1000-8000-00805f9b34fb
+
+# ReconnectAttempts define the number of attempts to reconnect after a link
+# lost. Setting the value to 0 disables reconnecting feature.
+#ReconnectAttempts=7
+
+# ReconnectIntervals define the set of intervals in seconds to use in between
+# attempts.
+# If the number of attempts defined in ReconnectAttempts is bigger than the
+# set of intervals the last interval is repeated until the last attempt.
+#ReconnectIntervals=1, 2, 4, 8, 16, 32, 64
+
+# AutoEnable defines option to enable all controllers when they are found.
+# This includes adapters present on start as well as adapters that are plugged
+# in later on. Defaults to 'false'.
+AutoEnable=true

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5/obex.service
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5/obex.service
@@ -1,0 +1,25 @@
+# @@@LICENSE
+#
+# Copyright (c) 2019-2023 LG Electronics, Inc.
+#
+# Confidential computer software. Valid license from LG required for
+# possession, use or copying. Consistent with FAR 12.211 and 12.212,
+# Commercial Computer Software, Computer Software Documentation, and
+# Technical Data for Commercial Items are licensed to the U.S. Government
+# under vendor's standard commercial license.
+#
+# LICENSE@@@
+
+[Unit]
+Description=meta-webos - "%n"
+Requires=bluetooth.service
+After=bluetooth.service
+
+[Service]
+Type=dbus
+BusName=org.bluez.obex
+ExecStart=/usr/libexec/bluetooth/obexd -r /media/internal
+Restart=on-failure
+
+[Install]
+Alias=dbus-org.bluez.obex.service

--- a/meta-luneos/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/meta-luneos/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,5 +1,73 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+# Copyright (c) 2018-2023 LG Electronics, Inc.
 
-SRC_URI:append = " \
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+RRECOMMENDS:${PN} += " \
+    glibc-gconv-utf-16 \
+    glibc-gconv-utf-32 \
+"
+
+# Original patch from LuneOS
+SRC_URI += " \
     file://0001-Case-insensitive-firmware-name.patch \
-    "
+"
+
+# Patches coming from webOS OSE
+SRC_URI += " \
+    file://0001-Fix-advertise-time-out-when-default-is-set-to-zero.patch \
+    file://0002-Send-disconnect-signal-on-remote-device-disconnect.patch \
+    file://0003-Fetching-device-type-like-BLE-BREDR-from-bluez.patch \
+    file://0004-Fix-Gatt-connect-when-device-address-type-is-BDADDR_.patch \
+    file://0005-Use-system-bus-instead-of-session-for-obexd.patch \
+    file://0006-Implementation-to-get-connected-profiles-uuids.patch \
+    file://0007-recievePassThrough-commad-support-required-for-webos.patch \
+    file://0008-Added-dbus-signal-for-MediaPlayRequest.patch \
+    file://0009-avrcp-getting-remote-device-features-list.patch \
+    file://0010-Fix-volume-property-not-able-to-set.patch \
+    file://0011-Fix-volume-level-notification-not-appearing-after-12.patch \
+    file://0012-Support-enabling-avdtp-delayReport.patch \
+    file://0013-Implementation-to-get-connectedUuid-s-in-case-of-inc.patch \
+    file://0014-Fix-for-updating-connected-uuids-when-profile-is-dis.patch \
+    file://0015-Fix-device-getStatus-not-updated-when-unpaired.patch \
+    file://0016-Set-default-pairing-capability-as-NoInputNoOutput.patch \
+    file://0017-AVRCP-getting-supported-notification-events.patch \
+    file://0018-Modified-MapInstanceName-MapInstanceProperties-parsi.patch \
+    file://0019-Enabled-EMAIL-support-based-on-MAPInstance-Name-Modi.patch \
+    file://0020-Disabling-DB-Hash-for-Gatt.patch \
+    file://0021-Added-Notification-property-in-org.bluez.obex.Messag.patch \
+    file://0022-Added-MessageHandle-property-in-org.bluez.obex.Trans.patch \
+    file://0023-Create-Message-interface-for-sent-message-related-no.patch \
+    file://0024-AVRCP-addToNowPlaying-return-error-when-player-not-s.patch \
+    file://0025-AVRCP-MediaItem-object-path-fix.patch \
+    file://0026-Revert-a2dp-Add-reverse-discovery.patch \
+    file://0027-Add-support-for-meshd-to-use-RAW-channel.patch \
+    file://0028-Enable-mesh-fixed-ell-undefined-symbol-error.patch \
+    file://main.conf \
+    file://brcm43438.service \
+"
+
+inherit webos_systemd
+WEBOS_SYSTEMD_SERVICE = "obex.service"
+
+SRC_URI:append:raspberrypi4 = " \
+    file://blacklistbtusb.conf \
+"
+
+PACKAGECONFIG:append = " mesh \
+    sixaxis \
+    testing \
+"
+
+EXTRA_OECONF:remove = "--enable-external-ell"
+
+do_install:append () {
+    install -d ${D}${sysconfdir}/systemd/system
+    install -v -m 0644  ${WORKDIR}/main.conf ${D}${sysconfdir}/bluetooth/
+}
+
+do_install:append:raspberrypi4 () {
+    install -d  ${D}${sysconfdir}/modprobe.d
+    install -m 644 ${WORKDIR}/blacklistbtusb.conf  ${D}${sysconfdir}/modprobe.d/blacklistbtusb.conf
+}
+
+FILES:${PN}:append:raspberrypi4 = " ${sysconfdir}/modprobe.d/*"

--- a/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
@@ -188,6 +188,7 @@ RDEPENDS:${PN} = " \
     webos-fontconfig-files \
     com.webos.service.audiofocusmanager \
     com.webos.service.audiooutput \
+    ${VIRTUAL-RUNTIME_bluetooth_service} \
     ${VIRTUAL-RUNTIME_com.webos.service.cec} \
     com.webos.service.hfp \
     com.webos.service.mediaindexer \

--- a/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2.bb
+++ b/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2.bb
@@ -74,6 +74,7 @@ PACKAGECONFIG[support-response-bt-prepare-suspend-done] = "-DSUPPORT_RESPONSE_BT
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Fix-build-with-gcc-12.patch \
     file://0002-Fix-build-with-gcc-13.patch \
+    file://0003-com.webos.service.bluetooth2.role.json.in-Add-additi.patch \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2/0003-com.webos.service.bluetooth2.role.json.in-Add-additi.patch
+++ b/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2/0003-com.webos.service.bluetooth2.role.json.in-Add-additi.patch
@@ -1,0 +1,33 @@
+From ef04630df0791dc9247e8f24d60af39dc01ec416 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 21 Dec 2023 16:03:01 +0100
+Subject: [PATCH] com.webos.service.bluetooth2.role.json.in: Add additional
+ permissions
+
+Fix LS2 permission issues:
+
+Dec 21 14:56:10 qemux86-64 ls-hubd[242]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.service.mediacontroller","SRC_APP_ID":"com.webos.service.bluetooth2","EXE":"/usr/sbin/webos-bluetooth-service","PID":1023} "com.webos.service.bluetooth2" does not have sufficient outbound permissions to communicate with "com.webos.service.mediacontroller" (cmdline: /usr/sbin/webos-bluetooth-service)
+
+Dec 22 08:49:25 pinephonepro ls-hubd[341]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.monitor1594","SRC_APP_ID":"com.webos.service.bluetooth2","EXE":"/usr/sbin/webos-bluetooth-service","PID":689} "com.webos.service.bluetooth2" does not have sufficient outbound permissions to communicate with "com.webos.monitor1594" (cmdline:
+/usr/sbin/webos-bluetooth-service)
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Pending 
+
+ files/sysbus/com.webos.service.bluetooth2.role.json.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/files/sysbus/com.webos.service.bluetooth2.role.json.in b/files/sysbus/com.webos.service.bluetooth2.role.json.in
+index b2d5e74..f7145d5 100644
+--- a/files/sysbus/com.webos.service.bluetooth2.role.json.in
++++ b/files/sysbus/com.webos.service.bluetooth2.role.json.in
+@@ -6,7 +6,7 @@
+     "permissions": [
+         {
+             "service":"com.webos.service.bluetooth2",
+-            "outbound":["com.webos.service.account" , "com.webos.service.pdm", "com.webos.service.db"]
++            "outbound":["com.webos.service.account" , "com.webos.service.pdm", "com.webos.service.db", "com.webos.service.mediacontroller", "com.webos.monitor*"]
+         }
+     ]
+ }

--- a/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2/webos-bluetooth-service.service
+++ b/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2/webos-bluetooth-service.service
@@ -26,3 +26,6 @@ EnvironmentFile=-/var/systemd/system/env/webos-bluetooth-service.env
 ExecStartPre=/lib/systemd/system/scripts/webos-bluetooth-service.sh
 ExecStart=/usr/sbin/webos-bluetooth-service
 Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller.bb
@@ -24,7 +24,11 @@ inherit webos_public_repo
 inherit webos_machine_impl_dep
 inherit webos_system_bus
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+SRC_URI = " \
+    ${WEBOSOSE_GIT_REPO_COMPLETE} \
+    file://0001-com.webos.service.mediacontroller-Make-it-work-gener.patch \
+    file://0002-com.webos.service.mediacontroller.role.json.in-Fix-o.patch \
+    "
 S = "${WORKDIR}/git"
 inherit webos_systemd
 WEBOS_SYSTEMD_SERVICE = "com.webos.service.mediacontroller.service"

--- a/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller/0001-com.webos.service.mediacontroller-Make-it-work-gener.patch
+++ b/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller/0001-com.webos.service.mediacontroller-Make-it-work-gener.patch
@@ -1,0 +1,160 @@
+From 5a13a97c2112ec58d5171b8cbbe4c85e8570c56d Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 21 Dec 2023 12:54:37 +0100
+Subject: [PATCH] com.webos.service.mediacontroller: Make it work generically
+
+Not liking the hardcoded bits from OSE, let's make it more flexible and keep the same functionality
+---
+Upstream-Status: Pending
+
+ CMakeLists.txt              |  6 ++----
+ src/MediaControlService.cpp | 33 +++++++++++++--------------------
+ src/MediaSessionManager.cpp |  2 +-
+ 3 files changed, 16 insertions(+), 25 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 13f158f..6434b6e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,12 +45,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+ add_definitions(-DUSE_TEST_METHOD)
+ endif()
+ 
+-if(WEBOS_TARGET_MACHINE STREQUAL "raspberrypi4" OR WEBOS_TARGET_MACHINE STREQUAL "raspberrypi4-64" OR WEBOS_TARGET_MACHINE STREQUAL "qemux86" OR WEBOS_TARGET_MACHINE STREQUAL "qemux86-64")
+-add_definitions(-DPLATFORM_RASPBERRYPI4)
+-endif()
+-
+ if(WEBOS_TARGET_MACHINE STREQUAL "sa8155")
+ add_definitions(-DPLATFORM_SA8155)
++else ()
++add_definitions(-DPLATFORM_GENERIC)
+ endif()
+ 
+ webos_add_compiler_flags(ALL -Wall -funwind-tables)
+diff --git a/src/MediaControlService.cpp b/src/MediaControlService.cpp
+index 5faecac..b9a140c 100644
+--- a/src/MediaControlService.cpp
++++ b/src/MediaControlService.cpp
+@@ -150,14 +150,7 @@ bool MediaControlService::onBTAdapterQueryCb(LSHandle *lshandle, LSMessage *mess
+       std::string adapterAddress = adapters[i]["adapterAddress"].asString();
+       PMLOG_INFO(CONST_MODULE_MCS,"%s : adapterName : %s, adapterAddress : %s",
+                                    __FUNCTION__, adapterName.c_str(), adapterAddress.c_str());
+-
+-#if defined(PLATFORM_RASPBERRYPI4)
+-      if(("raspberrypi4 #2" == adapterName) || ("raspberrypi4" == adapterName) ||
+-         ("raspberrypi4-64 #2" == adapterName) || ("raspberrypi4-64" == adapterName) ||
+-         ("qemux86-64 #2" == adapterName) || ("qemux86-64" == adapterName)) {
+-#elif defined(PLATFORM_SA8155)
+-      if ("sa8155 Bluetooth hci0" == adapterName) {
+-#endif
++      if (("" != adapterName) && ("sa8155 Bluetooth hci1" != adapterName)) {
+         deviceSetId = "RSE-L";
+         std::string payload = "{\"adapterAddress\":\"" + adapterAddress + "\",\"subscribe\":true}";
+         PMLOG_INFO(CONST_MODULE_MCS,"%s : payload = %s for first adapter",__FUNCTION__, payload.c_str());
+@@ -183,9 +176,9 @@ bool MediaControlService::onBTAdapterQueryCb(LSHandle *lshandle, LSMessage *mess
+             PMLOG_ERROR(CONST_MODULE_MCS,"%s : LSCall failed for BT device/getStatus", __FUNCTION__);
+         }
+       }
+-      else
+-        PMLOG_ERROR(CONST_MODULE_MCS,"%s: Already subscribe for adapter: %s", __FUNCTION__, adapterAddress.c_str());
+-
++      else {
++        PMLOG_ERROR(CONST_MODULE_MCS,"%s: Already subscribed for adapter: %s", __FUNCTION__, adapterAddress.c_str());
++      }
+     PMLOG_INFO(CONST_MODULE_MCS,"%s : adapterAddress = %s deviceSetId = %s [%d]",__FUNCTION__, adapterAddress.c_str(), deviceSetId.c_str(), __LINE__);
+     if (obj && !deviceSetId.empty() && !adapterAddress.empty())
+       obj->ptrMediaControlPrivate_->setBTAdapterInfo(deviceSetId, adapterAddress);
+@@ -281,7 +274,7 @@ bool MediaControlService::onBTAvrcpGetStatusCb(LSHandle *lshandle, LSMessage *me
+ 
+         if(!(obj->ptrMediaControlPrivate_->isDeviceRegistered(address, adapterAddress))) {
+           int displayId = obj->ptrMediaControlPrivate_->getDisplayIdForBT(adapterAddress);
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+           displayId = 0;
+ #endif
+           BTDeviceInfo objDevInfo(address, adapterAddress, "", displayId);
+@@ -371,7 +364,7 @@ bool MediaControlService::onBTAvrcpKeyEventsCb(LSHandle *lshandle, LSMessage *me
+         std::string mediaId = obj->ptrMediaControlPrivate_->getMediaId(address);
+         int displayIdForMedia = obj->ptrMediaSessionMgr_->getDisplayIdForMedia(mediaId);
+         //ToDo : Below platform check to be removed once multi intsnace support available in chromium for OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+         displayIdForBT = displayIdForMedia = 0;
+ #endif
+         PMLOG_INFO(CONST_MODULE_MCS, "%s mediaId for sending BT key event : %s", __FUNCTION__, mediaId.c_str());
+@@ -866,7 +859,7 @@ bool MediaControlService::setMediaMetaData(LSMessage& message) {
+       /*Get display ID from media ID*/
+       int displayId = ptrMediaSessionMgr_->getDisplayIdForMedia(mediaId);
+       //ToDo : Below platform check to be removed once dual blueetooth support in OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayId = 0;
+ #endif
+       pbnjson::JObject metaDataObj;
+@@ -951,7 +944,7 @@ bool MediaControlService::setMediaPlayStatus(LSMessage& message) {
+         PMLOG_INFO(CONST_MODULE_MCS, "%s Invalid PlaybackStatus", __FUNCTION__);
+ 
+       int displayIdForMedia = ptrMediaSessionMgr_->getDisplayIdForMedia(mediaId);
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayIdForMedia = 0;
+ #endif
+       BTDeviceInfo objDevInfo;
+@@ -986,7 +979,7 @@ bool MediaControlService::setMediaPlayStatus(LSMessage& message) {
+       /*Get display ID from media ID*/
+       int displayId = ptrMediaSessionMgr_->getDisplayIdForMedia(mediaId);
+       //ToDo : Below platform check to be removed once dual blueetooth support in OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayId = 0;
+ #endif
+       pbnjson::JValue responsePayload = pbnjson::Object();
+@@ -1056,7 +1049,7 @@ bool MediaControlService::setMediaMuteStatus (LSMessage & message){
+       /*Get display ID from media ID*/
+       int displayId = ptrMediaSessionMgr_->getDisplayIdForMedia(mediaId);
+       //ToDo : Below platform check to be removed once dual blueetooth support in OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayId = 0;
+ #endif
+       pbnjson::JValue responsePayload = pbnjson::Object();
+@@ -1121,7 +1114,7 @@ bool MediaControlService::setMediaPlayPosition (LSMessage & message){
+       /*Get display ID from media ID*/
+       int displayId = ptrMediaSessionMgr_->getDisplayIdForMedia(mediaId);
+       //ToDo : Below platform check to be removed once dual blueetooth support in OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayId = 0;
+ #endif
+       pbnjson::JValue responsePayload = pbnjson::Object();
+@@ -1174,7 +1167,7 @@ bool MediaControlService::receiveMediaPlaybackInfo (LSMessage & message){
+   pbnjson::JValue payload = msg.get();
+   int displayId  = payload["displayId"].asNumber<int>();
+       //ToDo : Below platform check to be removed once dual blueetooth support in OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayId = 0;
+ #endif
+   bool subscribed = payload["subscribe"].asBool();
+@@ -1284,7 +1277,7 @@ bool MediaControlService::injectMediaKeyEvent(LSMessage &message) {
+   pbnjson::JValue payload = msg.get();
+   int displayId  = payload["displayId"].asNumber<int>();
+       //ToDo : Below platform check to be removed once dual blueetooth support in OSE
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+       displayId = 0;
+ #endif
+   std::string keyEvent = payload["keyEvent"].asString();
+diff --git a/src/MediaSessionManager.cpp b/src/MediaSessionManager.cpp
+index e5d7f47..96aedc7 100644
+--- a/src/MediaSessionManager.cpp
++++ b/src/MediaSessionManager.cpp
+@@ -261,7 +261,7 @@ std::string MediaSessionManager::getMediaIdFromDisplayId(const int& displayId) {
+   for (const auto& itr : mapMediaSessionInfo_) {
+     std::string appId = itr.second.getAppId();
+     int appDisplayId = (appId.back()-48);
+-#if defined(PLATFORM_RASPBERRYPI4)
++#if defined(PLATFORM_GENERIC)
+     appDisplayId = 0;
+ #endif
+     if(appDisplayId == displayId){

--- a/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller/0002-com.webos.service.mediacontroller.role.json.in-Fix-o.patch
+++ b/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller/0002-com.webos.service.mediacontroller.role.json.in-Fix-o.patch
@@ -1,0 +1,31 @@
+From 5188111cfc4a3ae15b4f2a2f4c881753dc144b8e Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 21 Dec 2023 16:21:33 +0100
+Subject: [PATCH] com.webos.service.mediacontroller.role.json.in: Fix outbound
+ permission issues
+
+Fixes:
+
+Dec 21 14:59:53 qemux86-64 ls-hubd[242]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.monitor1123","SRC_APP_ID":"com.webos.service.mediacontroller","EXE":"/usr/sbin/com.webos.service.mediacontroller","PID":1091} "com.webos.service.mediacontroller" does not have sufficient outbound permissions to communicate with "com.webos.monitor1123" (cmdline: /usr/sbin/com.webos.service.mediacontroller)
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Pending
+
+ files/sysbus/com.webos.service.mediacontroller.role.json.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/files/sysbus/com.webos.service.mediacontroller.role.json.in b/files/sysbus/com.webos.service.mediacontroller.role.json.in
+index e15e1b8..16a5b85 100644
+--- a/files/sysbus/com.webos.service.mediacontroller.role.json.in
++++ b/files/sysbus/com.webos.service.mediacontroller.role.json.in
+@@ -7,7 +7,8 @@
+         {
+             "service": "com.webos.service.mediacontroller",
+             "outbound": ["com.webos.service.bluetooth2",
+-                         "com.webos.service.account"]
++                         "com.webos.service.account", 
++                         "com.webos.monitor*"]
+         }
+     ]
+ }

--- a/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller/com.webos.service.mediacontroller.service
+++ b/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller/com.webos.service.mediacontroller.service
@@ -28,3 +28,6 @@ Restart=on-failure
 #Need to add this on LuneOS still
 #User=media
 #Group=media
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Seems WAM isn't happy without com.webos.mediacontroller.service, even if disabled. 

Unfortunately com.webos.mediacontroller.service had ugly hardcoded values for the OSE targets, trying to work around this by making it more generic.

Also added Install sections in the service files for com.webos.service.bluetooth2|mediacontroller so they get started on boot. The errors in Testr are now gone, however still no audio playback for the audio tests or in the browser via speaker or Bluetooth. Audio works in cardshell. 
