### PR TITLE
nyx-conf: Add gpsConfig.conf

### DIFF
--- a/meta-luneos/recipes-navigation/com.webos.service.location/com.webos.service.location.bb
+++ b/meta-luneos/recipes-navigation/com.webos.service.location/com.webos.service.location.bb
@@ -29,6 +29,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0004-com.webos.service.location-include-LunaLocationServi.patch \
     file://0005-Add-back-various-API-s.patch \
     file://0006-com.webos.service.location-include-ServiceAgent.h-Fi.patch \
+    file://0007-com.webos.service.location-Remove-gpsConfig-file.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-navigation/com.webos.service.location/com.webos.service.location/0007-com.webos.service.location-Remove-gpsConfig-file.patch
+++ b/meta-luneos/recipes-navigation/com.webos.service.location/com.webos.service.location/0007-com.webos.service.location-Remove-gpsConfig-file.patch
@@ -1,0 +1,23 @@
+From b73e19eea357266ed74b3c74f8b3e1e85bd0bb9a Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Sat, 30 Dec 2023 08:44:16 +0100
+Subject: [PATCH] com.webos.service.location: Remove gpsConfig file
+
+Since we will provide this as part of nyx-conf, so we can make it device specific.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [LuneOS specific]
+
+ files/etc/gpsConfig.conf | 2 --
+ 1 file changed, 2 deletions(-)
+ delete mode 100644 files/etc/gpsConfig.conf
+
+diff --git a/files/etc/gpsConfig.conf b/files/etc/gpsConfig.conf
+deleted file mode 100644
+index 637183b..0000000
+--- a/files/etc/gpsConfig.conf
++++ /dev/null
+@@ -1,2 +0,0 @@
+-[GPSDEVICE]
+-PORT=/dev/ttyUSB0

--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf.bb
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf.bb
@@ -6,9 +6,14 @@ PV = "1.0"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-SRC_URI = "file://nyx.conf"
+SRC_URI = " \
+           file://nyx.conf \
+           file://gpsConfig.conf \
+"
 
 do_install() {
     install -d ${D}${sysconfdir}
+    install -d ${D}${sysconfdir}/location
     install -m 0644 ${WORKDIR}/nyx.conf ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/gpsConfig.conf ${D}${sysconfdir}/location
 }

--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf/gpsConfig.conf
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf/gpsConfig.conf
@@ -1,0 +1,2 @@
+[GPSDEVICE]
+PORT=/dev/ttyUSB0

--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf/pinephone/gpsConfig.conf
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf/pinephone/gpsConfig.conf
@@ -1,0 +1,2 @@
+[GPSDEVICE]
+PORT=/dev/ttyUSB1

--- a/meta-luneos/recipes-webos/nyx-conf/nyx-conf/pinephonepro/gpsConfig.conf
+++ b/meta-luneos/recipes-webos/nyx-conf/nyx-conf/pinephonepro/gpsConfig.conf
@@ -1,0 +1,2 @@
+[GPSDEVICE]
+PORT=/dev/ttyUSB1

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0003-Update-webos-connman-adapter.role.json.in-Add-permis.patch
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter/0003-Update-webos-connman-adapter.role.json.in-Add-permis.patch
@@ -1,8 +1,8 @@
-From cbd8980349c242835a0bfd51be0925cbf113577a Mon Sep 17 00:00:00 2001
+From 2660526b18cc9e2294e3f935c7c289ef56c76183 Mon Sep 17 00:00:00 2001
 From: Herrie <Github.com@herrie.org>
 Date: Mon, 2 Oct 2023 10:29:27 +0200
 Subject: [PATCH] Update webos-connman-adapter.role.json.in: Add permissions to
- com.webos.service.downloadmanager and com.webos.lunasend-*
+ com.webos.service.downloadmanager|location and com.webos.lunasend-*
 
 Fixes:
 
@@ -10,20 +10,49 @@ Oct 02 07:51:15 qemux86-64 ls-hubd[291]: [] [pmlog] ls-hubd MSG_TRUNCATED {"MSGI
 Oct 02 07:51:15 qemux86-64 ls-hubd[291]: [] [pmlog] ls-hubd LSHUB_NO_NAME_PERMS {} Can not find match for 'com.webos.service.downloadmanager' in pattern queue '["org.webosports.wifi", "org.webosports.systemservice", "org.webosports.settingsservice", "org.webosports.service.wifi", "org.webosports.service.systemservice", "org.webosports.service.settingsservice", "org.webosports.service.pdm", "org.webosports.service.eventmonitor", "org.webosports.service.connectionmanager", "org.webosports.service.config", "org.webosports.service.activitymanager.client", "org.webosports.pdm", "org.webosports.eventmonitor", "org.webosports.connectionmanager", "org.webosports.config", "org.webosports.activitymanager.client", "org.webosinternals.wifi", "org.webosinternals.systemservice", "org.webosinternals.settingsservice", "org.webosinternals.service.wifi", "org.webosinternals.service.systemservice", "org.webosinternals.service.settingsservice", "org.webosinternals.service.pdm", "org.webosinternals.service.eventmonitor", "org.webosinternals.service.connectionmanager", "org.webosinternals.service.config", "o
 Oct 02 07:51:15 qemux86-64 ls-hubd[291]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.service.downloadmanager","SRC_APP_ID":"com.webos.service.connectionmanager","EXE":"/usr/sbin/webos-connman-adapter","PID":522} "com.webos.service.connectionmanager" does not have sufficient outbound permissions to communicate with "com.webos.service.downloadmanager" (cmdline: /usr/sbin/webos-connman-adapter)
 
-Oct 09 12:35:56 qemux86-64 ls-hubd[240]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS "DEST_APP_ID":"com.webos.lunasend-1012","SRC_APP_ID":"com.webos.service.connectionmanager","EXE":"/usr/sbin/webos-connman-adapter","PID":411} "com.webos.service.connectionmanager" does not have sufficient outbound permissions to communicate with "com.webos.lunasend-1012" (cmdline: /usr/sbin/webos-connman-adapter)
+ ls-hubd LSHUB_NO_NAME_PERMS {} Can not find match for
+ 'com.webos.lunasend-1012' in pattern queue '["org.webosports.wifi",
+ "org.webosports.systemservice", "org.webosports.settingsservice",
+ "org.webosports.service.wifi", "org.webosports.service.systemservice",
+ "org.webosports.service.settingsservice", "org.webosports.service.pdm",
+ "org.webosports.service.eventmonitor",
+ "org.webosports.service.downloadmanager",
+ "org.webosports.service.connectionmanager",
+ "org.webosports.service.config",
+ "org.webosports.service.activitymanager.client", "org.webosports.pdm",
+ "org.webosports.eventmonitor", "org.webosports.downloadmanager",
+ "org.webosports.connectionmanager", "org.webosports.config",
+ "org.webosports.activitymanager.client", "org.webosinternals.wifi",
+ "org.webosinternals.systemservice",
+ "org.webosinternals.settingsservice",
+ "org.webosinternals.service.wifi",
+ "org.webosinternals.service.systemservice",
+ "org.webosinternals.service.settingsservice",
+ "org.webosinternals.service.pdm",
+ "org.webosinternals.service.eventmonitor", "org.webosinternals.s
+ Oct 09 12:35:56 qemux86-64 ls-hubd[240]: [] [pmlog] ls-hubd
+ LSHUB_NO_OUT_PERMS
+ {"DEST_APP_ID":"com.webos.lunasend-1012","SRC_APP_ID":"com.webos.service.connectionmanager","EXE":"/usr/sbin/webos-connman-adapter","PID":411}
+ "com.webos.service.connectionmanager" does not have sufficient outbound
+ permissions to communicate with "com.webos.lunasend-1012" (cmdline:
+ /usr/sbin/webos-connman-adapter)
+
+Upstream-Status: Submitted [https://github.com/webosose/webos-connman-adapter/pull/1]
 
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 ---
-Upstream-Status: Submitted [https://github.com/webosose/webos-connman-adapter/pull/1]
-
- files/sysbus/webos-connman-adapter.role.json.in | 12 +++++++++---
- 1 file changed, 9 insertions(+), 3 deletions(-)
+ files/sysbus/webos-connman-adapter.role.json.in | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
 
 diff --git a/files/sysbus/webos-connman-adapter.role.json.in b/files/sysbus/webos-connman-adapter.role.json.in
-index 917c391..f5f7fa3 100644
+index 917c391..9a54aac 100644
 --- a/files/sysbus/webos-connman-adapter.role.json.in
 +++ b/files/sysbus/webos-connman-adapter.role.json.in
-@@ -13,7 +13,9 @@
+@@ -10,10 +10,13 @@
+                         "com.webos.service.config",
+                         "com.webos.service.connectionmanager",
+                         "com.webos.service.eventmonitor",
++                        "com.webos.service.location",
                          "com.webos.service.pdm",
                          "com.webos.service.systemservice",
                          "com.webos.service.wifi",
@@ -34,7 +63,11 @@ index 917c391..f5f7fa3 100644
          },
          {
              "service":"com.webos.service.connectionmanager",
-@@ -24,7 +26,9 @@
+@@ -21,10 +24,13 @@
+                         "com.webos.service.config",
+                         "com.webos.service.connectionmanager",
+                         "com.webos.service.eventmonitor",
++                        "com.webos.service.location",
                          "com.webos.service.pdm",
                          "com.webos.service.systemservice",
                          "com.webos.service.wifi",
@@ -45,7 +78,11 @@ index 917c391..f5f7fa3 100644
          },
          {
              "service":"com.webos.service.wan",
-@@ -35,7 +39,9 @@
+@@ -32,10 +38,13 @@
+                         "com.webos.service.config",
+                         "com.webos.service.connectionmanager",
+                         "com.webos.service.eventmonitor",
++                        "com.webos.service.location",
                          "com.webos.service.pdm",
                          "com.webos.service.systemservice",
                          "com.webos.service.wifi",


### PR DESCRIPTION
We need a device specific configuration file for GPS, instead of having it provided by com.webos.service.location, have it provided by nyx-conf which is any way MACHINE_ARCH already.