### PR TITLE
webruntime: fix window.open after 94 -> 108 upgrade

### DIFF
--- a/meta-luneos/recipes-webos-ose/chromium/files/0002-Add-window.open-support.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0002-Add-window.open-support.patch
@@ -1,4 +1,4 @@
-From c0a38fec70182cffb6751727e47343a524c83662 Mon Sep 17 00:00:00 2001
+From 084518324bdcb5d1a66460ca4313eac3ebfca118 Mon Sep 17 00:00:00 2001
 From: Herman van Hazendonk <github.com@herrie.org>
 Date: Wed, 7 Dec 2022 07:42:34 +0100
 Subject: [PATCH] Add window.open support
@@ -16,21 +16,21 @@ Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
 ---
 Upstream-Status: Pending
 
- .../browser/web_contents/web_contents_impl.cc | 14 ++++++
+ .../browser/web_contents/web_contents_impl.cc | 14 +++++
  .../browser/web_contents/web_contents_impl.h  |  5 ++
  src/content/public/browser/web_contents.h     |  3 ++
  .../common/common_param_traits_macros.h       |  1 +
  .../renderer/window_features_converter.cc     |  2 +
  .../app_runtime/public/webview_delegate.h     |  7 +++
- src/neva/app_runtime/webview.cc               | 46 +++++++++++++++----
- src/neva/app_runtime/webview.h                | 16 ++++++-
+ src/neva/app_runtime/webview.cc               | 51 +++++++++++++++----
+ src/neva/app_runtime/webview.h                | 16 +++++-
  .../window_features/window_features.mojom     |  6 +++
  .../blink/public/web/web_window_features.h    |  2 +
  .../renderer/core/page/chrome_client_impl.h   |  2 +
- .../blink/renderer/core/page/create_window.cc | 24 +++++++++-
- src/webos/webview_base.cc                     | 46 +++++++++++++++----
- src/webos/webview_base.h                      | 14 ++++++
- 14 files changed, 168 insertions(+), 20 deletions(-)
+ .../blink/renderer/core/page/create_window.cc | 24 ++++++++-
+ src/webos/webview_base.cc                     | 46 ++++++++++++++---
+ src/webos/webview_base.h                      | 14 +++++
+ 14 files changed, 173 insertions(+), 20 deletions(-)
 
 diff --git a/src/content/browser/web_contents/web_contents_impl.cc b/src/content/browser/web_contents/web_contents_impl.cc
 index 631e210184..1044d5c3d2 100644
@@ -159,10 +159,10 @@ index f4fc4ef7cf..90cea2dc18 100644
    virtual void SendCookiesForHostname(const std::string& cookies) {}
  
 diff --git a/src/neva/app_runtime/webview.cc b/src/neva/app_runtime/webview.cc
-index 91bd668c77..e3da5d99b3 100644
+index 91bd668c77..7efc8f929d 100644
 --- a/src/neva/app_runtime/webview.cc
 +++ b/src/neva/app_runtime/webview.cc
-@@ -124,12 +124,16 @@ void WebView::SetFileAccessBlocked(bool blocked) {
+@@ -124,12 +124,21 @@ void WebView::SetFileAccessBlocked(bool blocked) {
    NOTIMPLEMENTED();
  }
  
@@ -178,11 +178,16 @@ index 91bd668c77..e3da5d99b3 100644
 +  if(!web_contents_) {
 +    CreateWebContents();
 +  }
++  else {
++    AppRuntimeWebViewHostImpl::CreateForWebContents(web_contents_.get());
++    AppRuntimeWebViewControllerImpl::CreateForWebContents(web_contents_.get());
++  }
 +  injection_manager_ = std::make_unique<WebAppInjectionManager>();
++  
    web_contents_->SetDelegate(this);
    Observe(web_contents_.get());
  
-@@ -198,7 +202,6 @@ void WebView::CreateWebContents() {
+@@ -198,7 +207,6 @@ void WebView::CreateWebContents() {
    params.desired_renderer_state =
        content::WebContents::CreateParams::kNoRendererProcess;
    web_contents_ = content::WebContents::Create(params);
@@ -190,7 +195,7 @@ index 91bd668c77..e3da5d99b3 100644
    AppRuntimeWebViewHostImpl::CreateForWebContents(web_contents_.get());
    AppRuntimeWebViewControllerImpl::CreateForWebContents(web_contents_.get());
  
-@@ -472,6 +475,19 @@ void WebView::LoadProgressChanged(double progress) {
+@@ -472,6 +480,19 @@ void WebView::LoadProgressChanged(double progress) {
      webview_delegate_->OnLoadProgressChanged(progress);
  }
  
@@ -210,7 +215,7 @@ index 91bd668c77..e3da5d99b3 100644
  // OpenURLFromTab() method is implemented for transition from old_url to new_url
  // where old_url.SchemeIs(url::kFileScheme) == false
  // and   new_url.SchemeIs(url::kFileScheme) == true
-@@ -487,14 +503,26 @@ content::WebContents* WebView::OpenURLFromTab(
+@@ -487,14 +508,26 @@ content::WebContents* WebView::OpenURLFromTab(
      return nullptr;
    }
  

--- a/meta-luneos/recipes-webos-ose/chromium/files/0003-WebOS-Shell-Surface-add-client_size_changed-wayland-.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0003-WebOS-Shell-Surface-add-client_size_changed-wayland-.patch
@@ -1,4 +1,4 @@
-From 0bc5e09ec747aaea0aecb2519d319f2e78dce4b2 Mon Sep 17 00:00:00 2001
+From ee994af786f724937c15699c7dd27c957df9bf6c Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Tue, 12 Apr 2022 18:18:48 +0000
 Subject: [PATCH] WebOS Shell Surface: add client_size_changed wayland event

--- a/meta-luneos/recipes-webos-ose/chromium/files/0004-DesktopNativeWidgetAura-don-t-apply-DIP-for-SetBound.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0004-DesktopNativeWidgetAura-don-t-apply-DIP-for-SetBound.patch
@@ -1,4 +1,4 @@
-From a6cd943dde1c2f2cf4ed80947be6338e1eee3086 Mon Sep 17 00:00:00 2001
+From 7ed210437efe4da6a7c1ef3adf951baf272b01d7 Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Thu, 10 Nov 2022 21:54:24 +0000
 Subject: [PATCH] DesktopNativeWidgetAura: don't apply DIP for SetBounds

--- a/meta-luneos/recipes-webos-ose/chromium/files/0005-palmGetResource-improve-legacy-compatibility.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0005-palmGetResource-improve-legacy-compatibility.patch
@@ -1,4 +1,4 @@
-From 3a98acc3ca9035c2c8188fd00200354d5c09f181 Mon Sep 17 00:00:00 2001
+From c84b8720909891ec7e2fdd49cfbee3aa3e3c4974 Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Wed, 16 Nov 2022 18:01:06 +0000
 Subject: [PATCH] palmGetResource: improve legacy compatibility

--- a/meta-luneos/recipes-webos-ose/chromium/files/0006-Update-app-shell.role.json.in-Add-trustLevel.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0006-Update-app-shell.role.json.in-Add-trustLevel.patch
@@ -1,4 +1,4 @@
-From 9560217d43b9f37783f2ce10f97427b49ce66b84 Mon Sep 17 00:00:00 2001
+From 0f25084130ebeb379b66210c6a1af18bddb97fe5 Mon Sep 17 00:00:00 2001
 From: Herrie <Github.com@herrie.org>
 Date: Wed, 27 Sep 2023 09:21:38 +0200
 Subject: [PATCH] Update app-shell.role.json.in: Add trustLevel

--- a/meta-luneos/recipes-webos-ose/chromium/files/0007-palmGetResource-Fix-loading-of-local-resources.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0007-palmGetResource-Fix-loading-of-local-resources.patch
@@ -1,4 +1,4 @@
-From f0a2e773729418060298c3cd326b9152ba87feb4 Mon Sep 17 00:00:00 2001
+From c380cc32ab788e6d33fce3c5008de94ca95ed182 Mon Sep 17 00:00:00 2001
 From: Herrie <Github.com@herrie.org>
 Date: Wed, 4 Oct 2023 08:23:20 +0200
 Subject: [PATCH] palmGetResource: Fix loading of local resources

--- a/meta-luneos/recipes-webos-ose/chromium/files/0008-webossystem_injection.cc-fix-some-PalmSystem-functio.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0008-webossystem_injection.cc-fix-some-PalmSystem-functio.patch
@@ -1,4 +1,4 @@
-From df58ff1ed0c9944a577ac23e973c3111013f8cb0 Mon Sep 17 00:00:00 2001
+From 8f3f50f5d347f24e77be0b1b1e1ad566ccc95479 Mon Sep 17 00:00:00 2001
 From: Herrie <Github.com@herrie.org>
 Date: Fri, 6 Oct 2023 10:00:51 +0200
 Subject: [PATCH] webossystem_injection.cc: fix some PalmSystem functions

--- a/meta-luneos/recipes-webos-ose/chromium/files/0009-app_shell-override-default-OnWindowHostClose-to-clos.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0009-app_shell-override-default-OnWindowHostClose-to-clos.patch
@@ -1,4 +1,4 @@
-From 64d874c70f37f2089d04eb24371aad245f7e524e Mon Sep 17 00:00:00 2001
+From 71056ef94b96f329d83543c69774f838cd0a08d8 Mon Sep 17 00:00:00 2001
 From: Christophe Chapuis <chris.chapuis@gmail.com>
 Date: Fri, 24 Nov 2023 19:03:44 +0000
 Subject: [PATCH] app_shell: override default OnWindowHostClose to close


### PR DESCRIPTION
The issue here was that the new web_content_ didn't have its host view created, because the following calls were never made:

 AppRuntimeWebViewHostImpl::CreateForWebContents(web_contents_.get());
 AppRuntimeWebViewControllerImpl::CreateForWebContents(web_contents_.get());

Add these calls in WebView::WebView, when web_contents_ already exists.