### PR TITLE
webruntime.inc: Disable libpci

### DIFF
--- a/meta-luneos/recipes-webos-ose/chromium/files/0001-avoid-link-latomic-failure-on-CentOS-8-host.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0001-avoid-link-latomic-failure-on-CentOS-8-host.patch
@@ -1,0 +1,49 @@
+From 873b172e35f9074688a48d65ad6ab16567a1249b Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Fri, 22 Jan 2021 00:02:25 +0800
+Subject: [PATCH] avoid link latomic failure on CentOS 8 host
+
+When host (such as CentOS 8) did not install libatomic, there was a
+link failure on native. In fact, only target requires to link atomic,
+the native does not. So link atomic for target only
+
+Upstream-Status: Inappropriate [oe specific]
+
+Change-Id: I702c2b2018c114fbc1b608fca6dfca4a1ddd5b22
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+Signed-off-by: Randy MacLeod <Randy.MacLeod@windriver.com>
+---
+Upstream-Status: Submitted [http://gpro.lge.com/c/webosose/chromium108/+/393125 avoid link latomic failure on CentOS 8 host]
+
+ src/base/BUILD.gn               | 2 ++
+ src/build/config/linux/BUILD.gn | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/src/base/BUILD.gn b/src/base/BUILD.gn
+index 1d19d79d02..db7d0c1916 100644
+--- a/src/base/BUILD.gn
++++ b/src/base/BUILD.gn
+@@ -1561,7 +1561,9 @@ mixed_component("base") {
+   # Needed for <atomic> if using newer C++ library than sysroot, except if
+   # building inside the cros_sdk environment - use host_toolchain as a
+   # more robust check for this.
++  # Only target requires <atomic>
+   if (!use_sysroot && (is_android || is_chromeos || (is_linux && !is_castos)) &&
++      (current_toolchain != host_toolchain) &&
+       host_toolchain != "//build/toolchain/cros:host") {
+     libs += [ "atomic" ]
+   }
+diff --git a/src/build/config/linux/BUILD.gn b/src/build/config/linux/BUILD.gn
+index 8d1a5a9428..38abba54c2 100644
+--- a/src/build/config/linux/BUILD.gn
++++ b/src/build/config/linux/BUILD.gn
+@@ -47,7 +47,9 @@ config("runtime_library") {
+     defines = [ "OS_CHROMEOS" ]
+   }
+ 
++  # Only target requires <atomic>
+   if ((!is_chromeos || default_toolchain != "//build/toolchain/cros:target") &&
++      (current_toolchain != host_toolchain) &&
+       (!use_custom_libcxx || current_cpu == "mipsel")) {
+     libs = [ "atomic" ]
+   }

--- a/meta-luneos/recipes-webos-ose/chromium/files/0002-Fix-build-with-gcc-13.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0002-Fix-build-with-gcc-13.patch
@@ -1,0 +1,88 @@
+From b475533e87a6b7985d1157038325c894fecc5aab Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin2.jansa@lgepartner.com>
+Date: Thu, 22 Feb 2024 23:51:21 +0100
+Subject: [PATCH] Fix build with gcc-13
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+:Release Notes:
+
+:Detailed Notes:
+Fixes:
+http://gecko.lge.com:8000/Errors/Details/783269
+
+FAILED: host/obj/base/allocator/partition_allocator/partition_alloc/partition_alloc.o
+g++  -MMD -MF host/obj/base/allocator/partition_allocator/partition_alloc/partition_alloc.o.d -DPA_PCSCAN_STACK_SUPPORTED -DENABLE_BROWSER_CONTROL_WEBAPI=1 -DENABLE_SAMPLE_WEBAPI=1 -DENABLE_MEMORYMANAGER_WEBAPI=1 -DENABLE_WEBOS_SERVICE_BRIDGE_WEBAPI=1 -DENABLE_WEBOS_SYSTEM_WEBAPI=1 -DNEVA_DCHECK_ALWAYS_ON=1 -DOZONE_PLATFORM_WAYLAND_EXTERNAL=1 -DNEVA_OZONE_PLATFORM_WAYLAND=1 -DOS_WEBOS=1 -DNEVA_VIDEO_HOLE=1 -DUSE_NEVA_APPRUNTIME=1 -DUSE_NEVA_BROWSER_SERVICE=1 -DUSE_WEBRISK_SERVICE=1 -DUSE_WEBRISK_DATABASE=1 -DENABLE_PINCH_TO_ZOOM=1 -DENABLE_WEBM_AUDIO_CODECS=1 -DENABLE_WEBM_VIDEO_CODECS=1 -DUSE_CBE=1 -DUSE_NEVA_SUSPEND_MEDIA_CAPTURE=1 -DUSE_FILESCHEME_CODECACHE=1 -DUSE_SINGLE_WINDOW_MODE=1 -DWEBOS_SUBMISSION_NUMBER=16 -DUSE_LOCAL_STORAGE_TRACKER=1 -DDCHECK_ALWAYS_ON=1 -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_OZONE=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DCR_SYSROOT_KEY=20220331T153654Z-0 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DIS_PARTITION_ALLOC_IMPL -I../../git/src -Ihost/gen -Wno-unused-variable -Wall -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -Wno-comments -Wno-packed-not-aligned -Wno-attributes -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -fno-ident -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -funwind-tables -fPIC -pipe -pthread -m64 -msse3 -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -fno-omit-frame-pointer -g0 -fvisibility=hidden -O3 -fdata-sections -ffunction-sections -Wno-narrowing -Wno-class-memaccess -std=gnu++2a -fno-exceptions -fno-rtti --sysroot=../../../../../../../../../../ -fvisibility-inlines-hidden -isystem/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/include -isystem/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/include -O2 -pipe -c ../../git/src/base/allocator/partition_allocator/partition_alloc.cc -o host/obj/base/allocator/partition_allocator/partition_alloc/partition_alloc.o
+In file included from ../../git/src/base/allocator/partition_allocator/partition_alloc.h:10,
+                 from ../../git/src/base/allocator/partition_allocator/partition_alloc.cc:5:
+../../git/src/base/allocator/partition_allocator/partition_alloc_forward.h:44:6: error: variable or field ‘CheckThatSlotOffsetIsZero’ declared void
+   44 | void CheckThatSlotOffsetIsZero(uintptr_t address);
+      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
+../../git/src/base/allocator/partition_allocator/partition_alloc_forward.h:44:32: error: ‘uintptr_t’ was not declared in this scope
+   44 | void CheckThatSlotOffsetIsZero(uintptr_t address);
+      |                                ^~~~~~~~~
+../../git/src/base/allocator/partition_allocator/partition_alloc_forward.h:15:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
+   14 | #include "base/allocator/partition_allocator/partition_alloc_buildflags.h"
+  +++ |+#include <cstdint>
+   15 |
+
+And apply:
+https://chromium.googlesource.com/chromium/src/+/c401aa411f572245f8da418811abadeea7e21a4b%5E%21/#F0
+to fix:
+FAILED: host/obj/base/base/file_util.o
+g++  -MMD -MF host/obj/base/base/file_util.o.d -DBASE_IMPLEMENTATION -DUSE_SYMBOLIZE -DENABLE_BROWSER_CONTROL_WEBAPI=1 -DENABLE_SAMPLE_WEBAPI=1 -DENABLE_MEMORYMANAGER_WEBAPI=1 -DENABLE_WEBOS_SERVICE_BRIDGE_WEBAPI=1 -DENABLE_WEBOS_SYSTEM_WEBAPI=1 -DNEVA_DCHECK_ALWAYS_ON=1 -DOZONE_PLATFORM_WAYLAND_EXTERNAL=1 -DNEVA_OZONE_PLATFORM_WAYLAND=1 -DOS_WEBOS=1 -DNEVA_VIDEO_HOLE=1 -DUSE_NEVA_APPRUNTIME=1 -DUSE_NEVA_BROWSER_SERVICE=1 -DUSE_WEBRISK_SERVICE=1 -DUSE_WEBRISK_DATABASE=1 -DENABLE_PINCH_TO_ZOOM=1 -DENABLE_WEBM_AUDIO_CODECS=1 -DENABLE_WEBM_VIDEO_CODECS=1 -DUSE_CBE=1 -DUSE_NEVA_SUSPEND_MEDIA_CAPTURE=1 -DUSE_FILESCHEME_CODECACHE=1 -DUSE_SINGLE_WINDOW_MODE=1 -DWEBOS_SUBMISSION_NUMBER=16 -DUSE_LOCAL_STORAGE_TRACKER=1 -DDCHECK_ALWAYS_ON=1 -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_OZONE=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DCR_SYSROOT_KEY=20220331T153654Z-0 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_40 -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 -DGLOG_EXPORT= -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -I../../git/src -Ihost/gen -I../../git/src/third_party/perfetto/include -Ihost/gen/third_party/perfetto/build_config -Ihost/gen/third_party/perfetto -I../../git/src/third_party/abseil-cpp -I../../git/src/third_party/boringssl/src/include -I../../git/src/third_party/protobuf/src -Ihost/gen/protoc_out -I../../git/src/third_party/icu/source/common -I../../git/src/third_party/icu/source/i18n -Wno-unused-variable -Wall -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -Wno-comments -Wno-packed-not-aligned -Wno-attributes -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -fno-ident -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -funwind-tables -fPIC -pipe -pthread -m64 -msse3 -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -fno-omit-frame-pointer -g0 -fvisibility=hidden -I/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include -I/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include/glib-2.0 -I/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/lib/glib-2.0/include -I/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/lib/pkgconfig/../../../usr/include -O2 -fdata-sections -ffunction-sections -Wno-narrowing -Wno-class-memaccess -std=gnu++2a -fno-exceptions -fno-rtti --sysroot=../../../../../../../../../../ -fvisibility-inlines-hidden -isystem/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/include -isystem/OE/build/luneos-scarthgap/tmp-glibc/work/corei7-64-webos-linux/webruntime-clang/108.0.5359.217-16/recipe-sysroot-native/usr/include -O2 -pipe -c ../../git/src/base/files/file_util.cc -o host/obj/base/base/file_util.o
+In file included from ../../git/src/base/threading/thread_local.h:56,
+                 from ../../git/src/base/debug/activity_tracker.h:33,
+                 from ../../git/src/base/threading/scoped_blocking_call_internal.h:10,
+                 from ../../git/src/base/threading/scoped_blocking_call.h:12,
+                 from ../../git/src/base/files/file_util.cc:33:
+../../git/src/base/threading/thread_local_internal.h:33:37: error: expected unqualified-id before âconstâ
+   33 |   CheckedThreadLocalOwnedPointer<T>(const CheckedThreadLocalOwnedPointer<T>&) =
+      |                                     ^~~~~
+../../git/src/base/threading/thread_local_intern3:37: error: expected â)â before âconstâ
+   33 |   CheckedThreadLocalOwnedPointer<T>(const CheckedThreadLocalOwnedPointer<T>&) =
+      |                                    ~^~~~~
+      |                                     )
+
+:Testing Performed:
+Only build tested.
+
+:QA Notes:
+No change to image.
+
+:Issues Addressed:
+[WRP-412] Create GPVB with Yocto 4.2 Mickledore
+
+Change-Id: Ia34c80bdd9d417c648f3751530411a60b3e46fe3
+---
+Upstream-Status: Submitted [http://gpro.lge.com/c/webosose/chromium108/+/393556 Fix build with gcc-13]
+ .../allocator/partition_allocator/partition_alloc_forward.h     | 1 +
+ src/base/threading/thread_local_internal.h                      | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/base/allocator/partition_allocator/partition_alloc_forward.h b/src/base/allocator/partition_allocator/partition_alloc_forward.h
+index fd62e11e3e..5d6e614a56 100644
+--- a/src/base/allocator/partition_allocator/partition_alloc_forward.h
++++ b/src/base/allocator/partition_allocator/partition_alloc_forward.h
+@@ -7,6 +7,7 @@
+ 
+ #include <algorithm>
+ #include <cstddef>
++#include <cstdint>
+ 
+ #include "base/allocator/partition_allocator/partition_alloc_base/compiler_specific.h"
+ #include "base/allocator/partition_allocator/partition_alloc_base/component_export.h"
+diff --git a/src/base/threading/thread_local_internal.h b/src/base/threading/thread_local_internal.h
+index ed99410ea8..5504813b37 100644
+--- a/src/base/threading/thread_local_internal.h
++++ b/src/base/threading/thread_local_internal.h
+@@ -30,7 +30,7 @@ class CheckedThreadLocalOwnedPointer {
+  public:
+   CheckedThreadLocalOwnedPointer() = default;
+ 
+-  CheckedThreadLocalOwnedPointer<T>(const CheckedThreadLocalOwnedPointer<T>&) =
++  CheckedThreadLocalOwnedPointer(const CheckedThreadLocalOwnedPointer<T>&) =
+       delete;
+   CheckedThreadLocalOwnedPointer<T>& operator=(
+       const CheckedThreadLocalOwnedPointer<T>&) = delete;

--- a/meta-luneos/recipes-webos-ose/chromium/files/0003-Fix-build-with-dcheck_always_on-true-in-GN_ARGS.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0003-Fix-build-with-dcheck_always_on-true-in-GN_ARGS.patch
@@ -1,0 +1,64 @@
+From 5d20dfb348172e7ade9ad156ba88488f1c36be1f Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin2.jansa@lgepartner.com>
+Date: Fri, 23 Feb 2024 00:27:57 +0100
+Subject: [PATCH] Fix build with dcheck_always_on=true in GN_ARGS
+
+:Release Notes:
+DCHECK_CALLED_ON_VALID_THREAD(owning_thread_);
+was added twice in:
+
+  commit f9bebd4b90d6ec90e01f65d5b23b6bea2294af9e
+  Author: Minsu Kim <minsu0.kim@lge.com>
+  Date:   Wed Aug 23 18:18:35 2023 +0900
+
+    [op][n_ups][build][base] Snapshot of webos-pro/chromium release changes (branch: ose/chromium108)
+
+but there is no owning_thread_ since:
+https://chromium.googlesource.com/chromium/src/+/6c82dca1d95c8536f1a4949cc28d0aa542e9667a
+
+:Detailed Notes:
+Fixes:
+http://gecko.lge.com:8000/Errors/Details/783278
+
+FAILED: obj/services/audio/audio/input_controller.o
+ccache  ../../git/src/third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/services/audio/audio/input_controller.o.d -DENABLE_BROWSER_CONTROL_WEBAPI=1 -DENABLE_SAMPLE_WEBAPI=1 -DENABLE_MEMORYMANAGER_WEBAPI=1 -DENABLE_WEBOS_SERVICE_BRIDGE_WEBAPI=1 -DENABLE_WEBOS_SYSTEM_WEBAPI=1 -DNEVA_DCHECK_ALWAYS_ON=1 -DOZONE_PLATFORM_WAYLAND_EXTERNAL=1 -DNEVA_OZONE_PLATFORM_WAYLAND=1 -DOS_WEBOS=1 -DNEVA_VIDEO_HOLE=1 -DUSE_NEVA_APPRUNTIME=1 -DUSE_NEVA_MEDIA=1 -DUSE_GAV=1 -DUSE_NEVA_MEDIA_PLAYER_CAMERA=1 -DUSE_NEVA_BROWSER_SERVICE=1 -DUSE_WEBRISK_SERVICE=1 -DUSE_WEBRISK_DATABASE=1 -DENABLE_PINCH_TO_ZOOM=1 -DUSE_NEVA_PUNCH_HOLE=1 -DUSE_NEVA_V4L2_CODEC=1 -DENABLE_WEBM_AUDIO_CODECS=1 -DUSE_GST_MEDIA=1 -DUSE_CBE=1 -DUSE_PMLOG=1 -DUSE_NEVA_SUSPEND_MEDIA_CAPTURE=1 -DUSE_FILESCHEME_CODECACHE=1 -DUSE_SINGLE_WINDOW_MODE=1 -DWEBOS_SUBMISSION_NUMBER=23 -DUSE_LOCAL_STORAGE_TRACKER=1 -DUSE_WEBOS_CODEC=1 -DUSE_LTTNG=1 -DDCHECK_ALWAYS_ON=1 -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_OZONE=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -DCR_CLANG_REVISION=\"llvmorg-16-init-6578-g0d30e92f-2\" -DCR_SYSROOT_KEY=20220331T153654Z-0 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DUSE_NEON -DUSE_PULSEAUDIO -DDLOPEN_PULSEAUDIO -DUSE_WEBOS_AUDIO=1 -DUSE_ALSA -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_40 -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40 -DWEBP_EXTERN=extern -DUSE_EGL -DVK_USE_PLATFORM_WAYLAND_KHR -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_WEBP -DSK_ENCODE_PNG -DSK_ENCODE_WEBP -DSK_ENABLE_SKSL -DSK_UNTIL_CRBUG_1187654_IS_FIXED -DSK_USER_CONFIG_HEADER=\"../../skia/config/SkUserConfig.h\" -DSK_WIN_FONTMGR_NO_SIMULATIONS -DSK_GL -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_HAS_WUFFS_LIBRARY -DSK_VULKAN=1 -DSK_SUPPORT_GPU=1 -DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\" -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_NO_STATIC_INITIALIZER -DGOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE=0 -DHAVE_PTHREAD -DLEVELDB_PLATFORM_CHROMIUM=1 -DWEBRTC_ENABLE_AVX2 -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=0 -DWEBRTC_CHROMIUM_BUILD -DWEBRTC_POSIX -DWEBRTC_LINUX -DABSL_ALLOCATOR_NOTHROW=1 -DWEBRTC_USE_BUILTIN_ISAC_FIX=0 -DWEBRTC_USE_BUILTIN_ISAC_FLOAT=1 -DLOGGING_INSIDE_WEBRTC -I../../git/src -Igen -I../../git/src/third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -I../../git/src/third_party/libwebp/src/src -I../../git/src/third_party/khronos -I../../git/src/gpu -I../../git/src/third_party/vulkan-deps/vulkan-headers/src/include -Igen/third_party/dawn/include -I../../git/src/third_party/dawn/include -I../../git/src/third_party/libyuv/include -I../../git/src/third_party/jsoncpp/source/include -I../../git/src/third_party/abseil-cpp -I../../git/src/third_party/boringssl/src/include -I../../git/src/third_party/protobuf/src -Igen/protoc_out -I../../git/src/third_party/libwebm/source -I../../git/src/third_party/skia -I../../git/src/third_party/wuffs/src/release/c -I../../git/src/third_party/vulkan/include -I../../git/src/third_party/mesa_headers -I../../git/src/third_party/icu/source/common -I../../git/src/third_party/icu/source/i18n -I../../git/src/third_party/leveldatabase -I../../git/src/third_party/leveldatabase/src -I../../git/src/third_party/leveldatabase/src/include -I../../git/src/third_party/libaom/source/libaom -I../../git/src/third_party/ced/src -I../../git/src/net/third_party/quiche/overrides -I../../git/src/net/third_party/quiche/src/quiche/common/platform/default -I../../git/src/net/third_party/quiche/src -Igen/net/third_party/quiche/src -I../../git/src/third_party/webrtc_overrides -I../../git/src/third_party/webrtc -Igen/third_party/webrtc -Wno-unused-variable -Wall -Wextra -Wimplicit-fallthrough -Wextra-semi -Wunreachable-code-aggressive -Wthread-safety -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wloop-analysis -Wno-unneeded-internal-declaration -Wenum-compare-conditional -Wno-ignored-pragma-optimize -Wno-deprecated-builtins -Wno-bitfield-constant-conversion -Wshadow -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -funwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -fcrash-diagnostics-dir=../../git/src/tools/clang/crashreports -mllvm -instcombine-lower-dbg-declare=0 -ffp-contract=off -mbranch-protection=standard --target=aarch64-linux-gnu -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -ffile-compilation-dir=. -no-canonical-prefixes -ftrivial-auto-var-init=pattern -O2 -fdata-sections -ffunction-sections -fno-unique-section-names -fno-omit-frame-pointer -g0 -fvisibility=hidden -Xclang -add-plugin -Xclang find-bad-constructs -Xclang -plugin-arg-find-bad-constructs -Xclang raw-ref-template-as-trivial-member -Xclang -plugin-arg-find-bad-constructs -Xclang check-ipc -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wexit-time-destructors -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/glib-2.0 -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/lib/glib-2.0/include -DPROTOBUF_ALLOW_DEPRECATED=1 -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/nss3 -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/nspr -std=c++20 -Wno-trigraphs -fno-exceptions -fno-rtti --sysroot=../../recipe-sysroot -fvisibility-inlines-hidden -Wno-deprecated-declarations      -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/c++/v1       -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/cbe     -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/cbe/gmp     -ITOPDIR/BUILD/work/raspberrypi4_64-webos-linux/webruntime-clang/108.0.5359.217-23/recipe-sysroot/usr/include/media-resource-calculator-clang   -mcpu=cortex-a72+crc -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type  -c ../../git/src/services/audio/input_controller.cc -o obj/services/audio/audio/input_controller.o
+../../git/src/services/audio/input_controller.cc:374:33: error: unknown type name 'owning_thread_'
+  DCHECK_CALLED_ON_VALID_THREAD(owning_thread_);
+                                ^
+
+:Testing Performed:
+Only build tested.
+
+:QA Notes:
+No change to image.
+
+:Issues Addressed:
+[WRP-412] Create GPVB with Yocto 4.2 Mickledore
+
+Change-Id: I902cb04d90d021433be9dc691df66a39cc76f4fe
+---
+Upstream-Status: Submitted [http://gpro.lge.com/c/webosose/chromium108/+/393560 Fix build with dcheck_always_on=true in GN_ARGS]
+
+ src/services/audio/input_controller.cc | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/services/audio/input_controller.cc b/src/services/audio/input_controller.cc
+index 5b2558ece0..06c951bffe 100644
+--- a/src/services/audio/input_controller.cc
++++ b/src/services/audio/input_controller.cc
+@@ -371,7 +371,6 @@ void InputController::Record() {
+ 
+ #if defined(USE_NEVA_SUSPEND_MEDIA_CAPTURE)
+ void InputController::Pause() {
+-  DCHECK_CALLED_ON_VALID_THREAD(owning_thread_);
+   SCOPED_UMA_HISTOGRAM_TIMER("Media.AudioInputController.RecordTime");
+   event_handler_->OnLog("AIC::DoPause");
+ 
+@@ -382,7 +381,6 @@ void InputController::Pause() {
+ }
+ 
+ void InputController::Resume() {
+-  DCHECK_CALLED_ON_VALID_THREAD(owning_thread_);
+   SCOPED_UMA_HISTOGRAM_TIMER("Media.AudioInputController.RecordTime");
+ 
+   event_handler_->OnLog("AIC::DoResume");

--- a/meta-luneos/recipes-webos-ose/chromium/files/0004-neva-Fix-build-with-dcheck_always_on-true-in-GN_ARGS.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0004-neva-Fix-build-with-dcheck_always_on-true-in-GN_ARGS.patch
@@ -1,0 +1,50 @@
+From 19deb667e176c9e985795efa059b4d68d6f56b21 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin2.jansa@lgepartner.com>
+Date: Fri, 23 Feb 2024 00:27:57 +0100
+Subject: [PATCH] neva: Fix build with dcheck_always_on=true in GN_ARGS
+
+:Release Notes:
+DCHECK_EQ(origin_.GetOrigin(), origin_);
+was added in:
+
+  commit f9bebd4b90d6ec90e01f65d5b23b6bea2294af9e
+  Author: Minsu Kim <minsu0.kim@lge.com>
+  Date:   Wed Aug 23 18:18:35 2023 +0900
+
+    [op][n_ups][build][base] Snapshot of webos-pro/chromium release changes (branch: ose/chromium108)
+
+but there is no GetOrigin on GURL since:
+https://chromium.googlesource.com/chromium/src/+/800532c0bf6712ea4ab5928da9e776d6607a10b1
+
+:Detailed Notes:
+Fixes:
+
+:Testing Performed:
+Only build tested.
+
+:QA Notes:
+No change to image.
+
+:Issues Addressed:
+[WRP-412] Create GPVB with Yocto 4.2 Mickledore
+
+Change-Id: I902cb04d90d021433be9dc691df66a39cc76f4fe
+---
+Upstream-Status: Submitted [http://gpro.lge.com/c/webosose/chromium108/+/393561 neva: Fix build with dcheck_always_on=true in GN_ARGS]
+
+ .../browser/push_messaging/push_messaging_app_identifier.cc     | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/neva/app_runtime/browser/push_messaging/push_messaging_app_identifier.cc b/src/neva/app_runtime/browser/push_messaging/push_messaging_app_identifier.cc
+index a25ac56a89..c8d6c33451 100644
+--- a/src/neva/app_runtime/browser/push_messaging/push_messaging_app_identifier.cc
++++ b/src/neva/app_runtime/browser/push_messaging/push_messaging_app_identifier.cc
+@@ -300,7 +300,7 @@ void PushMessagingAppIdentifier::DCheckValid() const {
+   DCHECK_GE(service_worker_registration_id_, 0);
+ 
+   DCHECK(origin_.is_valid());
+-  DCHECK_EQ(origin_.GetOrigin(), origin_);
++  DCHECK_EQ(origin_.DeprecatedGetOriginAsURL(), origin_);
+ 
+   // "wp:"
+   DCHECK_EQ(kPushMessagingAppIdentifierPrefix,

--- a/meta-luneos/recipes-webos-ose/chromium/webruntime-repo_108.inc
+++ b/meta-luneos/recipes-webos-ose/chromium/webruntime-repo_108.inc
@@ -9,6 +9,7 @@ CHROMIUM_LICENSE_CHKSUM = "file://src/LICENSE;md5=c408a301e3407c3803499ce9290515
 # oss-pkg-info.yaml
 CHROMIUM_OSS_PKG_INFO_CHKSUM = "file://oss-pkg-info.yaml;md5=f6cf1c62d76fef64d3ca1b3556fc1d9a"
 
+# merged in upstream webruntime
 SRC_URI += " \
     file://0001-Replace-imp.load_source-with-importlib-equivalent.patch \
     file://0002-grit-apply-pyupgrade.patch \
@@ -16,6 +17,14 @@ SRC_URI += " \
     file://0004-Remove-unused-python-import.patch \
     file://0005-More-removal-of-six.py.patch \
     file://0006-Update-vendored-copy-of-six-to-1.16.0.patch \
+"
+
+# pending in upstream webruntime
+SRC_URI += " \
+    file://0001-avoid-link-latomic-failure-on-CentOS-8-host.patch \
+    file://0002-Fix-build-with-gcc-13.patch \
+    file://0003-Fix-build-with-dcheck_always_on-true-in-GN_ARGS.patch \
+    file://0004-neva-Fix-build-with-dcheck_always_on-true-in-GN_ARGS.patch \
 "
 
 # LuneOS specific patches

--- a/meta-luneos/recipes-webos-ose/chromium/webruntime.inc
+++ b/meta-luneos/recipes-webos-ose/chromium/webruntime.inc
@@ -73,6 +73,7 @@ GN_ARGS:append = " \
     use_cbe=true\
     use_cups=false\
     use_kerberos=false\
+    use_libpci=false\
     use_local_storage_tracker=true\
     use_ozone=true\
     use_pmlog=true\


### PR DESCRIPTION
Enabling libpci causes weird runtime issues with LSM (black screen on OSE, no windows for webapps on LuneOS) on qemux86-64.