### PR TITLE
waydroid: Install systemd service files by recipe

### DIFF
--- a/meta-luneos/recipes-support/waydroid/waydroid.bb
+++ b/meta-luneos/recipes-support/waydroid/waydroid.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SECTION = "webos/support"
 
-SRCREV = "7bd073c2b583cc1a9a3f258759399d377a1bdd8c"
+SRCREV = "41f309f4c185a2c716723c081274eb56eb9263ff"
 SPV = "1.4.2"
 PV = "${SPV}+git${SRCPV}"
 
@@ -42,6 +42,9 @@ COMPATIBLE_MACHINE:tissot = "(.*)"
 inherit pkgconfig
 inherit webos_app
 inherit webos_filesystem_paths
+inherit webos_systemd
+
+WEBOS_SYSTEMD_SERVICE = "waydroid-init.service waydroid-container.service"
 
 CLEANBROKEN = "1"
 
@@ -54,23 +57,22 @@ do_install() {
 # Provided by libgbinder already for Halium devices, but necessary to add for non-Halium devices.
 
 do_install:append:pinephone() {
-    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf" 
+    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf"
 }
 
 do_install:append:pinephonepro() {
-    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf" 
+    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf"
 }
 
 do_install:append:pinetab2() {
-    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf" 
+    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf"
 }
 
 do_install:append:qemux86-64() {
-    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf" 
+    install -Dm644 -t "${D}${sysconfdir}" "${WORKDIR}/gbinder.conf"
 }
 
 FILES:${PN} += " \
-    ${systemd_system_unitdir} \
     ${sysconfdir} \
     ${libdir} \
     ${datadir}/dbus-1 \

--- a/meta-luneos/recipes-support/waydroid/waydroid/waydroid-container.service
+++ b/meta-luneos/recipes-support/waydroid/waydroid/waydroid-container.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Waydroid Container
+After=waydroid-init.service
+Requires=surface-manager.service
+
+[Service]
+BusName=id.waydro.Container
+EnvironmentFile=/etc/id.waydro.Container/waydroid.env
+ExecStartPre=/bin/mkdir -p /tmp/luna-session
+ExecStartPre=/bin/ln -s /tmp/luna-session /run/luna-session
+ExecStart=/usr/bin/waydroid -w container start
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-luneos/recipes-support/waydroid/waydroid/waydroid-init.service
+++ b/meta-luneos/recipes-support/waydroid/waydroid/waydroid-init.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Waydroid init
+After=surface-manager.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/id.waydro.Container/waydroid.env
+ExecStartPre=/bin/mkdir -p /tmp/luna-session
+ExecStartPre=/bin/ln -s /tmp/luna-session /run/luna-session
+ExecStart=/usr/bin/waydroid init
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Let bitbake take care of the systemd service files, instead of Makefile. This way we can more easily enable it to auto-start.