### PR TITLE
Fix outbound permission calls to com.webos.service.memorymanager

### DIFF
--- a/meta-luneos/recipes-webos-ose/sam/sam/0001-com.webos.sam.role.json.in-Fix-various-outbound-perm.patch
+++ b/meta-luneos/recipes-webos-ose/sam/sam/0001-com.webos.sam.role.json.in-Fix-various-outbound-perm.patch
@@ -1,4 +1,4 @@
-From a321744d805874f983c884b83d8f8c804c99153e Mon Sep 17 00:00:00 2001
+From 7f73e2ff0ca1678015a119ee2ed937c5febf8ba0 Mon Sep 17 00:00:00 2001
 From: Herman van Hazendonk <github.com@herrie.org>
 Date: Fri, 29 Apr 2022 23:30:14 +0200
 Subject: [PATCH] com.webos.sam.role.json.in: Fix various outbound permission
@@ -17,13 +17,22 @@ Apr 29 20:38:55 qemux86-64 ls-hubd[241]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 Upstream-Status: Pending
 ---
- files/sysbus/com.webos.sam.role.json.in | 44 ++++++++++++++++++++++++-
- 1 file changed, 43 insertions(+), 1 deletion(-)
+ files/sysbus/com.webos.sam.role.json.in | 46 +++++++++++++++++++++++--
+ 1 file changed, 44 insertions(+), 2 deletions(-)
 
 diff --git a/files/sysbus/com.webos.sam.role.json.in b/files/sysbus/com.webos.sam.role.json.in
-index d4a24ce..ab145b4 100644
+index d4a24ce..e1d9ce4 100644
 --- a/files/sysbus/com.webos.sam.role.json.in
 +++ b/files/sysbus/com.webos.sam.role.json.in
+@@ -16,7 +16,7 @@
+                 "com.webos.appInstallService",
+                 "com.webos.booster",
+                 "com.webos.bootManager",
+-                "com.webos.memorymanager",
++                "com.webos.service.memorymanager",
+                 "com.webos.notification",
+                 "com.webos.service.attachedstoragemanager",
+                 "com.webos.service.bus",
 @@ -29,7 +29,49 @@
                  "com.webos.service.tvpower",
                  "com.palm.webappmanager",
@@ -44,7 +53,7 @@ index d4a24ce..ab145b4 100644
 +                "com.webos.appInstallService",
 +                "com.webos.booster",
 +                "com.webos.bootManager",
-+                "com.webos.memorymanager",
++                "com.webos.service.memorymanager",
 +                "com.webos.notification",
 +                "com.webos.service.attachedstoragemanager",
 +                "com.webos.service.bus",

--- a/meta-luneos/recipes-webos-ose/wam/wam/0002-ls2-Add-required-bits-for-LuneOS.patch
+++ b/meta-luneos/recipes-webos-ose/wam/wam/0002-ls2-Add-required-bits-for-LuneOS.patch
@@ -8,8 +8,8 @@ Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 Upstream-Status: Inappropriate [LuneOS specific]
 
  files/sysbus/com.palm.webappmanager.perm.json    | 1 +
- files/sysbus/com.palm.webappmanager.role.json.in | 7 ++++++-
- 2 files changed, 7 insertions(+), 1 deletion(-)
+ files/sysbus/com.palm.webappmanager.role.json.in | 9 +++++++--
+ 2 files changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/files/sysbus/com.palm.webappmanager.perm.json b/files/sysbus/com.palm.webappmanager.perm.json
 index 7ae8f0c..b67c601 100644
@@ -24,7 +24,7 @@ index 7ae8f0c..b67c601 100644
      ],
      "com.webos.chromium.audio-*": [
 diff --git a/files/sysbus/com.palm.webappmanager.role.json.in b/files/sysbus/com.palm.webappmanager.role.json.in
-index 47a9570..52f651d 100644
+index 47a9570..c19ab3a 100644
 --- a/files/sysbus/com.palm.webappmanager.role.json.in
 +++ b/files/sysbus/com.palm.webappmanager.role.json.in
 @@ -16,11 +16,15 @@
@@ -33,7 +33,8 @@ index 47a9570..52f651d 100644
            "com.webos.applicationManager",
 +          "com.webos.service.applicationManager",
            "com.webos.bootManager",
-           "com.webos.memorymanager",
+-          "com.webos.memorymanager",
++          "com.webos.service.memorymanager",
            "com.webos.service.activitymanager",
            "com.webos.service.connectionmanager",
 -          "com.webos.settingsservice"


### PR DESCRIPTION
Seems that OSE forgot to update their LS2 files after retiring com.webos.memorymanager legacy APIs with with https://github.com/webosose/com.webos.service.memorymanager/commit/c13f55d4c456b5b6006e6ef31c11ba40e698c974