### PR TITLE
pulseaudio-modules-droid*: fix install directory

### DIFF
--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-modules-droid-hidl_git.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-modules-droid-hidl_git.bb
@@ -18,14 +18,16 @@ SRC_URI = "git://github.com/droidian/pulseaudio-modules-droid-hidl.git;branch=bo
     file://0001-module-hidl-use-PA_MAJORMINOR-as-PA_MODULE_VERSION-.patch \
 "
 
+EXTRA_OECONF = "--with-module-dir=${libdir}/pulseaudio/modules"
+
 S = "${WORKDIR}/git"
 
 # inherit webos_ports_fork_repo
 inherit autotools pkgconfig
 
-FILES:${PN} += "${libdir}/pulse-*/modules/*.so"
-FILES:${PN}-dev += "${libdir}/pulse-*/modules/*.la"
-FILES:${PN}-staticdev += "${libdir}/pulse-*/modules/*.a"
+FILES:${PN} += "${libdir}/pulseaudio/modules/*.so"
+FILES:${PN}-dev += "${libdir}/pulseaudio/modules/*.la"
+FILES:${PN}-staticdev += "${libdir}/pulseaudio/modules/*.a"
 
 # Add pulse user to audio group so he can access audio dev nodes from Android
 GROUPMEMS_PARAM:${PN} = "-a pulse -g audio -G input"

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-modules-droid_git.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-modules-droid_git.bb
@@ -9,21 +9,23 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 # Depends on libhybris which has this restriction
 COMPATIBLE_MACHINE = "^halium$"
 
-PV = "15.0.88+git"
+PV = "17.0.88+git"
 SRCREV = "894f8da11f8335b09e336c599affbfc7d5fab536"
 
 SRC_URI = "git://github.com/droidian/pulseaudio-modules-droid.git;branch=bookworm;protocol=https \
     file://0001-module-droid-use-PA_MAJORMINOR-as-PA_MODULE_VERSION-.patch \
 "
 
+EXTRA_OECONF = "--with-module-dir=${libdir}/pulseaudio/modules"
+
 S = "${WORKDIR}/git"
 
 # inherit webos_ports_fork_repo
 inherit autotools pkgconfig
 
-FILES:${PN} += "${libdir}/pulse-*/modules/*.so"
-FILES:${PN}-dev += "${libdir}/pulse-*/modules/*.la"
-FILES:${PN}-staticdev += "${libdir}/pulse-*/modules/*.a"
+FILES:${PN} += "${libdir}/pulseaudio/modules/*.so"
+FILES:${PN}-dev += "${libdir}/pulseaudio/modules/*.la"
+FILES:${PN}-staticdev += "${libdir}/pulseaudio/modules/*.a"
 
 # Add pulse user to audio group so he can access audio dev nodes from Android
 GROUPMEMS_PARAM:${PN} = "-a pulse -g audio -G input"

--- a/meta-luneui/recipes-webos-ose/luna-service2/luna-service2.bb
+++ b/meta-luneui/recipes-webos-ose/luna-service2/luna-service2.bb
@@ -41,6 +41,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0004-hub.cpp-Add-support-for-org.webosports-and-org.webos.patch \
     file://0005-luna-service2-Add-permissions-for-com.palm-and-org.w.patch \
     file://0006-LSMessageIsSubscription-test-if-payload-is-a-JSON-ob.patch \
+    file://0007-_LSCheckProvidedTrustedGroups-reduce-log-noise.patch \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-luneui/recipes-webos-ose/luna-service2/luna-service2/0007-_LSCheckProvidedTrustedGroups-reduce-log-noise.patch
+++ b/meta-luneui/recipes-webos-ose/luna-service2/luna-service2/0007-_LSCheckProvidedTrustedGroups-reduce-log-noise.patch
@@ -1,0 +1,34 @@
+From 8db553f7943b758f67d954fe02dcb9e526024451 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sat, 2 Mar 2024 10:17:49 +0000
+Subject: [PATCH] _LSCheckProvidedTrustedGroups: reduce log noise
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+
+Upstream-Status: Pending
+---
+ src/libluna-service2/base.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libluna-service2/base.c b/src/libluna-service2/base.c
+index 6fadf0d..245d8e7 100644
+--- a/src/libluna-service2/base.c
++++ b/src/libluna-service2/base.c
+@@ -659,7 +659,7 @@ LSMessageHandlerResult _LSCheckProvidedTrustedGroups(LSHandle *sh,
+         jvalue_ref providedGroupTrustLevel = NULL;
+         jvalue_ref providedGroupsRef = NULL;
+ 
+-        LOG_LS_INFO(MSGID_LS_NOT_AN_ERROR, 0,"Enhanced ACG \n");
++        LOG_LS_DEBUG(MSGID_LS_NOT_AN_ERROR, 0,"Enhanced ACG \n");
+         // prepare full methods name for pattern matching
+         //char *full_name = g_build_path("/", category_path, m->name, NULL);
+         const LSTransportTrustLevelGroupBitmask *TrustLevel_bitmask = NULL;
+@@ -688,7 +688,7 @@ LSMessageHandlerResult _LSCheckProvidedTrustedGroups(LSHandle *sh,
+                     {
+                         if(TrustLevel_bitmask->trustLevel_group_bitmask)
+                         {
+-                            LOG_LS_INFO(MSGID_LS_NOT_AN_ERROR, 0, "[%s] found group bit mask : %d \n", __func__,
++                            LOG_LS_DEBUG(MSGID_LS_NOT_AN_ERROR, 0, "[%s] found group bit mask : %d \n", __func__,
+                                                *TrustLevel_bitmask->trustLevel_group_bitmask);
+                             providedGroupTrustLevel = LSTransportGetTrustFromMask(sh->transport,
+                                                           TrustLevel_bitmask->trustLevel_group_bitmask);


### PR DESCRIPTION
With scarthgap the PulseAudio 17.0 modules directory is now /usr/lib/pulseaudio/modules.