### PR TITLE
wam: fix deviceInfo content

### DIFF
--- a/meta-luneos/recipes-webos-ose/wam/wam/0005-DeviceInfoImpl-add-tvDeviceInfo-data.patch
+++ b/meta-luneos/recipes-webos-ose/wam/wam/0005-DeviceInfoImpl-add-tvDeviceInfo-data.patch
@@ -1,23 +1,35 @@
-From 9b4b7a54144e84e92a34145096560eb2ed3e4c8e Mon Sep 17 00:00:00 2001
+From 69638d3fbf62fe95bd3ea77e2b9ce599dc9a4a06 Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
-Date: Wed, 9 Mar 2022 18:50:41 +0000
+Date: Fri, 23 Feb 2024 14:13:02 +0000
 Subject: [PATCH] DeviceInfoImpl: add "tvDeviceInfo" data
 
 This corresponds to PalmSystem.deviceInfo object on client side
 
-Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
----
 Upstream-Status: Inappropriate [LuneOS specific]
 
- src/webos/device_info_impl.cc | 26 +++++++++++++++++++++++---
- 1 file changed, 23 insertions(+), 3 deletions(-)
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+ src/webos/device_info_impl.cc | 52 +++++++++++++++++++++++++++++++++--
+ 1 file changed, 49 insertions(+), 3 deletions(-)
 
 diff --git a/src/webos/device_info_impl.cc b/src/webos/device_info_impl.cc
-index fa3c0dc..6c64ab8 100644
+index fa3c0dc..cd8521c 100644
 --- a/src/webos/device_info_impl.cc
 +++ b/src/webos/device_info_impl.cc
-@@ -30,9 +30,7 @@ DeviceInfoImpl::DeviceInfoImpl() = default;
+@@ -17,6 +17,7 @@
+ #include "device_info_impl.h"
+ 
+ #include <string>
++#include <fstream>
+ 
+ #include <glib.h>
+ #include <json/value.h>
+@@ -28,11 +29,11 @@
+ DeviceInfoImpl::DeviceInfoImpl() = default;
+ 
  void DeviceInfoImpl::Initialize() {
++  GatherInfo();
++  
    const std::string& json_string =
        util::ReadFile("/var/luna/preferences/localeInfo");
 -  if (json_string.empty()) {
@@ -27,7 +39,7 @@ index fa3c0dc..6c64ab8 100644
  
    Json::Value locale_json = util::StringToJson(json_string);
    if (!locale_json.isObject() || locale_json.empty() ||
-@@ -56,6 +54,28 @@ void DeviceInfoImpl::Initialize() {
+@@ -56,6 +57,28 @@ void DeviceInfoImpl::Initialize() {
    SetSystemLanguage(language.c_str());
    SetDeviceInfo("LocalCountry", localcountry.c_str());
    SetDeviceInfo("SmartServiceCountry", smartservicecountry.c_str());
@@ -56,3 +68,34 @@ index fa3c0dc..6c64ab8 100644
  }
  
  bool DeviceInfoImpl::GetInfoFromLunaPrefs(const char* key,
+@@ -105,6 +128,29 @@ void DeviceInfoImpl::InitPlatformInfo() {
+      "platformVersionMinor": 00,
+   */
+ 
++  {
++    // setup fallback recognizable value, in case buildinfo can't be parsed
++    model_name_ = "LuneOS-dev";
++    platform_version_ = "0.9.9";
++    
++    std::ifstream buildinfoFile("/etc/buildinfo");
++    std::string line;
++    while (std::getline(buildinfoFile, line))
++    {
++      size_t startpos = line.find_first_of(" =");
++      if( std::string::npos == startpos ) continue; // skip useless lines
++      std::string key = line.substr(0, startpos);
++      std::string value = line.substr(line.find_last_of(" =")+1);
++
++      if (key == "DISTRO_VERSION") {
++        SetDeviceInfo("FirmwareVersion", value + ".0" /*add dot version*/);
++      }
++      else if (key == "MACHINE") {
++        SetDeviceInfo("ModelName", value);
++      }
++    }
++  }
++
+   std::string value;
+   if (GetDeviceInfo("ModelName", value)) {
+     model_name_ = value;
+


### PR DESCRIPTION
Parse /etc/buildinfo and use MACHINE and DISTRO_VERSION to populate PalmSystem.deviceInfo