### PR TITLE
com.webos.service.videooutput|wam: Fix LS2 permission errors

### DIFF
--- a/meta-luneos/recipes-webos-ose/com.webos.service.videooutput/com.webos.service.videooutput.bb
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.videooutput/com.webos.service.videooutput.bb
@@ -25,6 +25,7 @@ inherit webos_test_provider
 
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}\
     file://0001-Add-trustLevel.patch \
+    file://0002-com.webos.service.videooutput-Fix-outbound-permissio.patch \
 "
 
 inherit webos_systemd

--- a/meta-luneos/recipes-webos-ose/com.webos.service.videooutput/com.webos.service.videooutput/0002-com.webos.service.videooutput-Fix-outbound-permissio.patch
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.videooutput/com.webos.service.videooutput/0002-com.webos.service.videooutput-Fix-outbound-permissio.patch
@@ -1,0 +1,29 @@
+From 9f6e5d24ed8941b7a1e146cc6701ad57dc03355c Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Fri, 12 Apr 2024 08:42:30 +0200
+Subject: [PATCH] com.webos.service.videooutput: Fix outbound permission error
+
+Fixes:
+
+Apr 12 00:04:29 qemux86-64 SettingsService[1385]: [] [pmlog] LS_REQUIRES_SECURITY {"CLIENT":"com.webos.service.videooutput","SERVICE":"com.webos.service.settings","CATEGORY":"/","METHOD":"getSystemSettings"} Service security groups don't allow method call.
+
+Possibly contributes to YouTube that stopped working in recent releases.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+
+Upstream-Status: Pending [https://github.com/webosose/com.webos.service.videooutput/pull/2]
+---
+ files/sysbus/com.webos.service.videooutput.perm.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/files/sysbus/com.webos.service.videooutput.perm.json b/files/sysbus/com.webos.service.videooutput.perm.json
+index 7d21236..4140e94 100755
+--- a/files/sysbus/com.webos.service.videooutput.perm.json
++++ b/files/sysbus/com.webos.service.videooutput.perm.json
+@@ -1,5 +1,5 @@
+ {
+   "com.webos.service.videooutput": [
+-    "settings"
++    "settings.query"
+   ]
+ }

--- a/meta-luneos/recipes-webos-ose/wam/wam.inc
+++ b/meta-luneos/recipes-webos-ose/wam/wam.inc
@@ -50,6 +50,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0011-Add-additional-window.open-features-management.patch \
     file://0012-PalmSystem-add-banner-support.patch \
     file://0013-WebAppBase-fix-window.close-for-multi-window-apps.patch \
+    file://0014-WAM-Fix-outbound-permission-error.patch \
 "
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos-ose/wam/wam/0014-WAM-Fix-outbound-permission-error.patch
+++ b/meta-luneos/recipes-webos-ose/wam/wam/0014-WAM-Fix-outbound-permission-error.patch
@@ -1,0 +1,30 @@
+From cfc761ca8ea18e87548d908b397c7c95d193c774 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Fri, 12 Apr 2024 08:39:01 +0200
+Subject: [PATCH] WAM: Fix outbound permission error
+
+Fixes:
+
+Fixes: Apr 11 22:05:24 qemux86-64 webos-connman-adapter[1266]: [] [pmlog] LS_REQUIRES_SECURITY {"CLIENT":"com.webos.settingsservice.client-1136","SERVICE":"com.webos.service.connectionmanager","CATEGORY":"/","METHOD":"getStatus"} Service security groups don't allow method call.
+
+Might be a partial solution for YouTube not working in recent releases.
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+
+Upstream-Status: Pending [https://github.com/webosose/wam/pull/34]
+---
+ files/sysbus/com.palm.webappmanager.perm.json | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/files/sysbus/com.palm.webappmanager.perm.json b/files/sysbus/com.palm.webappmanager.perm.json
+index b67c601..fd335a3 100644
+--- a/files/sysbus/com.palm.webappmanager.perm.json
++++ b/files/sysbus/com.palm.webappmanager.perm.json
+@@ -23,6 +23,7 @@
+     "com.webos.settingsservice.client-*": [
+         "application.launcher",
+         "application.operation",
+-        "settings.query"
++        "settings.query",
++        "networkconnection.query"
+     ]
+ }


### PR DESCRIPTION
Fixes:

Apr 12 00:04:29 qemux86-64 SettingsService[1385]: [] [pmlog] LS_REQUIRES_SECURITY {"CLIENT":"com.webos.service.videooutput","SERVICE":"com.webos.service.settings","CATEGORY":"/","METHOD":"getSystemSettings"} Service security groups don't allow method call.

Apr 11 22:05:24 qemux86-64 webos-connman-adapter[1266]: [] [pmlog] LS_REQUIRES_SECURITY {"CLIENT":"com.webos.settingsservice.client-1136","SERVICE":"com.webos.service.connectionmanager","CATEGORY":"/","METHOD":"getStatus"} Service security groups don't allow method call.