### PR TITLE
wam: Update patch

### DIFF
--- a/meta-luneos/recipes-webos-ose/wam/wam/0001-security_policy.conf-Add-usr-palm-applications.patch
+++ b/meta-luneos/recipes-webos-ose/wam/wam/0001-security_policy.conf-Add-usr-palm-applications.patch
@@ -1,28 +1,36 @@
 From 093d5ca53325186d70486b0361c1626b2d2fb10c Mon Sep 17 00:00:00 2001
 From: Herman van Hazendonk <github.com@herrie.org>
 Date: Tue, 8 Feb 2022 23:20:43 +0100
-Subject: [PATCH] security_policy.conf: Add /usr/palm/applications
+Subject: [PATCH] security_policy.conf: Add paths for LuneOS
 
 So that apps actually render something and don't show network connection error.
+Add the following paths:
+
+For system apps:
+/usr/palm/applications
+
+For user installed apps:
+/media/cryptofs/apps/usr/palm/applications/
 
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 ---
 Upstream-Status: Inappropriate [LuneOS specific]
 
- files/launch/security_policy.conf | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ files/launch/security_policy.conf | 4 ++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/files/launch/security_policy.conf b/files/launch/security_policy.conf
 index cc29f96..6251de3 100644
 --- a/files/launch/security_policy.conf
 +++ b/files/launch/security_policy.conf
-@@ -8,7 +8,8 @@
+@@ -8,7 +8,9 @@
  7/path=/var/palm/license/
  8/path=/usr/palm/license/
  9/path=/usr/palm/plugins/license/
 -size=9
 +10/path=/usr/palm/applications/
-+size=10
++11/path=/media/cryptofs/apps/usr/palm/applications/
++size=11
  
  [Trusted]
  1/path=/media/


### PR DESCRIPTION
Apps installed via Preware will be in /media/cryptos/apps/usr/palm/applications.

Whitelist this path, so icons etc will render properly in Preware while listing them.

It will probably also fix unintended issues during the runtime of the apps themselves too.