### PR TITLE
base-passwd: Bring us into 2024

### DIFF
--- a/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-luneos/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -58,3 +58,12 @@ do_install:append() {
 }
 
 FILES:${PN} += "${systemd_unitdir}"
+
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+
+USERADD_PARAM:${PN} = " \
+    -u 1010 -d /var -s /usr/sbin/nologin -G netdev -U wifi ;\
+    -u 1025 -d /var -s /usr/sbin/nologin -G netdev -U network ;\
+"
+

--- a/meta-luneos/recipes-core/base-passwd/base-passwd/0001-base-passwd-Update-gid-for-input-and-audio-so-they-m.patch
+++ b/meta-luneos/recipes-core/base-passwd/base-passwd/0001-base-passwd-Update-gid-for-input-and-audio-so-they-m.patch
@@ -1,0 +1,37 @@
+From 6c54f2daee74ed98ae42c7ee218d5b260a868c59 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Tue, 26 Mar 2024 12:25:43 +0100
+Subject: [PATCH] base-passwd: Update gid for input and audio so they match
+ with Android's
+
+input and audio gid's need to be aligned with Android ones. Since webOS doesn't care about the gid, we simply patch it globally. LG uses this gid too at their end anyway, so not necessary to do this in meta-smartphone for Android only.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [webOS/LuneOS specific]
+
+ group.master | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/group.master b/group.master
+index 4c835bc..80bbdba 100644
+--- a/group.master
++++ b/group.master
+@@ -12,7 +12,7 @@ uucp:*:10:
+ man:*:12:
+ proxy:*:13:
+ kmem:*:15:
+-input:*:19:
++input:*:1004:
+ dialout:*:20:
+ fax:*:21:
+ voice:*:22:
+@@ -20,7 +20,7 @@ cdrom:*:24:
+ floppy:*:25:
+ tape:*:26:
+ sudo:*:27:
+-audio:*:29:
++audio:*:1005:
+ dip:*:30:
+ www-data:*:33:
+ backup:*:34:

--- a/meta-luneos/recipes-core/base-passwd/base-passwd_%.bbappend
+++ b/meta-luneos/recipes-core/base-passwd/base-passwd_%.bbappend
@@ -4,7 +4,46 @@
 # as the one in oe-core expects 0002-Use-bin-sh-instead-of-bin-bash-for-the-root-user.patch to be already
 # applied on the same line, do_configure:prepend to use bash is simpler
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# Need to change the IDs of input and audio group to match those from
+# the android system, but they are also used in webOS anyway
+
+SRC_URI:append = " file://0001-base-passwd-Update-gid-for-input-and-audio-so-they-m.patch"
+
 do_configure:prepend() {
     # Undo 0002-Use-bin-sh-instead-of-bin-bash-for-the-root-user.patch
     sed -i 's%^\(root:.*\):/bin/sh%\1:/bin/bash%g' ${S}/passwd.master
+}
+
+#Let's add the system and media users and groups early on as well as the netdev group, since these are needed by multiple recipes.
+
+WEBOS_EXTRA_USERS ?= "system:x:1000:1000::/var:/usr/sbin/nologin \
+                      media:x:1013:1013::/var:/usr/sbin/nologin \
+"
+WEBOS_EXTRA_GROUPS ?= "system:x:1000:system \
+                       netdev:x:82:system,network,bluetooth,wifi \
+                       media:x:1013:media \
+                       "
+
+do_install:append() {
+    local i
+
+    for i in ${WEBOS_EXTRA_USERS}; do
+        echo $i >>${D}${datadir}/base-passwd/passwd.master
+    done
+    awk -F: '{
+        if ($1 in name || $3 in gid) exit 1
+        name[$1] = 1; gid[$3] = 1
+    }' ${D}${datadir}/base-passwd/passwd.master || \
+      bbfatal "Same username or UID detected"
+
+    for i in ${WEBOS_EXTRA_GROUPS}; do
+        echo $i >>${D}${datadir}/base-passwd/group.master
+    done
+    awk -F: '{
+        if ($1 in name || $3 in gid) exit 1
+        name[$1] = 1; gid[$3] = 1
+    }' ${D}${datadir}/base-passwd/group.master || \
+      bbfatal "Same groupname or GID found"
 }

--- a/meta-luneos/recipes-core/dbus/dbus_%.bbappend
+++ b/meta-luneos/recipes-core/dbus/dbus_%.bbappend
@@ -1,16 +1,21 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+# Copyright (c) 2014-2024 LG Electronics, Inc.
 
-SRC_URI += " \
-    file://dbus-session.service \
-    file://startup-dbus-session.sh \
+EXTENDPRAUTO:append = "webos6"
+
+PACKAGES =+ "${PN}-gpl"
+LICENSE += "& GPL-2.0-only"
+LICENSE:${PN}-gpl = "GPL-2.0-only"
+
+RDEPENDS:${PN} += "${PN}-gpl"
+
+FILES:${PN}-gpl = " \
+    ${bindir}/dbus-cleanup-sockets \
+    ${bindir}/dbus-daemon \
+    ${bindir}/dbus-monitor \
+    ${bindir}/dbus-send \
+    ${bindir}/dbus-uuidgen \
 "
 
-do_install:append() {
-    install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/dbus-session.service ${D}${systemd_unitdir}/system/
-
-    install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/startup-dbus-session.sh ${D}${bindir}/
-}
-
-FILES:${PN} += "${bindir} ${systemd_unitdir}"
+VIRTUAL-RUNTIME_bash ?= "bash"
+RDEPENDS:${PN}-ptest:append:class-target = " ${VIRTUAL-RUNTIME_bash}"
+RDEPENDS:${PN}-ptest:remove:class-target = "${@oe.utils.conditional('WEBOS_PREFERRED_PROVIDER_FOR_BASH', 'busybox', 'bash', '', d)}"

--- a/meta-luneos/recipes-core/images/luneos-image.inc
+++ b/meta-luneos/recipes-core/images/luneos-image.inc
@@ -7,3 +7,10 @@ IMAGE_FEATURES += "${LUNEOS_IMAGE_DEFAULT_FEATURES}"
 inherit luneos_image
 
 WKS_FILE ?= "luneos-image.wks"
+
+# During build the pulse-access group is not available to wam, therefore add it here in the end of the image
+
+inherit extrausers
+EXTRA_USERS_PARAMS = " \
+    usermod -a -G pulse-access wam; \
+"

--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -89,6 +89,7 @@ RDEPENDS:${PN} = " \
   webos-system-update \
   \
   webos-systemd-services \
+  webos-users-groups \
   \
   audio-service \
   com.palm.keymanager \

--- a/meta-luneos/recipes-core/webos-users-groups/webos-users-groups_1.0.bb
+++ b/meta-luneos/recipes-core/webos-users-groups/webos-users-groups_1.0.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "User and group configuration for webOS"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
+
+inherit allarch
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+
+USERADD_PARAM:${PN} = " \
+    -u 1001 -d /var -s /usr/sbin/nologin -U radio ;\
+    -u 1003 -d /var -s /usr/sbin/nologin -G video -U graphics ;\
+    -u 1007 -d /var -s /usr/sbin/nologin -U log ;\
+    -u 1022 -d /var -s /usr/sbin/nologin -U security ;\
+    -u 1009 -d /var -s /usr/sbin/nologin -G disk -U sdcard ;\
+    -u 1018 -d /var -s /usr/sbin/nologin -G disk -U usb ;\
+    -u 1019 -d /var -s /usr/sbin/nologin -U drm ;\
+"
+
+GROUPMEMS_PARAM:${PN} = " \
+    -a system -g input; \
+    -a system -g disk; \
+    -a system -g audio; \
+    -a graphics -g video; \
+    -a system -g video; \
+    -a system -g netdev; \
+    -a nobody -g nogroup; \
+"
+
+ALLOW_EMPTY:${PN} = "1"

--- a/meta-luneos/recipes-extended/shadow/shadow-sysroot/login.defs_shadow-sysroot
+++ b/meta-luneos/recipes-extended/shadow/shadow-sysroot/login.defs_shadow-sysroot
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause OR Artistic-1.0
 #
 # /etc/login.defs - Configuration control definitions for the shadow package.
 #
@@ -229,7 +230,7 @@ SYS_UID_MAX		  999
 #
 # Min/max values for automatic gid selection in groupadd
 #
-GID_MIN			10000
+GID_MIN			 1000
 GID_MAX			60000
 # System accounts
 SYS_GID_MIN		  101

--- a/meta-luneos/recipes-extended/shadow/shadow-sysroot_%.bbappend
+++ b/meta-luneos/recipes-extended/shadow/shadow-sysroot_%.bbappend
@@ -4,4 +4,4 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 # As we're overriding login.defs_shadow-sysroot we have to readd the checksum for it here
 # as it's containing the license for this component
-LIC_FILES_CHKSUM = "file://login.defs_shadow-sysroot;md5=0b6fdfc8cdf9dbf137ba229ac93e4142"
+LIC_FILES_CHKSUM = "file://login.defs_shadow-sysroot;md5=b32b78cbdffbcfdbdc844dbb307722bd"

--- a/meta-luneos/recipes-luneos/services/org.webosports.service.devmode.bb
+++ b/meta-luneos/recipes-luneos/services/org.webosports.service.devmode.bb
@@ -37,3 +37,22 @@ do_install() {
 }
 
 FILES:${PN} += "${webos_servicesdir}/${PN}"
+
+inherit useradd
+
+# Let the devmode recipe, add the developer users & group
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = " \
+    -u 504 -r -g developer --system -c developer -d /home/developer -s /bin/sh developer; \
+    -u 2003 -g developer -d /var -s /usr/sbin/nologin debug; \
+    -u 2004 -g developer -d /var -s /usr/sbin/nologin dev-func; \
+"
+
+GROUPADD_PARAM:${PN} = " \
+    -g 504 -f developer; \
+"
+
+GROUPMEMS_PARAM:${PN} = " \
+    -a developer -g developer; \
+    -a dev-func -g developer; \ 
+"

--- a/meta-luneos/recipes-multimedia/com.webos.service.mediaindexer/com.webos.service.mediaindexer.bb
+++ b/meta-luneos/recipes-multimedia/com.webos.service.mediaindexer/com.webos.service.mediaindexer.bb
@@ -56,3 +56,10 @@ do_install:append() {
 # media indexer client library
 FILES_SOLIBSDEV = ""
 FILES:${PN} += "${libdir}/*.so"
+
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+
+GROUPMEMS_PARAM:${PN} = " \
+    -a media -g video; \
+"

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -29,3 +29,22 @@ SYSTEMD_SERVICE:${PN}-server = "pulseaudio.service"
 # - https://github.com/Freescale/meta-fsl-arm/commit/3e6ede30f5da132fc5e2c376c11df661efea7163
 # - https://bugs.launchpad.net/ubuntu/+source/pulseaudio/+bug/932096
 CACHED_CONFIGUREVARS:append:arm = " ax_cv_PTHREAD_PRIO_INHERIT=no"
+
+inherit useradd
+
+USERADD_PACKAGES = "pulseaudio-server"
+GROUPADD_PARAM:pulseaudio-server = " \
+    -g 507 -f --system pulse; \
+    -g 506 -f --system pulse-access; \
+"
+
+USERADD_PARAM:pulseaudio-server = " \
+    --system --home /var/run/pulse --no-create-home --shell /bin/false --groups audio,pulse --gid pulse pulse; \
+"
+
+GROUPMEMS_PARAM:pulseaudio-server = " \
+    -a root -g pulse-access; \
+    -a system -g pulse-access; \
+    -a pulse -g pulse-access; \
+    -a pulse -g audio; \
+"

--- a/meta-luneos/recipes-webos-ose/bluetooth/com.webos.service.bluetooth2.bb
+++ b/meta-luneos/recipes-webos-ose/bluetooth/com.webos.service.bluetooth2.bb
@@ -77,3 +77,22 @@ S = "${WORKDIR}/git"
 inherit webos_systemd
 WEBOS_SYSTEMD_SERVICE = "webos-bluetooth-service.service"
 WEBOS_SYSTEMD_SCRIPT = "webos-bluetooth-service.sh"
+
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+
+USERADD_PARAM:${PN} = " \
+    -u 1002 -d /var -s /usr/sbin/nologin -G netdev -U bluetooth ;\
+"
+
+GROUPMEMS_PARAM:${PN} = " \
+    -a bluetooth -g netdev; \
+"
+
+GROUPADD_PARAM:${PN} = " \
+    -g 2024 -f blemesh; \
+"
+
+#Below group only is required for webOS Auto
+GROUPADD_PARAM:${PN} += "${@oe.utils.conditional('DISTRO', 'webos-auto', '-g -f 2025 vcardshare', '', d)}"

--- a/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera.bb
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera.bb
@@ -44,3 +44,14 @@ do_install:append() {
 }
 
 COMPATIBLE_MACHINE = "(.*)"
+
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+
+USERADD_PARAM:${PN} = " \
+    -u 1006 -d /var -s /usr/sbin/nologin -G video -U camera; \
+"
+
+GROUPMEMS_PARAM:${PN} = " \
+    -a camera -g video; \
+"

--- a/meta-luneos/recipes-webos-ose/com.webos.service.pdm/com.webos.service.pdm.bb
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.pdm/com.webos.service.pdm.bb
@@ -26,6 +26,16 @@ inherit webos_system_bus
 inherit webos_public_repo
 inherit webos_enhanced_submissions
 inherit pkgconfig
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = " \
+    -g pdmgroup -d /home/pdmuser -m -s /bin/sh pdmuser; \
+"
+
+GROUPADD_PARAM:${PN} = " \
+    -g 2023 -f pdmgroup; \
+"
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-NfcDeviceHandler-Fix-incorrect-name.patch \

--- a/meta-luneos/recipes-webos-ose/wam/wam.inc
+++ b/meta-luneos/recipes-webos-ose/wam/wam.inc
@@ -7,6 +7,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM += "file://oss-pkg-info.yaml;md5=790420e31fa17284afec484d5b2ad2d8"
 
 DEPENDS = "virtual/webruntime luna-service2 sqlite3 librolegen nyx-lib openssl luna-prefs libpbnjson freetype serviceinstaller glib-2.0 pmloglib lttng-ust gtest jsoncpp boost"
+
 PROVIDES = "virtual/webappmanager-webos"
 
 # webappmgr's upstart conf expects to be able to LD_PRELOAD ptmalloc3
@@ -31,6 +32,7 @@ inherit webos_lttng
 inherit webos_public_repo
 inherit webos_enhanced_submissions
 inherit webos_systemd
+inherit useradd
 
 WAM_DATA_DIR = "${webos_execstatedir}/${BPN}"
 
@@ -162,4 +164,29 @@ FILES:${PN} += " \
     ${sysconfdir}/wam \
     ${libdir}/webappmanager/plugins/*.so \
     ${datadir}/localization/${BPN} \
+"
+# Needed for the users & groups
+DEPENDS += "webos-users-groups"
+
+# Let WAM create it's user & compositor and se group. "se" is used for DRM keys on some webOS distros
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = " \
+    -u 505 --system -g compositor -c wam -d /var/lib/wam -s /usr/sbin/nologin -G audio,video,se,media wam; \
+"
+
+GROUPADD_PARAM:${PN} = " \
+    -g 505 -f --system compositor; \
+    -g 509 -f --system se; \
+"
+
+GROUPMEMS_PARAM:${PN} = " \
+    -a graphics -g compositor; \
+    -a media -g compositor; \
+    -a wam -g compositor; \
+    -a wam -g input; \
+    -a wam -g video; \
+    -a wam -g se; \
+    -a root -g se; \
+    -a system -g se; \
 "


### PR DESCRIPTION
To finally get rid of the 2013 version of base-passwd from OSE.

Let recipes create the users/group and add permissions where they need it instead, so it's clear where they originate from.

Only create the system gid/uid and netdev gid hardcoded.