### PR TITLE
fix UCM loading with pulseaudio and fix dbus for voicecall

### DIFF
--- a/meta-luneos/recipes-core/dbus/dbus_%.bbappend
+++ b/meta-luneos/recipes-core/dbus/dbus_%.bbappend
@@ -19,3 +19,21 @@ FILES:${PN}-gpl = " \
 VIRTUAL-RUNTIME_bash ?= "bash"
 RDEPENDS:${PN}-ptest:append:class-target = " ${VIRTUAL-RUNTIME_bash}"
 RDEPENDS:${PN}-ptest:remove:class-target = "${@oe.utils.conditional('WEBOS_PREFERRED_PROVIDER_FOR_BASH', 'busybox', 'bash', '', d)}"
+
+# This part is introduced for LuneOS, to create a DBus session (needed by voicecall, for instance)
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += " \
+    file://dbus-session.service \
+    file://startup-dbus-session.sh \
+"
+
+do_install:append() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/dbus-session.service ${D}${systemd_unitdir}/system/
+
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/startup-dbus-session.sh ${D}${bindir}/
+}
+
+FILES:${PN} += "${bindir} ${systemd_unitdir}"

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio/0006-alsa-ucm-Check-UCM-verb.patch
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio/0006-alsa-ucm-Check-UCM-verb.patch
@@ -1,0 +1,97 @@
+From f5cacd94abcc47003bd88ad7ca1450de649ffb15 Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Thu, 30 Nov 2023 20:17:22 +0300
+Subject: [PATCH] alsa-ucm: Check UCM verb before working with device status
+
+Some versions of the ALSA libraries run into a segmentation fault when
+we query a UCM device/modifier status without first setting a UCM verb.
+It's not a reasonable thing to do anyway, so check for this case and
+return an error. Also do the check in other helpers.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/801>
+
+Upstream-Status: Backport
+---
+ src/modules/alsa/alsa-ucm.c | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/src/modules/alsa/alsa-ucm.c b/src/modules/alsa/alsa-ucm.c
+index bb9438f79..7f5136249 100644
+--- a/src/modules/alsa/alsa-ucm.c
++++ b/src/modules/alsa/alsa-ucm.c
+@@ -624,6 +624,11 @@ static long ucm_device_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev)
+     char *devstatus;
+     long status = 0;
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to get status for UCM device %s: no UCM verb set", dev_name);
++        return -1;
++    }
++
+     devstatus = pa_sprintf_malloc("_devstatus/%s", dev_name);
+     if (snd_use_case_geti(ucm->ucm_mgr, devstatus, &status) < 0) {
+         pa_log_debug("Failed to get status for UCM device %s", dev_name);
+@@ -637,6 +642,11 @@ static long ucm_device_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev)
+ static int ucm_device_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev) {
+     const char *dev_name = pa_proplist_gets(dev->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to disable UCM device %s: no UCM verb set", dev_name);
++        return -1;
++    }
++
+     /* If any of dev's conflicting devices is enabled, trying to disable
+      * dev gives an error despite the fact that it's already disabled.
+      * Check that dev is enabled to avoid this error. */
+@@ -657,6 +667,11 @@ static int ucm_device_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev)
+ static int ucm_device_enable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_device *dev) {
+     const char *dev_name = pa_proplist_gets(dev->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to enable UCM device %s: no UCM verb set", dev_name);
++        return -1;
++    }
++
+     /* We don't need to enable devices that are already enabled */
+     if (ucm_device_status(ucm, dev) > 0) {
+         pa_log_debug("UCM device %s is already enabled", dev_name);
+@@ -707,6 +722,11 @@ static long ucm_modifier_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *m
+     char *modstatus;
+     long status = 0;
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to get status for UCM modifier %s: no UCM verb set", mod_name);
++        return -1;
++    }
++
+     modstatus = pa_sprintf_malloc("_modstatus/%s", mod_name);
+     if (snd_use_case_geti(ucm->ucm_mgr, modstatus, &status) < 0) {
+         pa_log_debug("Failed to get status for UCM modifier %s", mod_name);
+@@ -720,6 +740,11 @@ static long ucm_modifier_status(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *m
+ static int ucm_modifier_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *mod) {
+     const char *mod_name = pa_proplist_gets(mod->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to disable UCM modifier %s: no UCM verb set", mod_name);
++        return -1;
++    }
++
+     /* We don't need to disable modifiers that are already disabled */
+     if (ucm_modifier_status(ucm, mod) == 0) {
+         pa_log_debug("UCM modifier %s is already disabled", mod_name);
+@@ -738,6 +763,11 @@ static int ucm_modifier_disable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *m
+ static int ucm_modifier_enable(pa_alsa_ucm_config *ucm, pa_alsa_ucm_modifier *mod) {
+     const char *mod_name = pa_proplist_gets(mod->proplist, PA_ALSA_PROP_UCM_NAME);
+ 
++    if (!ucm->active_verb) {
++        pa_log_error("Failed to disable UCM modifier %s: no UCM verb set", mod_name);
++        return -1;
++    }
++
+     /* We don't need to enable modifiers that are already enabled */
+     if (ucm_modifier_status(ucm, mod) > 0) {
+         pa_log_debug("UCM modifier %s is already enabled", mod_name);
+-- 
+GitLab
+

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio/0007-alsa-ucm-Replace-port-device-UCM-context-assertion.patch
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio/0007-alsa-ucm-Replace-port-device-UCM-context-assertion.patch
@@ -1,0 +1,66 @@
+From ed3d4f0837f670e5e5afb1afa5bcfc8ff05d3407 Mon Sep 17 00:00:00 2001
+From: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Date: Fri, 1 Dec 2023 13:28:05 +0300
+Subject: [PATCH] alsa-ucm: Replace port device UCM context assertion with an
+ error
+
+The pa_alsa_ucm_set_port() function is passed both a mapping context and
+a device port, and both of these refer to their respective UCM device.
+While switching over to having one port per mapping per UCM device, I
+expected both of these to be the same device struct, so added an assert
+checking so.
+
+This assertion gets triggered when we have multiple UCM verbs declaring
+the same UCM device name. The root cause here is that the ports' UCM
+device references are set once while creating the ports for the card, so
+they happen to be those of a specific verb and may not match those from
+a different UCM verb's profiles' mappings.
+
+Solving the root cause necessitates a larger refactor. What we actually
+assume here is that name of the UCM device is same for both the port and
+the UCM context, which ends up always true in practice. For now, replace
+the assert with a check and error.
+
+Signed-off-by: Alper Nebi Yasak <alpernebiyasak@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/802>
+
+Upstream-Status: Backport
+---
+ src/modules/alsa/alsa-ucm.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/modules/alsa/alsa-ucm.c b/src/modules/alsa/alsa-ucm.c
+index 7f5136249..018c01739 100644
+--- a/src/modules/alsa/alsa-ucm.c
++++ b/src/modules/alsa/alsa-ucm.c
+@@ -1581,6 +1581,7 @@ int pa_alsa_ucm_set_port(pa_alsa_ucm_mapping_context *context, pa_device_port *p
+     pa_alsa_ucm_config *ucm;
+     pa_alsa_ucm_device *dev;
+     pa_alsa_ucm_port_data *data;
++    const char *dev_name, *ucm_dev_name;
+ 
+     pa_assert(context && context->ucm);
+ 
+@@ -1588,8 +1589,17 @@ int pa_alsa_ucm_set_port(pa_alsa_ucm_mapping_context *context, pa_device_port *p
+     pa_assert(ucm->ucm_mgr);
+ 
+     data = PA_DEVICE_PORT_DATA(port);
+-    dev = context->ucm_device;
+-    pa_assert(dev == data->device);
++    dev = data->device;
++    pa_assert(dev);
++
++    if (context->ucm_device) {
++        dev_name = pa_proplist_gets(dev->proplist, PA_ALSA_PROP_UCM_NAME);
++        ucm_dev_name = pa_proplist_gets(context->ucm_device->proplist, PA_ALSA_PROP_UCM_NAME);
++        if (!pa_streq(dev_name, ucm_dev_name)) {
++            pa_log_error("Failed to set port %s with wrong UCM context: %s", dev_name, ucm_dev_name);
++            return -1;
++        }
++    }
+ 
+     return ucm_device_enable(ucm, dev);
+ }
+-- 
+GitLab
+

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -8,6 +8,8 @@ SRC_URI += " \
     file://0003-daemon-Set-default-resampler-to-speex-fixed-2.patch \
     file://0004-suspend-on-idle-Ensure-we-still-time-out-if-a-stream.patch \
     file://0005-Add-dbus-policy-for-Bluez4.patch \
+    file://0006-alsa-ucm-Check-UCM-verb.patch \
+    file://0007-alsa-ucm-Replace-port-device-UCM-context-assertion.patch \
 "
 
 do_install:append() {


### PR DESCRIPTION
Fixes: E: [pulseaudio] alsa-ucm.c: Assertion 'dev == data->device' failed at /usr/src/debug/pulseaudio/17.0/src/modules/alsa/alsa-ucm.c:1562, function pa_alsa_ucm_set_port(). Aborting.