### PR TITLE
pulseaudio-pulsecore-private-headers: upgrade to 17.0

### DIFF
--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-pulsecore-private-headers_17.0.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-pulsecore-private-headers_17.0.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=0e5cd938de1a7a53ea5adac38cc10c39 \
 SRC_URI = "http://freedesktop.org/software/pulseaudio/releases/pulseaudio-${PV}.tar.xz \
     file://pulsecore.pc \
 "
-SRC_URI[sha256sum] = "8eef32ce91d47979f95fd9a935e738cd7eb7463430dabc72863251751e504ae4"
+SRC_URI[sha256sum] = "053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5"
 
 S = "${WORKDIR}/pulseaudio-${PV}"
 


### PR DESCRIPTION
* follow pulseaudio recipe upgrade: https://git.openembedded.org/openembedded-core/commit/meta/recipes-multimedia/pulseaudio?id=123c75bd87330a81ba5b929c35ae34710ddcc449
* fixes pulseaudio-modules-droid failure:

|/home/amelia/devel/webos-ports-env/webos-ports/tmp-glibc/work/sargo-webos-linux/pulseaudio-modules-droid/15.0.88+git/recipe-sysroot-native/usr/bin/aarch64-webos-linux/../../libexec/aarch64-webos-linux/gcc/aarch64-webos-linux/13.2.0/ld: cannot find -lpulsecommon-16.1: No such file or directory
|collect2: error: ld returned 1 exit status