### PR TITLE
com.webos.service.tts: Update 0001-google-add-gpr-lib-to-TTS_ENGINE-c…

### DIFF
--- a/meta-luneos/recipes-webos-ose/com.webos.service.tts/com.webos.service.tts/0001-google-add-gpr-lib-to-TTS_ENGINE-call.patch
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.tts/com.webos.service.tts/0001-google-add-gpr-lib-to-TTS_ENGINE-call.patch
@@ -54,14 +54,14 @@ Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
 ---
 Upstream-Status: Pending
 
- src/engines/tts/google/CMakeLists.txt | 8 ++++++++
- 1 file changed, 8 insertions(+)
+ src/engines/tts/google/CMakeLists.txt | 9 ++++++++
+ 1 file changed, 9 insertions(+)
 
 diff --git a/src/engines/tts/google/CMakeLists.txt b/src/engines/tts/google/CMakeLists.txt
 index f04a47d..9b17f2d 100755
 --- a/src/engines/tts/google/CMakeLists.txt
 +++ b/src/engines/tts/google/CMakeLists.txt
-@@ -26,6 +26,14 @@ set(src ${CMAKE_CURRENT_SOURCE_DIR}/GoogleTTSEngine.cpp
+@@ -26,6 +26,15 @@ set(src ${CMAKE_CURRENT_SOURCE_DIR}/GoogleTTSEngine.cpp
      ${GOOGLE_SOURCE}
  )
   set(deps
@@ -73,6 +73,7 @@ index f04a47d..9b17f2d 100755
 +     absl_log_internal_nullguard
 +     absl_synchronization
 +     absl_hash
++     absl_city
       grpc
       grpc++
       protobuf


### PR DESCRIPTION
…all.patch

Fixes the following error for armv7 targets such as mako:

/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/cortexa8t2hf-neon-halium-webos-linux-gnueabi/com.webos.service.tts/1.0.0-28/recipe-sysroot-native/usr/bin/arm-webos-linux-gnueabi/../../libexec/arm-webos-linux-gnueabi/gcc/arm-webos-linux-gnueabi/13.2.0/ld: CMakeFiles/tts-service.dir/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/cortexa8t2hf-neon-halium-webos-linux-gnueabi/com.webos.service.tts/1.0.0-28/recipe-sysroot/usr/include/google/api/metric.pb.cc.o: undefined reference to symbol '_ZN4absl12lts_2023080213hash_internal10CityHash32EPKcj'
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/cortexa8t2hf-neon-halium-webos-linux-gnueabi/com.webos.service.tts/1.0.0-28/recipe-sysroot-native/usr/bin/arm-webos-linux-gnueabi/../../libexec/arm-webos-linux-gnueabi/gcc/arm-webos-linux-gnueabi/13.2.0/ld: /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/cortexa8t2hf-neon-halium-webos-linux-gnueabi/com.webos.service.tts/1.0.0-28/recipe-sysroot/usr/lib/libabsl_city.so.2308.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
