### PR TITLE
webosose: use webos_enhanced_submissions for OSE components

### DIFF
--- a/meta-luneos/recipes-multimedia/com.webos.service.audiofocusmanager/com.webos.service.audiofocusmanager.bb
+++ b/meta-luneos/recipes-multimedia/com.webos.service.audiofocusmanager/com.webos.service.audiofocusmanager.bb
@@ -14,15 +14,13 @@ DEPENDS = "glib-2.0 libpbnjson luna-service2 pmloglib"
 WEBOS_VERSION = "1.0.0-7_17689b0cbff53466134e79cdbfbfd4aa64fdce36"
 PR = "r4"
 
-PV = "1.0.0-7+git${SRCPV}"
-SRCREV = "17689b0cbff53466134e79cdbfbfd4aa64fdce36"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit gettext
 inherit webos_lttng
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-multimedia/com.webos.service.mediaindexer/com.webos.service.mediaindexer.bb
+++ b/meta-luneos/recipes-multimedia/com.webos.service.mediaindexer/com.webos.service.mediaindexer.bb
@@ -12,13 +12,11 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "1.0.0-25_41eadb20de0db9950251567680e83f4d218d9110"
 PR = "r11"
 
-PV = "1.0.0-25+git${SRCPV}"
-SRCREV = "41eadb20de0db9950251567680e83f4d218d9110"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 # third party libraries
 DEPENDS = "glib-2.0 libmtp gupnp libedit gstreamer1.0 gstreamer1.0-plugins-base taglib libpng libjpeg-turbo gdk-pixbuf jpeg libexif giflib"

--- a/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline.bb
+++ b/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline.bb
@@ -13,6 +13,7 @@ LIC_FILES_CHKSUM = " \
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 PR = "r18"
@@ -23,9 +24,6 @@ DEPENDS:append:rpi = " virtual/libomxil"
 COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
 
 WEBOS_VERSION = "1.0.0-gav.48_3ba1c574047904a87182f34482eea6197bf5a48f"
-
-PV = "1.0.0-gav.48+git${SRCPV}"
-SRCREV = "3ba1c574047904a87182f34482eea6197bf5a48f"
 
 WEBOS_GIT_PARAM_BRANCH = "@gav"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-webos.bb
+++ b/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-webos.bb
@@ -18,14 +18,13 @@ inherit gobject-introspection
 PACKAGES_DYNAMIC =+ "^libgst.*"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 WEBOS_REPO_NAME = "gst-plugins-webos"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
 WEBOS_VERSION = "1.18.2-6_7d108f95b8a6d7772b31fe9e07e05a2401c220e2"
-PV = "1.18.2-6+git${SRCPV}"
-SRCREV = "7d108f95b8a6d7772b31fe9e07e05a2401c220e2"
 
 EXTRA_OEMESON = "\
     -Ddoc=disabled \

--- a/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-webosrs.inc
+++ b/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-webosrs.inc
@@ -8,6 +8,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
 
 inherit cargo 
 inherit cargo-update-recipe-crates
+inherit webos_enhanced_submissions
+
 INC_PR = "r0"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
 
@@ -15,8 +17,6 @@ WEBOS_GIT_PARAM_BRANCH = "@rust"
 WEBOS_REPO_NAME = "gst-plugins-webos"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 WEBOS_VERSION = "1.18.5-rust.3_766c456fb7c97d00e27505882de9a237095def52"
-PV = "1.18.5-rust.3+git${SRCPV}"
-SRCREV = "766c456fb7c97d00e27505882de9a237095def52"
 
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-multimedia/umi/umi.bb
+++ b/meta-luneos/recipes-multimedia/umi/umi.bb
@@ -14,14 +14,12 @@ inherit pkgconfig
 inherit webos_cmake
 inherit webos_test_provider
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 DEPENDS = "glib-2.0 pmloglib libpbnjson alsa-lib"
 
 WEBOS_VERSION = "1.0.0-10_5562fabff79cce1fcd85034ff0273fc56cb806cd"
 PR = "r4"
-
-PV = "1.0.0-10+git${SRCPV}"
-SRCREV = "5562fabff79cce1fcd85034ff0273fc56cb806cd"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-navigation/com.webos.service.location/com.webos.service.location.bb
+++ b/meta-luneos/recipes-navigation/com.webos.service.location/com.webos.service.location.bb
@@ -14,10 +14,8 @@ DEPENDS = "glib-2.0 libpbnjson libxml2 pmloglib luna-service2 luna-prefs loc-uti
 WEBOS_VERSION = "1.0.0-104_69e22e6c07d087096885809b3f0da5650af3a488"
 PR = "r3"
 
-PV = "1.0.0-104+git${SRCPV}"
-SRCREV = "69e22e6c07d087096885809b3f0da5650af3a488"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit pkgconfig

--- a/meta-luneos/recipes-navigation/loc-utils/loc-utils.bb
+++ b/meta-luneos/recipes-navigation/loc-utils/loc-utils.bb
@@ -14,10 +14,8 @@ DEPENDS = "glib-2.0 curl pmloglib"
 WEBOS_VERSION = "1.0.0-22_37463ccfd326bd2cff2a8bcab61bb08645358507"
 PR = "r4"
 
-PV = "1.0.0-22+git${SRCPV}"
-SRCREV = "37463ccfd326bd2cff2a8bcab61bb08645358507"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/activitymanager/activitymanager.bb
+++ b/meta-luneos/recipes-webos/activitymanager/activitymanager.bb
@@ -15,10 +15,8 @@ DEPENDS = "luna-service2 db8 boost libpbnjson glib-2.0 pmloglib ${VIRTUAL-RUNTIM
 WEBOS_VERSION = "3.0.0-40_8da546299f22de459467d24e2d52f1d611ce2daa"
 PR = "r13"
 
-PV = "3.0.0-40+git${SRCPV}"
-SRCREV = "8da546299f22de459467d24e2d52f1d611ce2daa"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit pkgconfig

--- a/meta-luneos/recipes-webos/avoutputd/avoutput-adaptation-layer-api.bb
+++ b/meta-luneos/recipes-webos/avoutputd/avoutput-adaptation-layer-api.bb
@@ -10,12 +10,10 @@ DEPENDS = "glib-2.0"
 WEBOS_VERSION = "1.0.0-1_46828b6f12a027d70eab3e3ae720b3f8be1de261"
 PR = "r0"
 
-PV = "1.0.0-1+git${SRCPV}"
-SRCREV = "46828b6f12a027d70eab3e3ae720b3f8be1de261"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 # http://gpro.lge.com/c/webosose/avoutput-adaptation-layer-api/+/354361 Fix build with gcc-13
 # http://gpro.lge.com/c/webosose/avoutput-adaptation-layer-api/+/354362 LICENSE: add Apache-2.0 License

--- a/meta-luneos/recipes-webos/avoutputd/avoutput-adaptation-layer-mock.bb
+++ b/meta-luneos/recipes-webos/avoutputd/avoutput-adaptation-layer-mock.bb
@@ -11,6 +11,7 @@ PROVIDES = "aval-impl"
 inherit webos_cmake
 inherit webos_test_provider
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
@@ -19,8 +20,3 @@ DEPENDS = "glib-2.0 pmloglib libpbnjson ls2-helpers avoutput-adaptation-layer-ap
 
 WEBOS_VERSION = "1.0.0-2_ed69d432dc11eb63863228cfafc76bc4925c77d1"
 PR = "r0"
-
-PV = "1.0.0-2+git${SRCPV}"
-SRCREV = "ed69d432dc11eb63863228cfafc76bc4925c77d1"
-
-

--- a/meta-luneos/recipes-webos/avoutputd/avoutputd.bb
+++ b/meta-luneos/recipes-webos/avoutputd/avoutputd.bb
@@ -12,13 +12,11 @@ RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_aval-impl}"
 WEBOS_VERSION = "1.0.0-5_36d08c75feb62391af087ccdc9c00fcaf8271712"
 PR = "r1"
 
-PV = "1.0.0-5+git${SRCPV}"
-SRCREV = "36d08c75feb62391af087ccdc9c00fcaf8271712"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/bluetooth/bluetooth-sil-api.bb
+++ b/meta-luneos/recipes-webos/bluetooth/bluetooth-sil-api.bb
@@ -14,10 +14,8 @@ DEPENDS = "glib-2.0"
 WEBOS_VERSION = "1.0.0-26_d1236c28f289d0e40f4d26c5d73ad198158e62bb"
 PR = "r4"
 
-PV = "1.0.0-26+git${SRCPV}"
-SRCREV = "d1236c28f289d0e40f4d26c5d73ad198158e62bb"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/bluetooth/bluetooth-sil-bluez5.bb
+++ b/meta-luneos/recipes-webos/bluetooth/bluetooth-sil-bluez5.bb
@@ -20,10 +20,8 @@ RDEPENDS:${PN} += "${@ bb.utils.contains('WEBOS_BLUETOOTH_ENABLED_SERVICE_CLASSE
 WEBOS_VERSION = "0.1.0-81_efcb8e250dacebd13900c5625b6366f75f7ca189"
 PR = "r9"
 
-PV = "0.1.0-81+git${SRCPV}"
-SRCREV = "efcb8e250dacebd13900c5625b6366f75f7ca189"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_bluetooth_sil

--- a/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2.bb
+++ b/meta-luneos/recipes-webos/bluetooth/com.webos.service.bluetooth2.bb
@@ -51,10 +51,8 @@ WEBOS_BLUETOOTH_PAIRING_IO_CAPABILITY ??= "NoInputNoOutput"
 WEBOS_VERSION = "1.0.0-73_6255daed3e9da398abd49bc2bf82812607794627"
 PR = "r8"
 
-PV = "1.0.0-73+git${SRCPV}"
-SRCREV = "6255daed3e9da398abd49bc2bf82812607794627"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus

--- a/meta-luneos/recipes-webos/bluetooth/com.webos.service.hfp.bb
+++ b/meta-luneos/recipes-webos/bluetooth/com.webos.service.hfp.bb
@@ -15,12 +15,10 @@ DEPENDS = "glib-2.0 glib-2.0-native luna-service2 pmloglib libpbnjson"
 WEBOS_VERSION = "1.0.0-32_f3f53f2567b90babcc19608776addc450fdcb9ac"
 PR = "r7"
 
-PV = "1.0.0-32+git${SRCPV}"
-SRCREV = "f3f53f2567b90babcc19608776addc450fdcb9ac"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 # Set WEBOS_HFP_ENABLED_ROLE to a space-separted list of

--- a/meta-luneos/recipes-webos/cambufferlib/cambufferlib.bb
+++ b/meta-luneos/recipes-webos/cambufferlib/cambufferlib.bb
@@ -12,13 +12,11 @@ LIC_FILES_CHKSUM = " \
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 WEBOS_VERSION = "1.0.0-7_8ef639b99716bd1466d15d65210cc4a9c142095a"
 PR = "r1"
-
-PV = "1.0.0-7+git${SRCPV}"
-SRCREV = "8ef639b99716bd1466d15d65210cc4a9c142095a"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 

--- a/meta-luneos/recipes-webos/com.webos.app.camera/com.webos.app.camera.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.camera/com.webos.app.camera.bb
@@ -13,11 +13,9 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "0.0.1-14_ecbead987b164f57f8da2481532d2c9c662b2e02"
 PR = "r1"
 
-PV = "0.0.1-14+git${SRCPV}"
-SRCREV = "ecbead987b164f57f8da2481532d2c9c662b2e02"
-
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/com.webos.app.enactbrowser/com.webos.app.enactbrowser.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.enactbrowser/com.webos.app.enactbrowser.bb
@@ -16,9 +16,7 @@ inherit webos_public_repo
 inherit webos_enactjs_app
 inherit webos_filesystem_paths
 inherit webos_npm_env
-
-PV = "1.0.0-74+git${SRCPV}"
-SRCREV = "ef128c4af9260f302d941d1a4bab94ba4a09d462"
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-appinfo.json-Use-custom-icon-files-from-legacy.patch \

--- a/meta-luneos/recipes-webos/com.webos.app.home/com.webos.app.home.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.home/com.webos.app.home.bb
@@ -12,14 +12,12 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "0.1.0-37_394b55ebb51bb4251c288257e26b4a2dbe853c1e"
 PR = "r4"
 
-PV = "0.1.0-37+git${SRCPV}"
-SRCREV = "394b55ebb51bb4251c288257e26b4a2dbe853c1e"
-
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_localizable
 
 

--- a/meta-luneos/recipes-webos/com.webos.app.imageviewer/com.webos.app.imageviewer.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.imageviewer/com.webos.app.imageviewer.bb
@@ -12,11 +12,9 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "0.0.1-15_ca49d724d66ff827acee8eb5e95c380fd3fc1de2"
 PR = "r1"
 
-PV = "0.0.1-15+git${SRCPV}"
-SRCREV = "ca49d724d66ff827acee8eb5e95c380fd3fc1de2"
-
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/com.webos.app.mediagallery/com.webos.app.mediagallery.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.mediagallery/com.webos.app.mediagallery.bb
@@ -21,14 +21,12 @@ RDEPENDS:${PN} += "qml-webos-framework qml-webos-bridge"
 
 WEBOS_VERSION = "1.0.0-17_4fe324a62ee8d06e344e935f17cbda3d3e568b59"
 
-PV = "1.0.0-17+git${SRCPV}"
-SRCREV = "4fe324a62ee8d06e344e935f17cbda3d3e568b59"
-
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 PR = "r3"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_localizable
 inherit webos_qmake6
 inherit systemd

--- a/meta-luneos/recipes-webos/com.webos.app.notification/com.webos.app.notification.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.notification/com.webos.app.notification.bb
@@ -11,15 +11,13 @@ LIC_FILES_CHKSUM = " \
 
 WEBOS_VERSION = "0.1.0-17_843ac43ece5a0644799466ada5f4845993744124"
 
-PV = "0.1.0-17+git${SRCPV}"
-SRCREV = "843ac43ece5a0644799466ada5f4845993744124"
-
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 PR = "r2"
 
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 WEBOS_ENACTJS_APP_ID = "com.webos.app.notification"
 

--- a/meta-luneos/recipes-webos/com.webos.app.statusbar/com.webos.app.statusbar.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.statusbar/com.webos.app.statusbar.bb
@@ -12,15 +12,12 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "0.0.1-6_391a7829c540f4b41d3f34f478d37384a7585fc9"
 PR = "r0"
 
-PV = "0.0.1-6+git${SRCPV}"
-SRCREV = "391a7829c540f4b41d3f34f478d37384a7585fc9"
-
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
 inherit webos_enactjs_app
 inherit webos_public_repo
-
+inherit webos_enhanced_submissions
 
 WEBOS_ENACTJS_APP_ID = "com.webos.app.statusbar"
 

--- a/meta-luneos/recipes-webos/com.webos.app.videocall/com.webos.app.videocall.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.videocall/com.webos.app.videocall.bb
@@ -12,11 +12,9 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "0.0.1-6_32a649a56f2389243e7ecd95ec978f6ab0a7e335"
 PR = "r0"
 
-PV = "0.0.1-6+git${SRCPV}"
-SRCREV = "32a649a56f2389243e7ecd95ec978f6ab0a7e335"
-
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_localizable
 
 

--- a/meta-luneos/recipes-webos/com.webos.app.videoplayer/com.webos.app.videoplayer.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.videoplayer/com.webos.app.videoplayer.bb
@@ -12,11 +12,9 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "0.0.1-12_ff6e0081d1b0f8ad1bf0480c5f28b2616cd646d4"
 PR = "r1"
 
-PV = "0.0.1-12+git${SRCPV}"
-SRCREV = "ff6e0081d1b0f8ad1bf0480c5f28b2616cd646d4"
-
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/com.webos.app.volume/com.webos.app.volume.bb
+++ b/meta-luneos/recipes-webos/com.webos.app.volume/com.webos.app.volume.bb
@@ -11,15 +11,13 @@ LIC_FILES_CHKSUM = " \
 
 WEBOS_VERSION = "0.1.0-16_675f9154fca5dffb1c2f773ccb93aa0e0e6ffe72"
 
-PV = "0.1.0-16+git${SRCPV}"
-SRCREV = "675f9154fca5dffb1c2f773ccb93aa0e0e6ffe72"
-
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 PR = "r2"
 
 inherit webos_enactjs_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 WEBOS_ENACTJS_APP_ID = "com.webos.app.volume"
 

--- a/meta-luneos/recipes-webos/com.webos.service.ai/com.webos.service.ai.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.ai/com.webos.service.ai.bb
@@ -19,11 +19,9 @@ DEPENDS = "glib-2.0 luna-service2 json-c pmloglib libgoogleassistant"
 WEBOS_VERSION = "1.0.0-11_6bc7a16f334f58dfa4b439b6f849d79a1b72871b"
 PR = "r8"
 
-PV = "1.0.0-11+git${SRCPV}"
-SRCREV = "6bc7a16f334f58dfa4b439b6f849d79a1b72871b"
-
 inherit systemd
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus

--- a/meta-luneos/recipes-webos/com.webos.service.audiooutput/com.webos.service.audiooutput.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.audiooutput/com.webos.service.audiooutput.bb
@@ -16,12 +16,10 @@ inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 WEBOS_VERSION = "1.0.0-5_7b3b85dcfc2ad9394cfad761e4c34354f3126180"
 PR = "r2"
-
-PV = "1.0.0-5+git${SRCPV}"
-SRCREV = "7b3b85dcfc2ad9394cfad761e4c34354f3126180"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/com.webos.service.camera/com.webos.service.camera.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.camera/com.webos.service.camera.bb
@@ -19,12 +19,10 @@ DEPENDS = "glib-2.0 luna-service2 json-c alsa-lib pmloglib udev"
 WEBOS_VERSION = "1.0.0-36_9ffdd45eb7385bd8447117cc061ac9e73a819d57"
 PR = "r7"
 
-PV = "1.0.0-36+git${SRCPV}"
-SRCREV = "9ffdd45eb7385bd8447117cc061ac9e73a819d57"
-
 inherit webos_cmake 
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_system_bus
 inherit webos_machine_impl_dep
 

--- a/meta-luneos/recipes-webos/com.webos.service.cec/com.webos.service.cec.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.cec/com.webos.service.cec.bb
@@ -15,12 +15,10 @@ DEPENDS = "glib-2.0 libpbnjson luna-service2 pmloglib nyx-lib"
 WEBOS_VERSION = "1.0.0-5_a2236e7706698cdd091c64e4bafe49c8eac635ab"
 PR = "r1"
 
-PV = "1.0.0-5+git${SRCPV}"
-SRCREV = "a2236e7706698cdd091c64e4bafe49c8eac635ab"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/com.webos.service.contextintentmgr/com.webos.service.contextintentmgr.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.contextintentmgr/com.webos.service.contextintentmgr.bb
@@ -15,11 +15,9 @@ DEPENDS = "nodejs-module-node-red"
 WEBOS_VERSION = "1.0.0-19_15340c48143f287d667ce0c48a3ecbbad94691d1"
 PR = "r6"
 
-PV = "1.0.0-19+git${SRCPV}"
-SRCREV = "15340c48143f287d667ce0c48a3ecbbad94691d1"
-
 inherit systemd
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 

--- a/meta-luneos/recipes-webos/com.webos.service.flowmanager/flowmanager.inc
+++ b/meta-luneos/recipes-webos/com.webos.service.flowmanager/flowmanager.inc
@@ -1,9 +1,7 @@
 WEBOS_VERSION = "1.0.0-8_0461c67749f142da7d4565753380ae8108638f48"
 
-PV = "1.0.0-8+git${SRCPV}"
-SRCREV = "0461c67749f142da7d4565753380ae8108638f48"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 

--- a/meta-luneos/recipes-webos/com.webos.service.intent/com.webos.service.intent.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.intent/com.webos.service.intent.bb
@@ -15,13 +15,11 @@ DEPENDS = "glib-2.0 luna-service2 libpbnjson"
 WEBOS_VERSION = "1.0.0-17_ea416580431307921b4846e9421af5d22a8d62d5"
 PR = "r3"
 
-PV = "1.0.0-17+git${SRCPV}"
-SRCREV = "ea416580431307921b4846e9421af5d22a8d62d5"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 # [http://gpro.lge.com/c/webosose/com.webos.service.intent/+/348184 Fix luna-service2 usage]
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \

--- a/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.mediacontroller/com.webos.service.mediacontroller.bb
@@ -15,12 +15,10 @@ DEPENDS = "glib-2.0 luna-service2 json-c pmloglib"
 WEBOS_VERSION = "1.0.0-28_4cecd9e728e00db17e4e2a8707bad36d133f7618"
 PR = "r6"
 
-PV = "1.0.0-28+git${SRCPV}"
-SRCREV = "4cecd9e728e00db17e4e2a8707bad36d133f7618"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_machine_impl_dep
 inherit webos_system_bus
 

--- a/meta-luneos/recipes-webos/com.webos.service.mediarecorder/com.webos.service.mediarecorder.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.mediarecorder/com.webos.service.mediarecorder.bb
@@ -14,11 +14,9 @@ DEPENDS = "glib-2.0 luna-service2 pmloglib nlohmann-json"
 WEBOS_VERSION = "1.0.0-1_ab3652ecfc70c53ee79a660752ebbd57e9502804"
 PR = "r0"
 
-PV = "1.0.0-1+git${SRCPV}"
-SRCREV = "ab3652ecfc70c53ee79a660752ebbd57e9502804"
-
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_system_bus
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/com.webos.service.memorymanager/com.webos.service.memorymanager.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.memorymanager/com.webos.service.memorymanager.bb
@@ -14,12 +14,10 @@ DEPENDS = "glib-2.0 glib-2.0-native luna-service2 libpbnjson pmloglib"
 WEBOS_VERSION = "1.0.0-57_5d320c6c5fb80fce406b5384351985cda0808914"
 PR = "r10"
 
-PV = "1.0.0-57+git${SRCPV}"
-SRCREV = "5d320c6c5fb80fce406b5384351985cda0808914"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/com.webos.service.pdm/com.webos.service.pdm.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.pdm/com.webos.service.pdm.bb
@@ -21,12 +21,10 @@ RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_pdm-plugin}"
 WEBOS_VERSION = "1.0.1-84_ce309957eaa6afc905fd9c60504e776e8273ed27"
 PR = "r10"
 
-PV = "1.0.1-84+git${SRCPV}"
-SRCREV = "ce309957eaa6afc905fd9c60504e776e8273ed27"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \

--- a/meta-luneos/recipes-webos/com.webos.service.peripheralmanager/com.webos.service.peripheralmanager.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.peripheralmanager/com.webos.service.peripheralmanager.bb
@@ -15,13 +15,11 @@ DEPENDS = "glib-2.0 libpbnjson luna-service2 pmloglib "
 WEBOS_VERSION = "1.0.0-13_bbd3a51b96ef9ff375de3f9f7738e6f746b4f326"
 PR = "r3"
 
-PV = "1.0.0-13+git${SRCPV}"
-SRCREV = "bbd3a51b96ef9ff375de3f9f7738e6f746b4f326"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/com.webos.service.power2/com.webos.service.power2.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.power2/com.webos.service.power2.bb
@@ -11,13 +11,11 @@ DEPENDS = "luna-service2 glib-2.0 libpmscore virtual/pmssupportreference pmlogli
 WEBOS_VERSION = "1.0.0-11_7513b0adcb45c8a44f0ebc5b857023c8c6658451"
 PR = "r2"
 
-PV = "1.0.0-11+git${SRCPV}"
-SRCREV = "7513b0adcb45c8a44f0ebc5b857023c8c6658451"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/com.webos.service.sdkagent/com.webos.service.sdkagent.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.sdkagent/com.webos.service.sdkagent.bb
@@ -15,11 +15,9 @@ RDEPENDS:${PN} += "telegraf"
 WEBOS_VERSION = "1.0.0-8_7b57bed2916bf1a3f9842fdd82d612d37dde6add"
 PR = "r1"
 
-PV = "1.0.0-8+git${SRCPV}"
-SRCREV = "7b57bed2916bf1a3f9842fdd82d612d37dde6add"
-
 inherit systemd
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus

--- a/meta-luneos/recipes-webos/com.webos.service.storageaccess/com.webos.service.storageaccess.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.storageaccess/com.webos.service.storageaccess.bb
@@ -15,10 +15,8 @@ DEPENDS= "glib-2.0 libxml2 luna-service2 pmloglib libgdrive libpbnjson curl gupn
 WEBOS_VERSION = "1.0.0-24_fcb2542bb458d3677db58bddde44df8859c072a2"
 PR = "r6"
 
-PV = "1.0.0-24+git${SRCPV}"
-SRCREV = "fcb2542bb458d3677db58bddde44df8859c072a2"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus

--- a/meta-luneos/recipes-webos/com.webos.service.tts/com.webos.service.tts.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.tts/com.webos.service.tts.bb
@@ -15,10 +15,8 @@ DEPENDS = "glib-2.0 luna-service2 libpbnjson pmloglib json-c pulseaudio googleap
 WEBOS_VERSION = "1.0.0-28_06ceb4c6e4b9899e2c1760061a7130146ab5ae98"
 PR = "r9"
 
-PV = "1.0.0-28+git${SRCPV}"
-SRCREV = "06ceb4c6e4b9899e2c1760061a7130146ab5ae98"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_system_bus

--- a/meta-luneos/recipes-webos/com.webos.service.unifiedsearch/com.webos.service.unifiedsearch.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.unifiedsearch/com.webos.service.unifiedsearch.bb
@@ -13,12 +13,10 @@ DEPENDS = "luna-service2 libpbnjson glib-2.0 procps sqlite3"
 WEBOS_VERSION = "1.0.0-6_a911bcccbe9e7c5082a30173d064dca9e7c8ab21"
 PR = "r4"
 
-PV = "1.0.0-6+git${SRCPV}"
-SRCREV = "a911bcccbe9e7c5082a30173d064dca9e7c8ab21"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_system_bus
 
 # http://gpro.lge.com/c/webosose/com.webos.service.unifiedsearch/+/347405 Fix build with gcc-12

--- a/meta-luneos/recipes-webos/com.webos.service.videooutput/com.webos.service.videooutput.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.videooutput/com.webos.service.videooutput.bb
@@ -16,12 +16,10 @@ RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_val-impl}"
 WEBOS_VERSION = "1.0.0-13_931b3e59260a97ea0741ebbd1d84fd30b405b484"
 PR = "r2"
 
-PV = "1.0.0-13+git${SRCPV}"
-SRCREV = "931b3e59260a97ea0741ebbd1d84fd30b405b484"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 inherit webos_test_provider
 

--- a/meta-luneos/recipes-webos/com.webos.service.videooutput/videooutput-adaptation-layer-api.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.videooutput/videooutput-adaptation-layer-api.bb
@@ -14,12 +14,10 @@ DEPENDS = "glib-2.0"
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
 WEBOS_VERSION ="1.0.0-4_b8ddfdc6bd7f0de06b5e35a6ee9daf1eed633642"
 PR = "r1"
-
-PV = "1.0.0-4+git${SRCPV}"
-SRCREV = "b8ddfdc6bd7f0de06b5e35a6ee9daf1eed633642"

--- a/meta-luneos/recipes-webos/com.webos.service.videooutput/videooutput-adaptation-layer-mock.bb
+++ b/meta-luneos/recipes-webos/com.webos.service.videooutput/videooutput-adaptation-layer-mock.bb
@@ -12,6 +12,7 @@ inherit pkgconfig
 inherit webos_cmake
 inherit webos_test_provider
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
@@ -20,6 +21,3 @@ DEPENDS = "glib-2.0 pmloglib libpbnjson videooutput-adaptation-layer-api"
 
 WEBOS_VERSION = "1.0.0-3_730d28b116759f4d28c2ac4dbc56b29c13d5452e"
 PR = "r1"
-
-PV = "1.0.0-3+git${SRCPV}"
-SRCREV = "730d28b116759f4d28c2ac4dbc56b29c13d5452e"

--- a/meta-luneos/recipes-webos/configd/configd.bb
+++ b/meta-luneos/recipes-webos/configd/configd.bb
@@ -16,11 +16,9 @@ inherit webos_cmake
 inherit webos_system_bus
 inherit webos_systemd
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 WEBOS_VERSION = "1.2.0-18_0d07514460a6c35e3a7aa0d360468f626210eaae"
-
-PV = "1.2.0-18+git${SRCPV}"
-SRCREV = "0d07514460a6c35e3a7aa0d360468f626210eaae"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 

--- a/meta-luneos/recipes-webos/configurator/configurator.bb
+++ b/meta-luneos/recipes-webos/configurator/configurator.bb
@@ -15,10 +15,8 @@ DEPENDS = "luna-service2 db8 glib-2.0 pmloglib"
 WEBOS_VERSION = "3.0.0-11_ded3f968c2943ef77d81755e5bf7de088447651a"
 PR = "r10"
 
-PV = "3.0.0-11+git${SRCPV}"
-SRCREV = "ded3f968c2943ef77d81755e5bf7de088447651a"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit pkgconfig

--- a/meta-luneos/recipes-webos/db8/db8.bb
+++ b/meta-luneos/recipes-webos/db8/db8.bb
@@ -23,16 +23,13 @@ RDEPENDS:${PN}:append:class-target = " ${VIRTUAL-RUNTIME_stat} ${VIRTUAL-RUNTIME
 RDEPENDS:${PN}-tests:append:class-target = " ${VIRTUAL-RUNTIME_bash}"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit pkgconfig
 
 WEBOS_VERSION = "3.2.0-29_bc18024e9cb039d7eba18c9266b54128f25a3dbd"
 PR = "r40"
-
-PV = "3.2.0-29+git${SRCPV}"
-SRCREV = "bc18024e9cb039d7eba18c9266b54128f25a3dbd"
-
 
 EXTRA_OECMAKE += "-DWEBOS_DB8_BACKEND:STRING='leveldb;sandwich' -DCMAKE_SKIP_RPATH:BOOL=TRUE"
 EXTRA_OECMAKE:append:class-target = " -DWEBOS_CONFIG_BUILD_TESTS:BOOL=TRUE  -DUSE_PMLOG:BOOL=TRUE  -DBUILD_LS2:BOOL=TRUE -DWANT_PROFILING:BOOL=${@ 'true' if '${WEBOS_DISTRO_PRERELEASE}' != '' else 'false'}"

--- a/meta-luneos/recipes-webos/event-monitor-network/event-monitor-network.bb
+++ b/meta-luneos/recipes-webos/event-monitor-network/event-monitor-network.bb
@@ -10,12 +10,10 @@ DEPENDS = "glib-2.0 event-monitor pmloglib libpbnjson libwebosi18n"
 
 WEBOS_VERSION = "1.0.0-5_c99401afd1464f8b74766696560bad84a10e5ab4"
 
-PV = "1.0.0-5+git${SRCPV}"
-SRCREV = "c99401afd1464f8b74766696560bad84a10e5ab4"
-
 inherit webos_cmake
 inherit webos_event_monitor_plugin
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/event-monitor-pdm/event-monitor-pdm.bb
+++ b/meta-luneos/recipes-webos/event-monitor-pdm/event-monitor-pdm.bb
@@ -14,12 +14,10 @@ DEPENDS = "glib-2.0 event-monitor pmloglib libpbnjson libwebosi18n"
 WEBOS_VERSION = "1.0.0-8_fb0a3bab04d07537a4cc04c4e7274025fe5633ef"
 PR = "r2"
 
-PV = "1.0.0-8+git${SRCPV}"
-SRCREV = "fb0a3bab04d07537a4cc04c4e7274025fe5633ef"
-
 inherit webos_cmake
 inherit webos_event_monitor_plugin
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_localizable
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/event-monitor/event-monitor.bb
+++ b/meta-luneos/recipes-webos/event-monitor/event-monitor.bb
@@ -10,13 +10,11 @@ DEPENDS = "glib-2.0 luna-service2 pmloglib libpbnjson libwebosi18n"
 
 WEBOS_VERSION = "1.1.0-14_ebed44ed82acfbb2c6e4193d21eb22742c6d5ad2"
 
-PV = "1.1.0-14+git${SRCPV}"
-SRCREV = "ebed44ed82acfbb2c6e4193d21eb22742c6d5ad2"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_event_monitor_plugin
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_systemd
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/filecache/filecache.bb
+++ b/meta-luneos/recipes-webos/filecache/filecache.bb
@@ -11,10 +11,8 @@ DEPENDS = "jemalloc luna-service2 db8 glibmm boost libsandbox glib-2.0 libsigc++
 WEBOS_VERSION = "2.0.1-12_31660e50ab350dab3304bc57a87ee68d65a8edf7"
 PR = "r6"
 
-PV = "2.0.1-12+git${SRCPV}"
-SRCREV = "31660e50ab350dab3304bc57a87ee68d65a8edf7"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_machine_impl_dep

--- a/meta-luneos/recipes-webos/g-camera-pipeline/g-camera-pipeline.bb
+++ b/meta-luneos/recipes-webos/g-camera-pipeline/g-camera-pipeline.bb
@@ -13,6 +13,7 @@ LIC_FILES_CHKSUM = " \
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 PR = "r14"
@@ -23,9 +24,6 @@ DEPENDS:append:rpi = " userland"
 COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
 
 WEBOS_VERSION = "1.0.0-gav.40_48def9addb5dcb0f408137c5f8c34c33d799ab90"
-
-PV = "1.0.0-gav.40+git${SRCPV}"
-SRCREV = "48def9addb5dcb0f408137c5f8c34c33d799ab90"
 
 WEBOS_GIT_PARAM_BRANCH = "@gav"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/ilib-webapp/ilib-qml-plugin.bb
+++ b/meta-luneos/recipes-webos/ilib-webapp/ilib-qml-plugin.bb
@@ -15,11 +15,9 @@ RDEPENDS:${PN} += "ilib-webapp"
 WEBOS_VERSION = "11.0.0-6_bdf1beb39a1326243eac0797791f099ca4f1c5ae"
 PR = "r7"
 
-PV = "11.0.0-6+git${SRCPV}"
-SRCREV = "bdf1beb39a1326243eac0797791f099ca4f1c5ae"
-
 inherit webos_qmake6
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/ilib-webapp/ilib-webapp.bb
+++ b/meta-luneos/recipes-webos/ilib-webapp/ilib-webapp.bb
@@ -12,10 +12,8 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "14.18.0-29_7b4faed3a1366b51f9bbfca62e767bb7f8318540"
 PR = "r8"
 
-PV = "14.18.0-29+git${SRCPV}"
-SRCREV = "7b4faed3a1366b51f9bbfca62e767bb7f8318540"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/imemanager/imemanager.bb
+++ b/meta-luneos/recipes-webos/imemanager/imemanager.bb
@@ -19,12 +19,10 @@ RDEPENDS:${PN} += "qml-webos-bridge"
 WEBOS_VERSION = "1.0.0-29_277aa343ce79866539ee1cafda091f06548b3f79"
 PR = "r6"
 
-PV = "1.0.0-29+git${SRCPV}"
-SRCREV = "277aa343ce79866539ee1cafda091f06548b3f79"
-
 inherit webos_qmake6
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 #inherit webos_qt_localization
 
 WEBOS_SYSTEM_BUS_SKIP_DO_TASKS = "1"

--- a/meta-luneos/recipes-webos/jemalloc/jemalloc.bb
+++ b/meta-luneos/recipes-webos/jemalloc/jemalloc.bb
@@ -9,10 +9,8 @@ LIC_FILES_CHKSUM = "file://README.md;beginline=94;md5=b159f6c7121460dba2c5965602
 WEBOS_VERSION = "0.20080828a-0webos9-6_f527e94e1facd3a9c801bf181d5e7cba287d04bb"
 PR = "r5"
 
-PV = "0.20080828a-0webos9-6+git${SRCPV}"
-SRCREV = "f527e94e1facd3a9c801bf181d5e7cba287d04bb"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/libgoogleassistant/libgoogleassistant.bb
+++ b/meta-luneos/recipes-webos/libgoogleassistant/libgoogleassistant.bb
@@ -24,11 +24,9 @@ RDEPENDS:${PN}:remove:class-target = "${@oe.utils.conditional('WEBOS_PREFERRED_P
 WEBOS_VERSION = "1.0.1-10_b8610f05673d48b498e38cb774d6f1056c3b5522"
 PR = "r8"
 
-PV = "1.0.1-10+git${SRCPV}"
-SRCREV = "b8610f05673d48b498e38cb774d6f1056c3b5522"
-
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/libpmscore/libpmscore.bb
+++ b/meta-luneos/recipes-webos/libpmscore/libpmscore.bb
@@ -15,13 +15,11 @@ DEPENDS = "luna-service2 glib-2.0 pmloglib libpbnjson nyx-lib"
 WEBOS_VERSION = "1.0.0-11_f7dd5e7ec8cb39154634aab0d70667c29253e0be"
 PR = "r1"
 
-PV = "1.0.0-11+git${SRCPV}"
-SRCREV = "f7dd5e7ec8cb39154634aab0d70667c29253e0be"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/libsandbox/libsandbox.bb
+++ b/meta-luneos/recipes-webos/libsandbox/libsandbox.bb
@@ -13,10 +13,8 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "2.0.0-2_03120c12ebae2cb2fbd4cb2b58e6b2c6b565efa5"
 PR = "r3"
 
-PV = "2.0.0-2+git${SRCPV}"
-SRCREV = "03120c12ebae2cb2fbd4cb2b58e6b2c6b565efa5"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_machine_impl_dep
 

--- a/meta-luneos/recipes-webos/libwebosi18n/libwebosi18n.bb
+++ b/meta-luneos/recipes-webos/libwebosi18n/libwebosi18n.bb
@@ -14,12 +14,10 @@ DEPENDS = "libpbnjson boost"
 WEBOS_VERSION = "1.0.1-8_af063dc035e950fda7967144c0e4fa8acc7ded91"
 PR = "r3"
 
-PV = "1.0.1-8+git${SRCPV}"
-SRCREV = "af063dc035e950fda7967144c0e4fa8acc7ded91"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/ls2-helpers/ls2-helpers.bb
+++ b/meta-luneos/recipes-webos/ls2-helpers/ls2-helpers.bb
@@ -13,13 +13,10 @@ DEPENDS = "glib-2.0 luna-service2 pmloglib libpbnjson"
 WEBOS_VERSION = "1.0.0-1_d44eeede2de5b06d08fd86ace6e93f5aed9f7f27"
 PR = "r3"
 
-PV = "1.0.0-1+git${SRCPV}"
-
-SRCREV = "d44eeede2de5b06d08fd86ace6e93f5aed9f7f27"
-
 inherit webos_cmake
 inherit webos_test_provider
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 # http://gpro.lge.com/c/webosose/ls2-helpers/+/348043 test_subscriptionpoint.cpp: Prevent issues with new gtest
 # http://gpro.lge.com/c/webosose/ls2-helpers/+/348042 Fix build with gcc-12

--- a/meta-luneos/recipes-webos/luna-downloadmgr/luna-downloadmgr.bb
+++ b/meta-luneos/recipes-webos/luna-downloadmgr/luna-downloadmgr.bb
@@ -16,12 +16,10 @@ RDEPENDS:${PN} = "applicationinstallerutility"
 WEBOS_VERSION = "4.0.0-12_abc1c307bbd50aa2a362c256098da1199220c277"
 PR = "r12"
 
-PV = "4.0.0-12+git${SRCPV}"
-SRCREV = "abc1c307bbd50aa2a362c256098da1199220c277"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 

--- a/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager.bb
+++ b/meta-luneos/recipes-webos/luna-surfacemanager/luna-surfacemanager.bb
@@ -14,14 +14,11 @@ DEPENDS = "qtdeclarative wayland-native qtwayland qtwayland-native qt-features-w
 WEBOS_VERSION = "2.0.0-395_4e88486015c69db462654a7ef797f5c6a56e616f"
 PR = "r60"
 
-PV ="2.0.0-395+git${SRCPV}"
-
-SRCREV = "4e88486015c69db462654a7ef797f5c6a56e616f"
-
 inherit webos_qmake6
 inherit pkgconfig
 inherit webos_lttng
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Add-capability-to-pass-extra-options-to-surface-mana.patch \

--- a/meta-luneos/recipes-webos/luna-sysservice/luna-sysservice.bb
+++ b/meta-luneos/recipes-webos/luna-sysservice/luna-sysservice.bb
@@ -19,10 +19,8 @@ RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_ntp} tzcode luna-init"
 WEBOS_VERSION = "4.4.0-25_527dfeba2b7d1c7f84ea5e8775b1f1ec4c40b183"
 PR = "r11"
 
-PV = "4.4.0-25+git${SRCPV}"
-SRCREV = "527dfeba2b7d1c7f84ea5e8775b1f1ec4c40b183"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake_qt6
 inherit webos_system_bus
 inherit webos_systemd

--- a/meta-luneos/recipes-webos/maliit-framework-webos/maliit-framework-webos.bb
+++ b/meta-luneos/recipes-webos/maliit-framework-webos/maliit-framework-webos.bb
@@ -18,13 +18,11 @@ PACKAGECONFIG[libim] = "CONFIG+=enable-libim,CONFIG-=enable-libim,libim"
 WEBOS_VERSION = "0.99.0+20-102_b3c5fe41a33b6dd3d5c11b704c6ff2c8974ef7b6"
 PR = "r35"
 
-PV = "0.99.0+20-102+git${SRCPV}"
-SRCREV = "b3c5fe41a33b6dd3d5c11b704c6ff2c8974ef7b6"
-
 inherit pkgconfig
 inherit webos_qmake6
 inherit webos_filesystem_paths
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/media-resource-calculator/media-resource-calculator.bb
+++ b/meta-luneos/recipes-webos/media-resource-calculator/media-resource-calculator.bb
@@ -16,12 +16,10 @@ EXTRA_OECMAKE += "-DNO_TEST=1"
 WEBOS_VERSION = "1.0.0-12_067d32e0a22b2dcb23985f728515cc34f13b0712"
 PR = "r7"
 
-PV = "1.0.0-12+git${SRCPV}"
-SRCREV = "067d32e0a22b2dcb23985f728515cc34f13b0712"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/mojoloader/mojoloader.bb
+++ b/meta-luneos/recipes-webos/mojoloader/mojoloader.bb
@@ -13,11 +13,8 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "1.1-3_7c22039cbef6e78adc0b4165a0f6c7232eac24d8"
 PR = "r7"
 
-PV = "1.1-3+git${SRCPV}"
-SRCREV = "7c22039cbef6e78adc0b4165a0f6c7232eac24d8"
-
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit allarch
 inherit webos_filesystem_paths
 

--- a/meta-luneos/recipes-webos/mojoservicelauncher/mojoservicelauncher.bb
+++ b/meta-luneos/recipes-webos/mojoservicelauncher/mojoservicelauncher.bb
@@ -18,10 +18,8 @@ RDEPENDS:${PN} += "nodejs-module-webos-dynaload nodejs-module-webos-pmlog nodejs
 WEBOS_VERSION = "3.0.2-7_b759589be50ce52c4ae4e6af40ecbc78c7232a96"
 PR = "r10"
 
-PV = "3.0.2-7+git${SRCPV}"
-SRCREV = "b759589be50ce52c4ae4e6af40ecbc78c7232a96"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-dynaload.bb
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-dynaload.bb
@@ -12,9 +12,6 @@ DEPENDS += "boost"
 WEBOS_VERSION = "3.0.2-4_ef029ca96241caf25700b51a47502e6752cc8638"
 PR = "r13"
 
-PV = "3.0.2-4+git${SRCPV}"
-SRCREV = "ef029ca96241caf25700b51a47502e6752cc8638"
-
 inherit pkgconfig
 
 do_configure() {

--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-pmlog.bb
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-pmlog.bb
@@ -12,9 +12,6 @@ DEPENDS += "pmloglib vim-native"
 WEBOS_VERSION = "3.0.1-8_bf9622036e9fcfd0de2fe135ab3039742c73ad05"
 PR = "r16"
 
-PV = "3.0.1-8+git${SRCPV}"
-SRCREV = "bf9622036e9fcfd0de2fe135ab3039742c73ad05"
-
 inherit pkgconfig
 
 do_configure() {

--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-service.bb
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-service.bb
@@ -13,11 +13,9 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "1.0.1-7_a514543927ec3998a054ead7654cea6dfa5dee90"
 PR = "r5"
 
-PV = "1.0.1-7+git${SRCPV}"
-SRCREV = "a514543927ec3998a054ead7654cea6dfa5dee90"
-
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-sysbus.bb
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos-sysbus.bb
@@ -14,9 +14,6 @@ inherit pkgconfig
 WEBOS_VERSION = "3.0.1-15_a8d17fa1037cd0056449a95aa22c01ded2989d85"
 PR = "r17"
 
-PV = "3.0.1-15+git${SRCPV}"
-SRCREV = "a8d17fa1037cd0056449a95aa22c01ded2989d85"
-
 do_configure() {
     export GYP_DEFINES="sysroot=${STAGING_DIR_HOST}"
     # used by binding.gyp

--- a/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos.inc
+++ b/meta-luneos/recipes-webos/nodejs-module-webos/nodejs-module-webos.inc
@@ -9,6 +9,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 DEPENDS = "node-gyp-native"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_filesystem_paths
 inherit webos_npm_env
 inherit python3native

--- a/meta-luneos/recipes-webos/notificationmgr/notificationmgr.bb
+++ b/meta-luneos/recipes-webos/notificationmgr/notificationmgr.bb
@@ -15,13 +15,11 @@ DEPENDS = "glib-2.0 luna-service2 libpbnjson pmloglib boost libxml++"
 WEBOS_VERSION = "1.0.0-26_44ada0c03140ee74a73a0e41b8f506e79c58d97f"
 PR = "r11"
 
-PV = "1.0.0-26+git${SRCPV}"
-SRCREV = "44ada0c03140ee74a73a0e41b8f506e79c58d97f"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_systemd
 
 

--- a/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
+++ b/meta-luneos/recipes-webos/nyx-modules/nyx-modules.bb
@@ -19,9 +19,6 @@ RDEPENDS:${PN} = "lsb-release gzip nyx-conf"
 WEBOS_VERSION = "7.1.0-22_677ed3eca696f1d5b00d8b7579f981e37e319ce3"
 PR = "r19"
 
-PV = "7.1.0-22+git${SRCPV}"
-SRCREV = "677ed3eca696f1d5b00d8b7579f981e37e319ce3"
-
 EXTRA_OECMAKE += "-DDISTRO_VERSION:STRING='${DISTRO_VERSION}' -DDISTRO_NAME:STRING='${DISTRO_NAME}${WEBOS_DISTRO_NAME_SUFFIX}' \
                   -DWEBOS_DISTRO_API_VERSION:STRING='${WEBOS_DISTRO_API_VERSION}' \
                   -DWEBOS_DISTRO_RELEASE_CODENAME:STRING='${WEBOS_DISTRO_RELEASE_CODENAME}' \
@@ -48,6 +45,7 @@ WEBOS_TARGET_CORE_OS = "rockhopper"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_machine_impl_dep
 inherit webos_core_os_dep

--- a/meta-luneos/recipes-webos/pdm-plugin/pdm-plugin.bb
+++ b/meta-luneos/recipes-webos/pdm-plugin/pdm-plugin.bb
@@ -16,11 +16,9 @@ DEPENDS = "com.webos.service.pdm"
 WEBOS_VERSION = "1.0.1-11_d63d098d4f9735ea19e73eda31e10b6ab52dd8d5"
 PR = "r3"
 
-PV = "1.0.1-11+git${SRCPV}"
-SRCREV = "d63d098d4f9735ea19e73eda31e10b6ab52dd8d5"
-
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit pkgconfig
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/pmklogd/pmklogd.bb
+++ b/meta-luneos/recipes-webos/pmklogd/pmklogd.bb
@@ -15,10 +15,8 @@ DEPENDS = "glib-2.0"
 WEBOS_VERSION = "2.0.0-2_62a67a5fdce9918eda41a2f4479a2c97307bceec"
 PR = "r6"
 
-PV = "2.0.0-2+git${SRCPV}"
-SRCREV = "62a67a5fdce9918eda41a2f4479a2c97307bceec"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/pmlogctl/pmlogctl.bb
+++ b/meta-luneos/recipes-webos/pmlogctl/pmlogctl.bb
@@ -15,10 +15,8 @@ DEPENDS = "pmloglib"
 WEBOS_VERSION = "3.0.0-2_a6ac2b162550e69d2a2bfe5b77eaff24e1a92184"
 PR = "r4"
 
-PV = "3.0.0-2+git${SRCPV}"
-SRCREV = "a6ac2b162550e69d2a2bfe5b77eaff24e1a92184"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/pmlogdaemon/pmlogdaemon.bb
+++ b/meta-luneos/recipes-webos/pmlogdaemon/pmlogdaemon.bb
@@ -18,10 +18,8 @@ RDEPENDS:${PN} = "busybox"
 WEBOS_VERSION = "3.1.0-13_17f40f7074f3f0a54395e6b1bc6b29af02d46fb8"
 PR = "r11"
 
-PV = "3.1.0-13+git${SRCPV}"
-SRCREV = "17f40f7074f3f0a54395e6b1bc6b29af02d46fb8"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_pmlog_config

--- a/meta-luneos/recipes-webos/pms-support-reference/pms-support-reference.bb
+++ b/meta-luneos/recipes-webos/pms-support-reference/pms-support-reference.bb
@@ -12,13 +12,11 @@ PROVIDES = "virtual/pmssupportreference"
 WEBOS_VERSION = "1.0.0-4_fb77973c4c82a384cee430719365b95e26de6d03"
 PR = "r1"
 
-PV = "1.0.0-4+git${SRCPV}"
-SRCREV = "fb77973c4c82a384cee430719365b95e26de6d03"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/pmtrace/pmtrace.bb
+++ b/meta-luneos/recipes-webos/pmtrace/pmtrace.bb
@@ -24,12 +24,10 @@ DEPENDS = "lttng-ust libpbnjson pmloglib glib-2.0"
 WEBOS_VERSION = "1.0.0-15_407d07f257498472a53bf39c9d176953885cadeb"
 PR = "r13"
 
-PV = "1.0.0-15+git${SRCPV}"
-SRCREV = "407d07f257498472a53bf39c9d176953885cadeb"
-
 inherit webos_cmake
 inherit webos_lttng
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/qml-app-components/qml-app-components.bb
+++ b/meta-luneos/recipes-webos/qml-app-components/qml-app-components.bb
@@ -15,12 +15,10 @@ DEPENDS:append = " ${@ 'qtshadertools-native' if d.getVar('QT_VERSION')[0] == '6
 WEBOS_VERSION = "1.0.0-6_ad9b0aee66408b214d5f4d61b9912ed411da2f00"
 PR = "r4"
 
-PV = "1.0.0-6+git${SRCPV}"
-SRCREV = "ad9b0aee66408b214d5f4d61b9912ed411da2f00"
-
 inherit webos_qmake6
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-FontStyle.qml-Use-Prelude-on-LuneOS-instead-of-Museo.patch \

--- a/meta-luneos/recipes-webos/qml-webos-bridge/qml-webos-bridge.bb
+++ b/meta-luneos/recipes-webos/qml-webos-bridge/qml-webos-bridge.bb
@@ -15,12 +15,10 @@ RDEPENDS:${PN} += "qml-webos-components"
 WEBOS_VERSION = "1.0.0-134_657db46613ebe921d835b84391ad0b521170143c"
 PR = "r18"
 
-PV = "1.0.0-134+git${SRCPV}"
-SRCREV = "657db46613ebe921d835b84391ad0b521170143c"
-
 inherit webos_qmake6
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/qml-webos-components/qml-webos-components.bb
+++ b/meta-luneos/recipes-webos/qml-webos-components/qml-webos-components.bb
@@ -14,13 +14,11 @@ DEPENDS = "qtdeclarative pmloglib qt-features-webos luna-service2 glib-2.0"
 WEBOS_VERSION = "1.0.0-59_bf114a608322c5d188959da22646ea83d1e1a6b7"
 PR = "r21"
 
-PV = "1.0.0-59+git${SRCPV}"
-SRCREV = "bf114a608322c5d188959da22646ea83d1e1a6b7"
-
 inherit webos_qmake6
 inherit pkgconfig
 inherit webos_lttng
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos/qml-webos-framework/qml-webos-framework.bb
+++ b/meta-luneos/recipes-webos/qml-webos-framework/qml-webos-framework.bb
@@ -21,14 +21,12 @@ RPROVIDES:${PN}-examples = " \
 WEBOS_VERSION = "1.0.0-166_976ef6a9f06993cbaf2ed3babc6dcb96dd3b1b1f"
 PR = "r35"
 
-PV = "1.0.0-166+git${SRCPV}"
-SRCREV = "976ef6a9f06993cbaf2ed3babc6dcb96dd3b1b1f"
-
 inherit webos_qmake6
 inherit pkgconfig
 inherit webos_app_generate_security_files
 inherit webos_filesystem_paths
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-AppLoader-add-import-path-for-QML-apps.patch \

--- a/meta-luneos/recipes-webos/qt-features-webos/qt-features-webos.bb
+++ b/meta-luneos/recipes-webos/qt-features-webos/qt-features-webos.bb
@@ -14,11 +14,9 @@ DEPENDS = "qtbase"
 WEBOS_VERSION = "1.0.0-55_8bf2bf5ced2aafd6220233cbddc750965ff535d1"
 PR = "r8"
 
-PV = "1.0.0-55+git${SRCPV}"
-SRCREV = "8bf2bf5ced2aafd6220233cbddc750965ff535d1"
-
 inherit webos_qmake6
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Do-not-depend-on-QtInputSupport-for-generate_qmap.patch \

--- a/meta-luneos/recipes-webos/qtbase-plugins-webos/qtbase-plugins-webos.bb
+++ b/meta-luneos/recipes-webos/qtbase-plugins-webos/qtbase-plugins-webos.bb
@@ -14,11 +14,9 @@ DEPENDS = "qtbase"
 WEBOS_VERSION = "1.0.0-20_3fa4ffc17d21075a70bba418c3ca1723459c5680"
 PR = "r8"
 
-PV = "1.0.0-20+git${SRCPV}"
-SRCREV = "3fa4ffc17d21075a70bba418c3ca1723459c5680"
-
 inherit webos_qmake6
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_qt_global
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/qtwayland-webos/qtwayland-webos.bb
+++ b/meta-luneos/recipes-webos/qtwayland-webos/qtwayland-webos.bb
@@ -14,9 +14,6 @@ DEPENDS = "qtwayland webos-wayland-extensions libxkbcommon qt-features-webos way
 WEBOS_VERSION = "6.0.0-93_fa22224e6e6549d89c19f99a984a63c3062dd4f5"
 PR = "r20"
 
-PV = "6.0.0-93+git${SRCPV}"
-SRCREV = "fa22224e6e6549d89c19f99a984a63c3062dd4f5"
-
 PACKAGECONFIG ??= ""
 
 # qtwayland-webos_cmake.inc or qtwayland-webos_qmake.inc
@@ -26,6 +23,7 @@ inherit webos_qmake6
 inherit pkgconfig
 inherit webos_lttng
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Fix-platform-keys.patch \

--- a/meta-luneos/recipes-webos/sam/sam.bb
+++ b/meta-luneos/recipes-webos/sam/sam.bb
@@ -19,13 +19,11 @@ VIRTUAL-RUNTIME_webos-customization ?= ""
 WEBOS_VERSION = "2.0.0-68_efe1735e8c136b7795856e24103778877701fe60"
 PR = "r28"
 
-PV = "2.0.0-68+git${SRCPV}"
-SRCREV = "efe1735e8c136b7795856e24103778877701fe60"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-com.webos.sam.role.json.in-Fix-various-outbound-perm.patch \

--- a/meta-luneos/recipes-webos/settingsservice-conf/settingsservice-conf.bb
+++ b/meta-luneos/recipes-webos/settingsservice-conf/settingsservice-conf.bb
@@ -9,11 +9,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 WEBOS_VERSION = "1.0.0-11_8e3694a3d3da9a26a688bda58655d13e714c3967"
 PR = "r2"
 
-PV = "1.0.0-11+git${SRCPV}"
-SRCREV = "8e3694a3d3da9a26a688bda58655d13e714c3967"
-
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 WEBOS_REPO_NAME = "webos-settingsservice-conf"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/settingsservice/settingsservice.bb
+++ b/meta-luneos/recipes-webos/settingsservice/settingsservice.bb
@@ -16,12 +16,10 @@ RDEPENDS:${PN} = "settingsservice-conf db8"
 WEBOS_VERSION = "1.0.22-19_7684fcc6813104ee5c139701f8ed6627ef851b97"
 PR = "r26"
 
-PV = "1.0.22-19+git${SRCPV}"
-SRCREV = "7684fcc6813104ee5c139701f8ed6627ef851b97"
-
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit systemd
 inherit pkgconfig
 

--- a/meta-luneos/recipes-webos/sleepd/sleepd.bb
+++ b/meta-luneos/recipes-webos/sleepd/sleepd.bb
@@ -16,10 +16,8 @@ RDEPENDS:${PN} += "com.webos.service.battery"
 WEBOS_VERSION = "2.0.0-17_3727287956ca9ac3c6dfb05c64a2df446fa61289"
 PR = "r11"
 
-PV = "2.0.0-17+git${SRCPV}"
-SRCREV = "3727287956ca9ac3c6dfb05c64a2df446fa61289"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit pkgconfig

--- a/meta-luneos/recipes-webos/test-apps/webos-open-test-apps.inc
+++ b/meta-luneos/recipes-webos/test-apps/webos-open-test-apps.inc
@@ -7,13 +7,11 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 WEBOS_VERSION = "1.0.0-22_648edac42dfe23fda82f9e041d4f5b5e3c75479f"
 INC_PR = "r6"
 
-PV = "1.0.0-22+git${SRCPV}"
-SRCREV = "648edac42dfe23fda82f9e041d4f5b5e3c75479f"
-
 EXTRA_INHERIT ?= "webos_cmake"
 
 inherit webos_app
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit ${EXTRA_INHERIT}
 
 WEBOS_REPO_NAME = "test-apps"

--- a/meta-luneos/recipes-webos/umediaserver/umediaserver-configs.bb
+++ b/meta-luneos/recipes-webos/umediaserver/umediaserver-configs.bb
@@ -13,13 +13,11 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "1.0.0-15_48cb6a1271fbb3c08f8503da81047b28b1ef8c7c"
 PR = "r7"
 
-PV = "1.0.0-15+git${SRCPV}"
-SRCREV = "48cb6a1271fbb3c08f8503da81047b28b1ef8c7c"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_filesystem_paths
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/meta-luneos/recipes-webos/umediaserver/umediaserver.inc
+++ b/meta-luneos/recipes-webos/umediaserver/umediaserver.inc
@@ -23,15 +23,13 @@ inherit webos_system_bus
 inherit python3-dir
 inherit python3native
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 do_configure:prepend() {
     sed -i 's@add_subdirectory(test/python)@#disabled until updated to work with python3 add_subdirectory(test/python)@g' ${S}/CMakeLists.txt
 }
 
 WEBOS_VERSION = "1.0.0-gav.35_fd5cba5e25bb62b19ed467ee53f7691a87b2d0b8"
-
-PV = "1.0.0-gav.35+git${SRCPV}"
-SRCREV = "fd5cba5e25bb62b19ed467ee53f7691a87b2d0b8"
 
 WEBOS_GIT_PARAM_BRANCH = "@gav"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"

--- a/meta-luneos/recipes-webos/wam/wam.inc
+++ b/meta-luneos/recipes-webos/wam/wam.inc
@@ -21,9 +21,6 @@ RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_cpushareholder}"
 WEBOS_VERSION = "1.0.2-83_9e666f281d73ba1ff7b24d996f199b2343950369"
 INC_PR = "r64"
 
-PV = "1.0.2-83+git${SRCPV}"
-SRCREV = "9e666f281d73ba1ff7b24d996f199b2343950369"
-
 WAM_BUILD_SYSTEM ?= "webos_cmake"
 WAM_BUILD_DEFAULT_PLUGIN ?= "1"
 
@@ -32,6 +29,7 @@ inherit ${WAM_BUILD_SYSTEM}
 inherit pkgconfig
 inherit webos_lttng
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_systemd
 
 WAM_DATA_DIR = "${webos_execstatedir}/${BPN}"

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support-api.bb
@@ -14,13 +14,10 @@ DEPENDS = "libpbnjson luna-service2"
 WEBOS_VERSION = "1.0.0-4_54eca17251c81e7291893682ed86bc39a8f568ac"
 PR = "r2"
 
-PV = "1.0.0-4+git${SRCPV}"
-
-SRCREV = "54eca17251c81e7291893682ed86bc39a8f568ac"
-
 inherit pkgconfig
 inherit webos_cmake
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Revert-Removing-support-for-com.webos.service.wan-se.patch \

--- a/meta-luneos/recipes-webos/webos-connman-adapter/wca-support.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/wca-support.bb
@@ -12,9 +12,6 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "1.0.0-4_a59127baf2ddebc99874f714c9fe5528772e94d1"
 PR = "r2"
 
-PV = "1.0.0-4+git${SRCPV}"
-SRCREV = "a59127baf2ddebc99874f714c9fe5528772e94d1"
-
 DEPENDS = "glib-2.0 luna-service2 libpbnjson pmloglib luna-prefs wca-support-api"
 
 RDEPENDS:${PN} = "iw"
@@ -22,6 +19,7 @@ RDEPENDS:${PN} = "iw"
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Revert-Removing-support-for-com.webos.service.wan-se.patch \

--- a/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter.bb
+++ b/meta-luneos/recipes-webos/webos-connman-adapter/webos-connman-adapter.bb
@@ -16,10 +16,8 @@ RDEPENDS:${PN} = "connman connman-client"
 WEBOS_VERSION = "1.1.0-42_83a6b8517c2f4ce630e4fe3d1498965cff5fbac3"
 PR = "r13"
 
-PV = "1.1.0-42+git${SRCPV}"
-SRCREV = "83a6b8517c2f4ce630e4fe3d1498965cff5fbac3"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit pkgconfig

--- a/meta-luneos/recipes-webos/webos-fontconfig-files/webos-fontconfig-files.bb
+++ b/meta-luneos/recipes-webos/webos-fontconfig-files/webos-fontconfig-files.bb
@@ -9,14 +9,12 @@ LIC_FILES_CHKSUM = " \
     file://oss-pkg-info.yaml;md5=704f5c65b7aa0484b9e3f01c09e74b58 \
 "
 
-#WEBOS_VERSION = "1.0.0-5_e3b8d5297c20edd8fc73ee3ac8729094159942ec"
+WEBOS_VERSION = "1.0.0-5_e3b8d5297c20edd8fc73ee3ac8729094159942ec"
 PR = "r4"
-
-PV = "1.0.0-5+git${SRCPV}"
-SRCREV = "e3b8d5297c20edd8fc73ee3ac8729094159942ec"
 
 inherit fontcache
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-31-webos-aliases.conf-Use-Prelude-for-LuneOS.patch \

--- a/meta-luneos/recipes-webos/webos-nettools/webos-nettools.bb
+++ b/meta-luneos/recipes-webos/webos-nettools/webos-nettools.bb
@@ -18,11 +18,9 @@ WEBOS_REPO_NAME = "com.webos.service.nettools"
 WEBOS_VERSION = "1.1.0-6_5ebd0866e9709d88db9c433746ccfcbc7561d48f"
 PR = "r1"
 
-PV = "1.1.0-6+git${SRCPV}"
-SRCREV = "5ebd0866e9709d88db9c433746ccfcbc7561d48f"
-
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 

--- a/meta-luneos/recipes-webos/webos-wayland-extensions/webos-wayland-extensions.bb
+++ b/meta-luneos/recipes-webos/webos-wayland-extensions/webos-wayland-extensions.bb
@@ -14,12 +14,10 @@ DEPENDS = "wayland wayland-native"
 WEBOS_VERSION = "1.0.0-46_9ccf2cf894f9f5de46f110bba40aa0decb37acea"
 PR = "r6"
 
-PV = "1.1.0-46+git${SRCPV}"
-SRCREV = "9ccf2cf894f9f5de46f110bba40aa0decb37acea"
-
 inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Add-client-size-event.patch \

--- a/meta-luneui/recipes-webos/cmake-modules-webos-native/cmake-modules-webos-native.bb
+++ b/meta-luneui/recipes-webos/cmake-modules-webos-native/cmake-modules-webos-native.bb
@@ -9,10 +9,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=89aea4e17d99a7cacdbeed46a0096b10"
 WEBOS_VERSION = "1.6.3-6_b22ef30599f9af4c5b146538148552b495320ba3"
 PR = "r2"
 
-PV = "1.6.3-6+git${SRCPV}"
-SRCREV = "b22ef30599f9af4c5b146538148552b495320ba3"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit native
 

--- a/meta-luneui/recipes-webos/cpushareholder-stub/cpushareholder-stub.bb
+++ b/meta-luneui/recipes-webos/cpushareholder-stub/cpushareholder-stub.bb
@@ -14,10 +14,8 @@ RPROVIDES:${PN} = "cpushareholder"
 WEBOS_VERSION = "2.0.1-3_215a50182594720b99a53880393833a4f28c5c25"
 PR = "r5"
 
-PV = "2.0.1-3+git${SRCPV}"
-SRCREV = "215a50182594720b99a53880393833a4f28c5c25"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit allarch
 inherit webos_cmake
 inherit pkgconfig

--- a/meta-luneui/recipes-webos/libpbnjson/libpbnjson.bb
+++ b/meta-luneui/recipes-webos/libpbnjson/libpbnjson.bb
@@ -9,14 +9,12 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 DEPENDS = "yajl glib-2.0 gperf-native flex-native lemon-native gmp uriparser boost"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 
 WEBOS_VERSION = "2.15.0-15_038a2f0aa9f74a4db831e39a78754e250aeec651"
 PR = "r15"
-
-PV = "2.15.0-15+git${SRCPV}"
-SRCREV = "038a2f0aa9f74a4db831e39a78754e250aeec651"
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG:append:class-native = " tools"

--- a/meta-luneui/recipes-webos/librolegen/librolegen.bb
+++ b/meta-luneui/recipes-webos/librolegen/librolegen.bb
@@ -15,10 +15,8 @@ DEPENDS = "glib-2.0"
 WEBOS_VERSION = "2.1.0-5_0e70f221299476786627f169a0915556f315b72b"
 PR = "r7"
 
-PV = "2.1.0-5+git${SRCPV}"
-SRCREV = "0e70f221299476786627f169a0915556f315b72b"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneui/recipes-webos/luna-service2-security-conf/luna-service2-security-conf.bb
+++ b/meta-luneui/recipes-webos/luna-service2-security-conf/luna-service2-security-conf.bb
@@ -13,10 +13,8 @@ LIC_FILES_CHKSUM = " \
 WEBOS_VERSION = "1.0.2-24_408d29b850749c79ecd6356ed8917df53116b4b3"
 PR = "r6"
 
-PV = "1.0.2-24+git${SRCPV}"
-SRCREV = "408d29b850749c79ecd6356ed8917df53116b4b3"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 

--- a/meta-luneui/recipes-webos/luna-service2/luna-service2.bb
+++ b/meta-luneui/recipes-webos/luna-service2/luna-service2.bb
@@ -21,13 +21,11 @@ RDEPENDS:${PN} = "luna-service2-security-conf ${VIRTUAL-RUNTIME_cpushareholder} 
 WEBOS_VERSION = "3.21.2-34_e59ad3680ba012ca008d51500275c0ada6c2116a"
 PR = "r32"
 
-PV = "3.21.2-34+git${SRCPV}"
-SRCREV = "e59ad3680ba012ca008d51500275c0ada6c2116a"
-
 EXTRA_OECMAKE += "${@ '-DWEBOS_DISTRO_PRERELEASE:STRING="devel"' \
                   if d.getVar('WEBOS_DISTRO_PRERELEASE') != '' else ''}"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_system_bus
 inherit webos_core_os_dep

--- a/meta-luneui/recipes-webos/nyx-lib/nyx-lib.bb
+++ b/meta-luneui/recipes-webos/nyx-lib/nyx-lib.bb
@@ -26,10 +26,8 @@ DEPENDS = "glib-2.0 pmloglib"
 WEBOS_VERSION = "7.3.0-13_0ee217947853f7fbd0e0a625d99c229ecd33ab91"
 PR = "r9"
 
-PV = "7.3.0-13+git${SRCPV}"
-SRCREV = "0ee217947853f7fbd0e0a625d99c229ecd33ab91"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 inherit systemd

--- a/meta-luneui/recipes-webos/nyx-utils/nyx-utils.bb
+++ b/meta-luneui/recipes-webos/nyx-utils/nyx-utils.bb
@@ -13,15 +13,12 @@ LIC_FILES_CHKSUM = " \
 DEPENDS = "nyx-lib glib-2.0"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 
 WEBOS_VERSION = "1.5.0-9_1e45c59b3671f66b8a372d57a32bcc2a400ff933"
 PR = "r5"
-
-PV = "1.5.0-9+git${SRCPV}"
-SRCREV = "1e45c59b3671f66b8a372d57a32bcc2a400ff933"
-
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"

--- a/meta-luneui/recipes-webos/pmloglib/pmloglib-private.bb
+++ b/meta-luneui/recipes-webos/pmloglib/pmloglib-private.bb
@@ -6,13 +6,11 @@ SECTION = "webos/libs"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-WEBOS_VERSION = "3.3.0-2_75eef528791b73b8bc4f84cf522c6a1c533edc32"
+WEBOS_VERSION = "3.3.0-7_70ff1081b4ff6d910b89b96c86c6e42a5fa29c6a"
 PR = "r1"
 
-PV = "3.3.0-7+git${SRCPV}"
-SRCREV = "70ff1081b4ff6d910b89b96c86c6e42a5fa29c6a"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 

--- a/meta-luneui/recipes-webos/pmloglib/pmloglib.bb
+++ b/meta-luneui/recipes-webos/pmloglib/pmloglib.bb
@@ -15,13 +15,11 @@ DEPENDS = "glib-2.0 libpbnjson"
 WEBOS_VERSION = "3.3.0-7_70ff1081b4ff6d910b89b96c86c6e42a5fa29c6a"
 PR = "r10"
 
-PV = "3.3.0-7+git${SRCPV}"
-SRCREV = "70ff1081b4ff6d910b89b96c86c6e42a5fa29c6a"
-
 LEAD_SONAME = "libPmLogLib.so"
 EXTRA_OECMAKE += "-DWEBOS_DISTRO_PRERELEASE:STRING='${WEBOS_DISTRO_PRERELEASE}'"
 
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit webos_pmlog_config
 inherit pkgconfig

--- a/meta-luneui/recipes-webos/serviceinstaller/serviceinstaller.bb
+++ b/meta-luneui/recipes-webos/serviceinstaller/serviceinstaller.bb
@@ -14,10 +14,8 @@ DEPENDS = "librolegen glib-2.0 libpbnjson luna-service2"
 WEBOS_VERSION = "2.0.0-4_13eaf63ab5ec5c4dd62b02f176c0b60894251b1c"
 PR = "r6"
 
-PV = "2.0.0-4+git${SRCPV}"
-SRCREV = "13eaf63ab5ec5c4dd62b02f176c0b60894251b1c"
-
 inherit webos_public_repo
+inherit webos_enhanced_submissions
 inherit webos_cmake
 inherit pkgconfig
 


### PR DESCRIPTION
* at this point it's easier to use WEBOS_VERSION and webos_enhanced_submissions than PV and SRCREV defined separately

* we're using many OSE components as-is or very similar and manually splitting WEBOS_VERSION to PV and SRCREV is more tedious and error-prone than accepting webos_enhanced_submissions.bbclass (e.g. see pmloglib-private.bb).