### PR TITLE
nyx-modules-hybris: Fix FILESEXTRAPATHS:prepend

### DIFF
--- a/meta-luneos/recipes-luneos/nyx-modules-hybris/nyx-modules-hybris.bb
+++ b/meta-luneos/recipes-luneos/nyx-modules-hybris/nyx-modules-hybris.bb
@@ -14,7 +14,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # Let us fetch the machine-specific CMake configuration used by nyx-modules, to
 # define it only once
-FILESEXTRAPATHS:prepend := "${THISDIR}/nyx-modules:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/../../recipes-webos-ose/nyx-modules/nyx-modules:"
 
 # Depends on libhybris which has this restriction
 COMPATIBLE_MACHINE = "^halium$"


### PR DESCRIPTION
After moving the nyx-modules-hybris recipe, we need to update the FILESEXTRAPATHS:prepend to point to the correct location of nyx-modules.