### PR TITLE
sensorfw, sam: Add TimeoutStopSec to systemd service files

### DIFF
--- a/meta-luneos/recipes-support/sensorfw/sensorfw.bb
+++ b/meta-luneos/recipes-support/sensorfw/sensorfw.bb
@@ -12,6 +12,7 @@ DEPENDS = "qtbase luna-sysmgr-common luna-service2 json-c glib-2.0 luna-sysmgr-i
 
 SRC_URI = " \
     git://github.com/sailfishos/sensorfw.git;protocol=https;branch=master \
+    file://0001-sensorfwd-Add-TimeoutStopSec-to-improve-shutdown.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-support/sensorfw/sensorfw/0001-sensorfwd-Add-TimeoutStopSec-to-improve-shutdown.patch
+++ b/meta-luneos/recipes-support/sensorfw/sensorfw/0001-sensorfwd-Add-TimeoutStopSec-to-improve-shutdown.patch
@@ -1,0 +1,26 @@
+From 7ae990a3481c80f953ef6d081355030b0374bf34 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Fri, 9 Feb 2024 15:04:03 +0100
+Subject: [PATCH] sensorfwd: Add TimeoutStopSec to improve shutdown
+
+Both SAM and sensorfwd were causing shutdown to take up to 90 seconds (default timeout for systemd to kill services if they don't shut down). Force it to 5s to make it behave better and improve shutdown times.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Pending
+
+ LuneOS/systemd/sensorfwd.service | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/LuneOS/systemd/sensorfwd.service b/LuneOS/systemd/sensorfwd.service
+index 08caefe..fbf5fdc 100644
+--- a/LuneOS/systemd/sensorfwd.service
++++ b/LuneOS/systemd/sensorfwd.service
+@@ -12,6 +12,7 @@ ExecStart=/usr/sbin/sensorfwd -c=/etc/sensorfw/primaryuse.conf -d --log-level=wa
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=always
+ RestartSec=1
++TimeoutStopSec=5
+ 
+ [Install]
+ WantedBy=multi-user.target

--- a/meta-luneos/recipes-webos-ose/sam/sam/sam.service
+++ b/meta-luneos/recipes-webos-ose/sam/sam/sam.service
@@ -29,6 +29,7 @@ EnvironmentFile=-/var/systemd/system/env/sam.env
 ExecStartPre=/lib/systemd/system/scripts/sam.sh
 ExecStart=/usr/sbin/sam
 Restart=on-failure
+TimeoutStopSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To force the service to shut down after 5 seconds instead of waiting the default 90 seconds. This reduces the shutdown/reboot time to 10s from 90s.