### PR TITLE
waydroid-android.cfg: Silence do_kernel_configcheck

### DIFF
--- a/meta-luneos/recipes-kernel/linux/linux-yocto/waydroid-anbox.cfg
+++ b/meta-luneos/recipes-kernel/linux/linux-yocto/waydroid-anbox.cfg
@@ -32,11 +32,6 @@ CONFIG_SQUASHFS_XATTR=y
 
 # Missing LXC/Docker config as per lxc-checkconfig and https://gitlab.com/postmarketOS/pmbootstrap/-/blob/master/pmb/config/__init__.py?ref_type=heads#L464:
 
-# Below is no longer needed from Kernel 5.1 onwards as per https://github.com/lxc/lxc/issues/3917 since this is now CONFIG_NF_NAT as per kernel commit: https://github.com/torvalds/linux/commit/3bf195ae6037e310d693ff3313401cfaf1261b71
-
-# CONFIG_NF_NAT_IPV4 is not set
-# CONFIG_NF_NAT_IPV6 is not set
-
 CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
 CONFIG_NETFILTER_XT_MATCH_IPVS=y
 CONFIG_BLK_DEV_THROTTLING=y
@@ -71,11 +66,8 @@ CONFIG_IPV6_SUBTREES=y
 CONFIG_IPV6_SEG6_LWTUNNEL=y
 CONFIG_IPV6_SEG6_HMAC=y
 CONFIG_IPV6_RPL_LWTUNNEL=y
-CONFIG_NETFILTER_XT_TARGET_CHECKSUM=y
 CONFIG_NETFILTER_XT_MATCH_COMMENT=y
-CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
 CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
-CONFIG_NETFILTER_XT_MATCH_IPVS=y
 CONFIG_NETFILTER_XT_MARK=y
 
 # As per https://gitlab.com/postmarketOS/pmaports/-/merge_requests/3901/diffs?commit_id=19b11408c902a19b97096945a1a75533edc01fd2
@@ -92,5 +84,3 @@ CONFIG_TASKS_RCU_GENERIC=y
 CONFIG_TASKS_RCU=y
 CONFIG_TASKS_TRACE_RCU=y
 # CONFIG_TASKS_TRACE_RCU_READ_MB is not set
-# CONFIG_XDP_SOCKETS is not set
-# CONFIG_BPF_STREAM_PARSER is not set


### PR DESCRIPTION
Previous changes lead to some warnings in do_kernel_configcheck due to duplication and comments. Fixes:

[INFO]: Fragments with duplicated configuration options:
    - fragment configs/v5.15/standard/./waydroid-anbox.cfg has a duplicated option: CONFIG_NETFILTER_XT_TARGET_CHECKSUM
    - fragment configs/v5.15/standard/./waydroid-anbox.cfg has a duplicated option: CONFIG_NETFILTER_XT_MATCH_ADDRTYPE
    - fragment configs/v5.15/standard/./waydroid-anbox.cfg has a duplicated option: CONFIG_NETFILTER_XT_MATCH_IPVS
    - fragment configs/v5.15/standard/./waydroid-anbox.cfg has a duplicated option: CONFIG_XDP_SOCKETS
    - fragment configs/v5.15/standard/./waydroid-anbox.cfg has a duplicated option: CONFIG_BPF_STREAM_PARSER

[INFO]: the following symbols were not found in the active configuration:
     - CONFIG_NF_NAT_IPV4 - CONFIG_NF_NAT_IPV6