### PR TITLE
Implement media and camera framework from OSE

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
@@ -30,14 +30,8 @@ VIRTUAL-RUNTIME_com.webos.app.home ?= ""
 VIRTUAL-RUNTIME_pdm ?= "com.webos.service.pdm"
 VIRTUAL-RUNTIME_ai ?= "com.webos.service.ai"
 VIRTUAL-RUNTIME_memorymanager ?= "com.webos.service.memorymanager"
-VIRTUAL-RUNTIME_g-media-pipeline ?= ""
-VIRTUAL-RUNTIME_g-media-pipeline:rpi = "g-media-pipeline"
-VIRTUAL-RUNTIME_g-media-pipeline:qemux86 = "g-media-pipeline"
-VIRTUAL-RUNTIME_g-media-pipeline:qemux86-64 = "g-media-pipeline"
-VIRTUAL-RUNTIME_g-camera-pipeline ?= ""
-VIRTUAL-RUNTIME_g-camera-pipeline:rpi = "g-camera-pipeline"
-VIRTUAL-RUNTIME_g-camera-pipeline:qemux86 = "g-camera-pipeline"
-VIRTUAL-RUNTIME_g-camera-pipeline:qemux86-64 = "g-camera-pipeline"
+VIRTUAL-RUNTIME_g-media-pipeline ?= "g-media-pipeline"
+VIRTUAL-RUNTIME_g-camera-pipeline ?= "g-camera-pipeline"
 VIRTUAL-RUNTIME_nodejs-module-node-red ?= "nodejs-module-node-red"
 VIRTUAL-RUNTIME_contextintentmgr ?= "com.webos.service.contextintentmgr"
 VIRTUAL-RUNTIME_mojoservicelauncher ?= "mojoservicelauncher"
@@ -154,6 +148,8 @@ RDEPENDS:${PN} = " \
     activitymanager \
     ${VIRTUAL-RUNTIME_com.webos.app.camera} \
     ${VIRTUAL-RUNTIME_com.webos.app.home} \
+    ${VIRTUAL-RUNTIME_g-camera-pipeline} \
+    ${VIRTUAL-RUNTIME_g-media-pipeline} \
     bootd \
     configd \
     configurator \
@@ -212,9 +208,6 @@ RDEPENDS:${PN} = " \
     ${WEBOS_PACKAGESET_MEDIA} \
 "
 
-#FIXME: 
-#   ${VIRTUAL-RUNTIME_g-camera-pipeline}
-#   ${VIRTUAL-RUNTIME_g-media-pipeline}
 
 # XXX These FOSS components must be explicitly added because they are missing
 # from the RDEPENDS lists of the components that expect them to be present at

--- a/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline.bb
+++ b/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline.bb
@@ -14,6 +14,7 @@ inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
 inherit webos_enhanced_submissions
+inherit webos_machine_dep
 inherit pkgconfig
 
 # media-resource-calculator since submissions 47 isn't usable for any other MACHINE than
@@ -23,7 +24,8 @@ inherit pkgconfig
 # raspberrypi4-64
 # qemux86
 # qemux86-64
-COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
+#In LuneOS we want this for all machines
+#COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
 
 PR = "r19"
 DEPENDS = "boost gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad umediaserver media-resource-calculator webos-wayland-extensions"
@@ -32,5 +34,9 @@ DEPENDS:append:rpi = " virtual/libomxil"
 
 WEBOS_VERSION = "1.0.0-gav.53_4e91a56809eb88d4b45d0121f3912a040995a141"
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+WEBOS_GIT_PARAM_BRANCH = "@gav"
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}\ 
+    file://0001-Add-generic-config.patch \
+"
 S = "${WORKDIR}/git"
+

--- a/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline/0001-Add-generic-config.patch
+++ b/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline/0001-Add-generic-config.patch
@@ -1,0 +1,132 @@
+From c52f448ba81ec59fbf36df8c07385434a06f3c9d Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Sat, 6 Jan 2024 16:59:03 +0100
+Subject: [PATCH] Add generic config
+
+---
+Upstream-Status: Inappropriate [LuneOS specific]
+
+ CMakeLists.txt                       |  2 +
+ src/player/CMakeLists.txt            |  4 +-
+ src/player/generic/gst_debug.conf    | 11 +++++
+ src/player/generic/gst_elements.conf | 65 ++++++++++++++++++++++++++++
+ 4 files changed, 81 insertions(+), 1 deletion(-)
+ create mode 100644 src/player/generic/gst_debug.conf
+ create mode 100644 src/player/generic/gst_elements.conf
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5419fed..2e5067d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,6 +50,8 @@ link_directories(${GSTREAMER_LIBRARIES})
+ 
+ if(${WEBOS_TARGET_MACHINE} STREQUAL "qemux86" OR ${WEBOS_TARGET_MACHINE} STREQUAL "qemux86-64")
+     add_definitions(-DPLATFORM_QEMUX86)
++else()
++    add_definitions(-DPLATFORM_GENERIC)
+ endif()
+ 
+ add_subdirectory(src)
+diff --git a/src/player/CMakeLists.txt b/src/player/CMakeLists.txt
+index d24e48f..2138891 100644
+--- a/src/player/CMakeLists.txt
++++ b/src/player/CMakeLists.txt
+@@ -147,7 +147,9 @@ elseif (${WEBOS_TARGET_MACHINE} STREQUAL "qemux86" OR ${WEBOS_TARGET_MACHINE} ST
+   install(FILES ./qemux86/gst_debug.conf DESTINATION /etc/g-media-pipeline)
+   install(FILES ./qemux86/gst_elements.conf DESTINATION /etc/g-media-pipeline)
+ else()
+-  message(FATAL_ERROR the "Check WEBOS_TARGET_MACHINE: " ${WEBOS_TARGET_MACHINE})
++  message(STATUS "Using config & debug file for generic device (might not always work)")
++  install(FILES ./generic/gst_debug.conf DESTINATION /etc/g-media-pipeline)
++  install(FILES ./generic/gst_elements.conf DESTINATION /etc/g-media-pipeline)
+ endif()
+ 
+ install(TARGETS gmp-player DESTINATION lib)
+diff --git a/src/player/generic/gst_debug.conf b/src/player/generic/gst_debug.conf
+new file mode 100644
+index 0000000..7345ee7
+--- /dev/null
++++ b/src/player/generic/gst_debug.conf
+@@ -0,0 +1,11 @@
++{
++    "license" : "Copyright (c) 2018-2019 LG Electronics, Inc. Licensed under the Apache License, Version 2.0 (the \"License\");  you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 ss required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. SPDX-License-Identifier: Apache-2.0",
++
++    "gst_debug" : [
++        {
++            "GST_DEBUG" : "",
++            "GST_DEBUG_FILE" : "/tmp/gst.log",
++            "GST_DEBUG_DUMP_DOT_DIR" : "/tmp"
++        }
++    ]
++}
+diff --git a/src/player/generic/gst_elements.conf b/src/player/generic/gst_elements.conf
+new file mode 100644
+index 0000000..336c813
+--- /dev/null
++++ b/src/player/generic/gst_elements.conf
+@@ -0,0 +1,65 @@
++{
++    "license" : "Copyright (c) 2018-2020 LG Electronics, Inc. Licensed under the Apache License, Version 2.0 (the \"License\");  you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 ss required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. SPDX-License-Identifier: Apache-2.0",
++    "platform" : "generic",
++    "use_audio" : 1,
++    "gst_elements" : [
++        {
++            "audio-sink" : {"name" : "pulsesink",
++                "device" : [ "default1",
++                             "default2"]
++            },
++            "video-sink" : {"name" : "waylandsink",
++                "properties" : {
++                    "use-drmbuf" : true
++                }
++            },
++            "video-converter" : {"name" : "videoconvert"}
++        },
++        {
++            "audio-sink" : {"name" : "pulsesink",
++                "device" : [ "default1",
++                             "default2"]
++            },
++            "video-sink" : {"name" : "waylandsink",
++                "properties" : {
++                    "use-drmbuf" : true
++                }
++            },
++            "video-converter" : {"name" : "videoconvert",
++                "properties" : {
++                    "caps" : "video/x-raw, format=RGB16"
++                }
++            },
++            "video-queue" : {"name" : ""},
++
++            "audio-codec-aac" : {"name" : "avdec_aac"},
++            "audio-codec-mp3" : {"name" : ""},
++            "audio-codec-pcm" : {"name" : "adpcmdec"},
++            "audio-codec-vorbis" : {"name" : ""},
++            "audio-codec-flac" : {"name" : ""},
++            "audio-codec-amr_nb" : {"name" : ""},
++            "audio-codec-amr_wb" : {"name" : ""},
++            "audio-codec-pcm_mulaw" : {"name" : ""},
++            "audio-codec-gsm_ms" : {"name" : ""},
++            "audio-codec-pcm_s16be" : {"name" : ""},
++            "audio-codec-pcm_s24be" : {"name" : ""},
++            "audio-codec-opus" : {"name" : ""},
++            "audio-codec-eac3" : {"name" : "avdec_ac3"},
++            "audio-codec-pcm_alaw" : {"name" : ""},
++            "audio-codec-alac" : {"name" : ""},
++            "audio-codec-ac3" : {"name" : "avdec_ac3"},
++            "audio-codec-dts" : {"name" : "avdec_dca"},
++
++            "video-codec-h264" : {"name" : "avdec_264"},
++
++            "video-codec-vc1" : {"name" : "avdec_vc1"},
++            "video-codec-mpeg2" : {"name" : ""},
++            "video-codec-mpeg4" : {"name" : ""},
++            "video-codec-theora" : {"name" : ""},
++            "video-codec-vp8" : {"name" : "avdec_vp8"},
++            "video-codec-vp9" : {"name" : "avdec_vp9"},
++            "video-codec-h265" : {"name" : "avdec_h265"},
++            "video-codec-mjpeg" : {"name" : ""}
++        }
++    ]
++}

--- a/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline/0002-Fix-incorrect-include-name.patch
+++ b/meta-luneos/recipes-multimedia/g-media-pipeline/g-media-pipeline/0002-Fix-incorrect-include-name.patch
@@ -1,0 +1,24 @@
+From 0cb5f510b7c5c5af4bb0d794e611b479d97d8dd9 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Mon, 22 Jan 2024 08:43:32 +0100
+Subject: [PATCH] Fix incorrect include name
+
+---
+Upstream-Status: Inappropriate [LuneOS specific]
+
+ src/player/UriPlayer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/player/UriPlayer.cpp b/src/player/UriPlayer.cpp
+index 4c53429..66cb3b9 100644
+--- a/src/player/UriPlayer.cpp
++++ b/src/player/UriPlayer.cpp
+@@ -24,7 +24,7 @@
+ #include <sys/types.h>
+ #include <unistd.h>
+ #include <gst/video/videooverlay.h>
+-#include <gst/codecparsers/gsth264parse.h>
++#include <gst/codecparsers/gsth264parser.h>
+ #include "ElementFactory.h"
+ 
+ #include "parser/parser.h"

--- a/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0006-fix-Webex-meeting-Participant-video-screen-is-gray.patch
+++ b/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad/0006-fix-Webex-meeting-Participant-video-screen-is-gray.patch
@@ -1,0 +1,69 @@
+From 5c249cc35625e5b0cbb088be5cb1a67a2c264914 Mon Sep 17 00:00:00 2001
+From: Veeresh Kadasani <veeresh.kadasani@lge.com>
+Date: Wed, 23 Aug 2023 15:14:05 +0530
+Subject: [PATCH] fix Webex meeting Participant video screen is gray
+
+:Release Notes:
+fix Webex meeting Opposite Participant video screen gray-boxed artifacts
+
+:Detailed Notes:
+when Webex meeting is started from windows webx app with
+HW accelerator enabled the video at the receiver show
+gray-boxed artifacts because of strange start code pattern
+[00 00 00 01 00 00 00 00 01] seen in the encoded stream.
+fixed this in hs264parse to treat the strange patter to
+correct start code [00 00 00 01].
+
+:Testing Performed:
+webx meeting from windows app with HW accelerator enabled
+
+:QA Notes:
+NA
+
+:Issues Addressed:
+[WRP-22692] [OSE RPi4 - VCS] Webex meeting Opposite Participant
+video screen is gray-boxed or appears broken
+
+Signed-off-by: Veeresh Kadasani <veeresh.kadasani@lge.com>
+---
+Upstream-Status: Submitted [http://gpro.lge.com/c/webos-pro/gst-plugins-bad/+/378479 fix Webex meeting Participant video screen is gray]
+
+ gst-libs/gst/codecparsers/gsth264parser.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/codecparsers/gsth264parser.c b/gst-libs/gst/codecparsers/gsth264parser.c
+index ec5cd3a..334aa36 100644
+--- a/gst-libs/gst/codecparsers/gsth264parser.c
++++ b/gst-libs/gst/codecparsers/gsth264parser.c
+@@ -1433,7 +1433,7 @@ GstH264ParserResult
+ gst_h264_parser_identify_nalu_unchecked (GstH264NalParser * nalparser,
+     const guint8 * data, guint offset, gsize size, GstH264NalUnit * nalu)
+ {
+-  gint off1;
++  gint off1, off2;
+ 
+   memset (nalu, 0, sizeof (*nalu));
+ 
+@@ -1460,6 +1460,22 @@ gst_h264_parser_identify_nalu_unchecked (GstH264NalParser * nalparser,
+   nalu->data = (guint8 *) data;
+   nalu->size = size - nalu->offset;
+ 
++  /*
++   * work around for webx strange start code [0x000000010000000001]
++   * when HW encoding enabled using webx app from windows.
++   */
++  off2 = scan_for_start_codes (data + nalu->offset, size - nalu->offset);
++  if (off2 >= 0 && off2 <= 2) {
++      guint tmp_sc_offset = 0;
++      tmp_sc_offset = nalu->sc_offset + off2;
++      if (tmp_sc_offset > 0 && (data[tmp_sc_offset - 1] == 00) && (data[tmp_sc_offset - 2] == 00)) {
++          nalu->sc_offset = tmp_sc_offset - 1;
++          nalu->offset = nalu->offset + off2 + 3;
++          nalu->data = (guint8 *) data;
++          nalu->size = size - nalu->offset;
++      }
++  }
++
+   if (!gst_h264_parse_nalu_header (nalu)) {
+     GST_WARNING ("error parsing \"NAL unit header\"");
+     nalu->size = 0;

--- a/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.22.%.bbappend
+++ b/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.22.%.bbappend
@@ -7,7 +7,8 @@ EXTENDPRAUTO:append = "webos6"
 PACKAGECONFIG:remove = "rsvg"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
-SRC_URI:append:qemuall = " \
+SRC_URI:append = " \
     file://0004-waylandsink-remove-unsupported-subcompositor.patch;striplevel=3 \
     file://0005-h264parse-resolution-changed-event-support.patch;striplevel=3 \
+    file://0006-fix-Webex-meeting-Participant-video-screen-is-gray.patch \
 "

--- a/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0_1.22.%.bbappend
+++ b/meta-luneos/recipes-multimedia/gstreamer/gstreamer1.0_1.22.%.bbappend
@@ -13,5 +13,6 @@ EXTENDPRAUTO:append = "webos4"
 PACKAGECONFIG[tests] = "-Dtests=enabled -Dinstalled_tests=true,-Dtests=disabled -Dinstalled_tests=false,gsl gmp"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
-SRC_URI:append:qemux86 = " file://0001-Add-support-for-seamless-seek-trickplay.patch"
-SRC_URI:append:qemux86-64 = " file://0001-Add-support-for-seamless-seek-trickplay.patch"
+SRC_URI:append = " file://0001-Add-support-for-seamless-seek-trickplay.patch"
+#SRC_URI:append:qemux86 = " file://0001-Add-support-for-seamless-seek-trickplay.patch"
+#SRC_URI:append:qemux86-64 = " file://0001-Add-support-for-seamless-seek-trickplay.patch"

--- a/meta-luneos/recipes-multimedia/media-codec-interface/media-codec-interface.bb
+++ b/meta-luneos/recipes-multimedia/media-codec-interface/media-codec-interface.bb
@@ -17,7 +17,8 @@ inherit webos_machine_impl_dep
 inherit webos_machine_dep
 inherit webos_pkgconfig
 
-COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
+#In LuneOS we want this for all machines
+#COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
 
 DEPENDS = "boost gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad umediaserver media-resource-calculator"
 DEPENDS:append:rpi = " virtual/libomxil"

--- a/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera.bb
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera.bb
@@ -29,7 +29,9 @@ PACKAGECONFIG ??= " \
 
 PACKAGECONFIG[webos-aiframework] = "-DWITH_AIFRAMEWORK=ON,-DWITH_AIFRAMEWORK=OFF,edgeai-vision"
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+          file://0001-com.webos.service.camera2-Fix-outbound-permission-er.patch \
+"
 S = "${WORKDIR}/git"
 
 inherit webos_systemd

--- a/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera.bb
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera.bb
@@ -35,16 +35,6 @@ S = "${WORKDIR}/git"
 inherit webos_systemd
 WEBOS_SYSTEMD_SERVICE = "com.webos.service.camera.service"
 
-# All service files will be managed in meta-lg-webos.
-# The service file in the repository is not used, so please delete it.
-# See the page below for more details.
-# http://collab.lge.com/main/pages/viewpage.action?pageId=2031668745
-do_install:append() {
-    rm ${D}${sysconfdir}/systemd/system/com.webos.service.camera.service
-}
-
-COMPATIBLE_MACHINE = "(.*)"
-
 inherit useradd
 USERADD_PACKAGES = "${PN}"
 

--- a/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera/0001-com.webos.service.camera2-Fix-outbound-permission-er.patch
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.camera/com.webos.service.camera/0001-com.webos.service.camera2-Fix-outbound-permission-er.patch
@@ -1,0 +1,32 @@
+From 1e4ba69d16ea087f3b3a31fa45610b752a26f4f6 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Fri, 19 Apr 2024 14:43:56 +0200
+Subject: [PATCH] com.webos.service.camera2: Fix outbound permission error to
+ com.webos.app.camera
+
+Fixes:
+
+Apr 19 12:52:45 qemux86-64 ls-hubd[96]: [] [pmlog] ls-hubd LSHUB_NO_NAME_PERMS {} Can not find match for 'com.webos.app.camera-718' in pattern queue '["org.webosports.service.pdm", "org.webosports.service.notification", "org.webosports.pdm", "org.webosports.notification", "org.webosinternals.service.pdm", "org.webosinternals.service.notification", "org.webosinternals.pdm", "org.webosinternals.notification", "com.webos.service.pdm", "com.webos.notification", "com.palm.service.pdm", "com.palm.service.notification", "com.palm.pdm", "com.palm.notification", "com.lge.pdm", "com.lge.notification"]'
+Apr 19 12:52:45 qemux86-64 ls-hubd[96]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.app.camera-718","SRC_APP_ID":"com.webos.service.camera2","EXE":"/usr/sbin/com.webos.service.camera2","PID":772} "com.webos.service.camera2" does not have sufficient outbound permissions to communicate with "com.webos.app.camera-718" (cmdline: /usr/sbin/com.webos.service.camera2)
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Pending
+
+ files/sysbus/com.webos.service.camera2.role.json.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/files/sysbus/com.webos.service.camera2.role.json.in b/files/sysbus/com.webos.service.camera2.role.json.in
+index 9b78b04..f83e47a 100755
+--- a/files/sysbus/com.webos.service.camera2.role.json.in
++++ b/files/sysbus/com.webos.service.camera2.role.json.in
+@@ -8,7 +8,8 @@
+             "service": "com.webos.service.camera2",
+             "outbound": [
+                 "com.webos.service.pdm",
+-                "com.webos.notification"
++                "com.webos.notification",
++                "com.webos.app.camera-*"
+             ]
+         },
+         {

--- a/meta-luneos/recipes-webos-ose/g-camera-pipeline/g-camera-pipeline.bb
+++ b/meta-luneos/recipes-webos-ose/g-camera-pipeline/g-camera-pipeline.bb
@@ -14,6 +14,7 @@ inherit webos_cmake
 inherit webos_system_bus
 inherit webos_public_repo
 inherit webos_enhanced_submissions
+inherit webos_machine_dep
 inherit pkgconfig
 
 PR = "r14"
@@ -21,12 +22,15 @@ PR = "r14"
 DEPENDS = "boost gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad pkgconfig umediaserver media-resource-calculator com.webos.service.camera webos-wayland-extensions"
 DEPENDS:append:rpi = " userland"
 
-COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
+#In LuneOS we want this for all machines
+#COMPATIBLE_MACHINE = "^qemux86$|^qemux86-64$|^raspberrypi3$|^raspberrypi3-64$|^raspberrypi4$|^raspberrypi4-64$"
 
 WEBOS_VERSION = "1.0.0-gav.44_efe4ae4576379afe03abbf71fe430c8b360bc838"
 
 WEBOS_GIT_PARAM_BRANCH = "@gav"
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+    file://0001-g-camera-pipeline-Add-generic-config.patch \
+"
 
 S = "${WORKDIR}/git"
 

--- a/meta-luneos/recipes-webos-ose/g-camera-pipeline/g-camera-pipeline/0001-g-camera-pipeline-Add-generic-config.patch
+++ b/meta-luneos/recipes-webos-ose/g-camera-pipeline/g-camera-pipeline/0001-g-camera-pipeline-Add-generic-config.patch
@@ -1,0 +1,115 @@
+From b75d872db40639aa2b605f17da5db2db135339b6 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Mon, 22 Jan 2024 06:38:15 +0100
+Subject: [PATCH] g-camera-pipeline: Add generic config
+
+So we can build on other targets as well.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [LuneOS specific]
+
+ src/cameraplayer/CMakeLists.txt            |  4 +-
+ src/cameraplayer/generic/gst_debug.conf    | 11 ++++
+ src/cameraplayer/generic/gst_elements.conf | 59 ++++++++++++++++++++++
+ 3 files changed, 73 insertions(+), 1 deletion(-)
+ create mode 100644 src/cameraplayer/generic/gst_debug.conf
+ create mode 100644 src/cameraplayer/generic/gst_elements.conf
+
+diff --git a/src/cameraplayer/CMakeLists.txt b/src/cameraplayer/CMakeLists.txt
+index a146bb7..16c38da 100755
+--- a/src/cameraplayer/CMakeLists.txt
++++ b/src/cameraplayer/CMakeLists.txt
+@@ -151,7 +151,9 @@ elseif (${WEBOS_TARGET_MACHINE} STREQUAL "qemux86" OR ${WEBOS_TARGET_MACHINE} ST
+   install(FILES ./qemux86/gst_debug.conf DESTINATION /etc/g-camera-pipeline)
+   install(FILES ./qemux86/gst_elements.conf DESTINATION /etc/g-camera-pipeline)
+ else()
+-  message(FATAL_ERROR the "Check WEBOS_TARGET_MACHINE: " ${WEBOS_TARGET_MACHINE})
++  message(Status "Using generic config files for machine: " ${WEBOS_TARGET_MACHINE})
++  install(FILES ./generic/gst_debug.conf DESTINATION /etc/g-camera-pipeline)
++  install(FILES ./generic/gst_elements.conf DESTINATION /etc/g-camera-pipeline)
+ endif()
+ 
+ install(TARGETS cmp-player DESTINATION lib)
+diff --git a/src/cameraplayer/generic/gst_debug.conf b/src/cameraplayer/generic/gst_debug.conf
+new file mode 100644
+index 0000000..96dbe5e
+--- /dev/null
++++ b/src/cameraplayer/generic/gst_debug.conf
+@@ -0,0 +1,11 @@
++{
++    "license" : "Copyright (c) 2021 LG Electronics, Inc. Licensed under the Apache License, Version 2.0 (the \"License\");  you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 ss required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. SPDX-License-Identifier: Apache-2.0",
++
++    "gst_debug" : [
++        {
++            "GST_DEBUG" : "",
++            "GST_DEBUG_FILE" : "/tmp/gst.log",
++            "GST_DEBUG_DUMP_DOT_DIR" : "/tmp"
++        }
++    ]
++}
+diff --git a/src/cameraplayer/generic/gst_elements.conf b/src/cameraplayer/generic/gst_elements.conf
+new file mode 100644
+index 0000000..98ec52c
+--- /dev/null
++++ b/src/cameraplayer/generic/gst_elements.conf
+@@ -0,0 +1,59 @@
++{
++    "license" : "Copyright (c) 2021 LG Electronics, Inc. Licensed under the Apache License, Version 2.0 (the \"License\");  you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 ss required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. SPDX-License-Identifier: Apache-2.0",
++    "platform" : "Generic Platform",
++    "gst_elements" : [
++        {
++            "audio-sink" : {"name" : "alsasink",
++                "properties" : {
++                    "device" : "hw:0,0"
++                }
++            },
++            "video-sink" : {"name" : "waylandsink"},
++            "video-converter" : {"name" : "videoconvert"}
++        },
++        {
++            "audio-sink" : {"name" : "alsasink",
++                "properties" : {
++                    "device" : "hw:0,0"
++                }
++            },
++            "audiosink-queue" : {"name" : "queue"},
++            "video-sink" : {"name" : "waylandsink"},
++            "video-converter" : {"name" : "videoconvert",
++                "properties" : {
++                    "caps" : "video/x-raw, format=RGB16"
++                }
++            },
++            "video-queue" : "",
++
++            "audio-codec-aac" : {"name" : "avdec_aac"},
++            "audio-codec-mp3" : {"name" : ""},
++            "audio-codec-pcm" : {"name" : "adpcmdec"},
++            "audio-codec-vorbis" : {"name" : ""},
++            "audio-codec-flac" : {"name" : ""},
++            "audio-codec-amr_nb" : {"name" : ""},
++            "audio-codec-amr_wb" : {"name" : ""},
++            "audio-codec-pcm_mulaw" : {"name" : ""},
++            "audio-codec-gsm_ms" : {"name" : ""},
++            "audio-codec-pcm_s16be" : {"name" : ""},
++            "audio-codec-pcm_s24be" : {"name" : ""},
++            "audio-codec-opus" : {"name" : ""},
++            "audio-codec-eac3" : {"name" : "avdec_ac3"},
++            "audio-codec-pcm_alaw" : {"name" : ""},
++            "audio-codec-alac" : {"name" : ""},
++            "audio-codec-ac3" : {"name" : "avdec_ac3"},
++            "audio-codec-dts" : {"name" : "avdec_dca"},
++
++            "video-codec-h264" : {"name" : ""},
++
++            "video-codec-vc1" : {"name" : ""},
++            "video-codec-mpeg2" : {"name" : ""},
++            "video-codec-mpeg4" : {"name" : ""},
++            "video-codec-theora" : {"name" : ""},
++            "video-codec-vp8" : {"name" : ""},
++            "video-codec-vp9" : {"name" : ""},
++            "video-codec-h265" : {"name" : "avdec_h265"},
++            "video-codec-mjpeg" : {"name" : "jpegdec"}
++        }
++    ]
++}

--- a/meta-luneos/recipes-webos-ose/media-resource-calculator/media-resource-calculator.bb
+++ b/meta-luneos/recipes-webos-ose/media-resource-calculator/media-resource-calculator.bb
@@ -20,6 +20,11 @@ inherit webos_cmake
 inherit pkgconfig
 inherit webos_public_repo
 inherit webos_enhanced_submissions
+inherit webos_machine_dep
 
-SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
+          file://0001-media-resource-calculator-Add-generic-config-files.patch \
+"
 S = "${WORKDIR}/git"

--- a/meta-luneos/recipes-webos-ose/media-resource-calculator/media-resource-calculator/0001-media-resource-calculator-Add-generic-config-files.patch
+++ b/meta-luneos/recipes-webos-ose/media-resource-calculator/media-resource-calculator/0001-media-resource-calculator-Add-generic-config-files.patch
@@ -1,0 +1,271 @@
+From 29ff9a02c767cf7c2c46c808aca906e7ab4a90e5 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Mon, 22 Jan 2024 06:18:11 +0100
+Subject: [PATCH] media-resource-calculator: Add generic config files
+
+So we can build it on every target even though the config might not 100% correct, at least it can build.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [LuneOS specific]
+
+---
+ calculator/CMakeLists.txt          | 13 +++-
+ calculator/resource_calculator.cpp |  5 +-
+ data/generic_adec.json             |  5 ++
+ data/generic_disp.json             |  3 +
+ data/generic_vdec.json             | 97 ++++++++++++++++++++++++++++++
+ data/generic_venc.json             | 78 ++++++++++++++++++++++++
+ 6 files changed, 199 insertions(+), 2 deletions(-)
+ create mode 100644 data/generic_adec.json
+ create mode 100644 data/generic_disp.json
+ create mode 100644 data/generic_vdec.json
+ create mode 100644 data/generic_venc.json
+
+diff --git a/calculator/CMakeLists.txt b/calculator/CMakeLists.txt
+index 8a2dcca..f5aafd7 100644
+--- a/calculator/CMakeLists.txt
++++ b/calculator/CMakeLists.txt
+@@ -82,7 +82,18 @@ elseif(${WEBOS_TARGET_MACHINE} MATCHES "qemux86" OR ${WEBOS_TARGET_MACHINE} MATC
+   set(DISP_RESOURCE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/disp_resources_qemux86.h)
+ 
+ else()
+-  message("Check the resource calculator json files")
++  message("Build resource calculator for generic platform")
++
++  add_definitions(-DPLATFORM_GENERIC)
++
++  set(ADEC_RESOURCE_JSON ../data/generic_adec.json)
++  set(VDEC_RESOURCE_JSON ../data/generic_vdec.json)
++  set(VENC_RESOURCE_JSON ../data/generic_venc.json)
++  set(DISP_RESOURCE_JSON ../data/generic_disp.json)
++  set(ADEC_RESOURCE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/adec_resources_generic.h)
++  set(VDEC_RESOURCE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/vdec_resources_generic.h)
++  set(VENC_RESOURCE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/venc_resources_generic.h)
++  set(DISP_RESOURCE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/disp_resources_generic.h)
+ endif()
+ 
+ # Generate resource headers from resource json files
+diff --git a/calculator/resource_calculator.cpp b/calculator/resource_calculator.cpp
+index 6e6acb5..af1fd0a 100644
+--- a/calculator/resource_calculator.cpp
++++ b/calculator/resource_calculator.cpp
+@@ -43,7 +43,10 @@
+ #include "disp_resources_qemux86.h"
+ 
+ #else
+-#  error "platform is not specified"
++#include "adec_resources_generic.h"
++#include "vdec_resources_generic.h"
++#include "venc_resources_generic.h"
++#include "disp_resources_generic.h"
+ #endif
+ 
+ namespace mrc {
+diff --git a/data/generic_adec.json b/data/generic_adec.json
+new file mode 100644
+index 0000000..3b33828
+--- /dev/null
++++ b/data/generic_adec.json
+@@ -0,0 +1,5 @@
++{
++  "default": {
++    "ADEC": 1
++  }
++}
+diff --git a/data/generic_disp.json b/data/generic_disp.json
+new file mode 100644
+index 0000000..c0305ba
+--- /dev/null
++++ b/data/generic_disp.json
+@@ -0,0 +1,3 @@
++{
++  "DISP": {"DISP": 1}
++}
+diff --git a/data/generic_vdec.json b/data/generic_vdec.json
+new file mode 100644
+index 0000000..4e7d2c9
+--- /dev/null
++++ b/data/generic_vdec.json
+@@ -0,0 +1,97 @@
++{
++  "H265": {
++    "1280*720 0p": { "VDEC": 8 },
++    "1280*720 24p": { "VDEC": 8 },
++    "1280*720 30p": { "VDEC": 8 },
++    "1280*720 60p": { "VDEC": 8 },
++    "1280*720 120p": { "VDEC": 8 },
++    "1920*1080 0p": { "VDEC": 8 },
++    "1920*1080 24p": { "VDEC": 8 },
++    "1920*1080 30p": { "VDEC": 8 },
++    "1920*1080 60p": { "VDEC": 8 },
++    "3840*2160 0p": { "VDEC": 8 },
++    "3840*2160 24p": { "VDEC": 8 },
++    "3840*2160 30p": { "VDEC": 8 },
++    "4096*2160 0p": { "VDEC": 8 },
++    "4096*2160 24p": { "VDEC": 8 },
++    "4096*2160 30p": { "VDEC": 8 },
++    "4096*2304 0p": { "VDEC": 8 },
++    "4096*2304 15p": { "VDEC": 8 }
++  },
++  "H264": {
++    "1280*720 24p": { "VDEC": 8 },
++    "1280*720 30p": { "VDEC": 8 },
++    "1280*720 60p": { "VDEC": 8 },
++    "1280*720 120p": { "VDEC": 8 },
++    "1280*720 0p": { "VDEC": 8},
++    "1920*1080 24p": { "VDEC": 8 },
++    "1920*1080 30p": { "VDEC": 8 },
++    "1920*1080 60p": { "VDEC": 8 },
++    "1920*1080 0p": { "VDEC": 8 },
++    "3840*2160 0p": { "VDEC": 8 },
++    "3840*2160 24p": { "VDEC": 8 },
++    "3840*2160 30p": { "VDEC": 8 },
++    "4096*2160 0p": { "VDEC": 8 },
++    "4096*2160 24p": { "VDEC": 8 },
++    "4096*2160 30p": { "VDEC": 8 },
++    "4096*2304 0p": { "VDEC": 8 },
++    "4096*2304 15p": { "VDEC": 8 }
++  },
++  "VP8": {
++    "1280*720 0p": { "VDEC": 8 },
++    "1280*720 24p": { "VDEC": 8 },
++    "1280*720 30p": { "VDEC": 8 },
++    "1280*720 60p": { "VDEC": 8 },
++    "1280*720 120p": { "VDEC": 8 },
++    "1920*1080 0p": { "VDEC": 8 },
++    "1920*1080 24p": { "VDEC": 8 },
++    "1920*1080 30p": { "VDEC": 8 },
++    "1920*1080 60p": { "VDEC": 8 },
++    "3840*2160 0p": { "VDEC": 8 },
++    "3840*2160 24p": { "VDEC": 8 },
++    "3840*2160 30p": { "VDEC": 8 },
++    "4096*2160 0p": { "VDEC": 8 },
++    "4096*2160 24p": { "VDEC": 8 },
++    "4096*2160 30p": { "VDEC": 8 },
++    "4096*2304 0p": { "VDEC": 8 },
++    "4096*2304 15p": { "VDEC": 8 }
++  },
++  "VP9": {
++    "1280*720 0p": { "VDEC": 8 },
++    "1280*720 24p": { "VDEC": 8 },
++    "1280*720 30p": { "VDEC": 8 },
++    "1280*720 60p": { "VDEC": 8 },
++    "1280*720 120p": { "VDEC": 8 },
++    "1920*1080 0p": { "VDEC": 8 },
++    "1920*1080 24p": { "VDEC": 8 },
++    "1920*1080 30p": { "VDEC": 8 },
++    "1920*1080 60p": { "VDEC": 8 },
++    "3840*2160 0p": { "VDEC": 8 },
++    "3840*2160 24p": { "VDEC": 8 },
++    "3840*2160 30p": { "VDEC": 8 },
++    "4096*2160 0p": { "VDEC": 8 },
++    "4096*2160 24p": { "VDEC": 8 },
++    "4096*2160 30p": { "VDEC": 8 },
++    "4096*2304 0p": { "VDEC": 8 },
++    "4096*2304 15p": { "VDEC": 8 }
++  },
++  "default": {
++    "1280*720 24p": { "VDEC": 8 },
++    "1280*720 30p": { "VDEC": 8 },
++    "1280*720 60p": { "VDEC": 8 },
++    "1280*720 120p": { "VDEC": 8 },
++    "1280*720 0p": { "VDEC": 8},
++    "1920*1080 24p": { "VDEC": 8 },
++    "1920*1080 30p": { "VDEC": 8 },
++    "1920*1080 60p": { "VDEC": 8 },
++    "1920*1080 0p": { "VDEC": 8 },
++    "3840*2160 0p": { "VDEC": 8 },
++    "3840*2160 24p": { "VDEC": 8 },
++    "3840*2160 30p": { "VDEC": 8 },
++    "4096*2160 0p": { "VDEC": 8 },
++    "4096*2160 24p": { "VDEC": 8 },
++    "4096*2160 30p": { "VDEC": 8 },
++    "4096*2304 0p": { "VDEC": 8 },
++    "4096*2304 15p": { "VDEC": 8 }
++  }
++}
+diff --git a/data/generic_venc.json b/data/generic_venc.json
+new file mode 100644
+index 0000000..6b16700
+--- /dev/null
++++ b/data/generic_venc.json
+@@ -0,0 +1,78 @@
++{
++  "H264": {
++    "1280*720 0p": { "VENC": 2 },
++    "1280*720 24p": { "VENC": 1 },
++    "1280*720 30p": { "VENC": 1 },
++    "1280*720 60p": { "VENC": 1 },
++    "1280*720 120p": { "VENC": 2 },
++    "1920*1080 0p": { "VENC": 2 },
++    "1920*1080 24p": { "VENC": 1 },
++    "1920*1080 30p": { "VENC": 1 },
++    "1920*1080 60p": { "VENC": 2 },
++    "3840*2160 0p": { "VENC": 4 },
++    "3840*2160 24p": { "VENC": 4 },
++    "3840*2160 30p": { "VENC": 4 },
++    "4096*2160 0p": { "VENC": 5 },
++    "4096*2160 24p": { "VENC": 5 },
++    "4096*2160 30p": { "VENC": 5 },
++    "4096*2304 0p": { "VENC": 8 },
++    "4096*2304 15p": { "VENC": 8 }
++  },
++  "H265": {
++    "1280*720 0p": { "VENC": 2 },
++    "1280*720 24p": { "VENC": 1 },
++    "1280*720 30p": { "VENC": 1 },
++    "1280*720 60p": { "VENC": 1 },
++    "1280*720 120p": { "VENC": 2 },
++    "1920*1080 0p": { "VENC": 2 },
++    "1920*1080 24p": { "VENC": 1 },
++    "1920*1080 30p": { "VENC": 1 },
++    "1920*1080 60p": { "VENC": 2 },
++    "3840*2160 0p": { "VENC": 4 },
++    "3840*2160 24p": { "VENC": 4 },
++    "3840*2160 30p": { "VENC": 4 },
++    "4096*2160 0p": { "VENC": 5 },
++    "4096*2160 24p": { "VENC": 5 },
++    "4096*2160 30p": { "VENC": 5 },
++    "4096*2304 0p": { "VENC": 8 },
++    "4096*2304 15p": { "VENC": 8 }
++  },
++  "VP8": {
++    "1280*720 0p": { "VENC": 2 },
++    "1280*720 24p": { "VENC": 1 },
++    "1280*720 30p": { "VENC": 1 },
++    "1280*720 60p": { "VENC": 1 },
++    "1280*720 120p": { "VENC": 2 },
++    "1920*1080 0p": { "VENC": 2 },
++    "1920*1080 24p": { "VENC": 1 },
++    "1920*1080 30p": { "VENC": 1 },
++    "1920*1080 60p": { "VENC": 2 },
++    "3840*2160 0p": { "VENC": 4 },
++    "3840*2160 24p": { "VENC": 4 },
++    "3840*2160 30p": { "VENC": 4 },
++    "4096*2160 0p": { "VENC": 5 },
++    "4096*2160 24p": { "VENC": 5 },
++    "4096*2160 30p": { "VENC": 5 },
++    "4096*2304 0p": { "VENC": 8 },
++    "4096*2304 15p": { "VENC": 8 }
++  },
++  "default": {
++    "1280*720 0p": { "VENC": 2 },
++    "1280*720 24p": { "VENC": 1 },
++    "1280*720 30p": { "VENC": 1 },
++    "1280*720 60p": { "VENC": 1 },
++    "1280*720 120p": { "VENC": 2 },
++    "1920*1080 0p": { "VENC": 2 },
++    "1920*1080 24p": { "VENC": 1 },
++    "1920*1080 30p": { "VENC": 1 },
++    "1920*1080 60p": { "VENC": 2 },
++    "3840*2160 0p": { "VENC": 4 },
++    "3840*2160 24p": { "VENC": 4 },
++    "3840*2160 30p": { "VENC": 4 },
++    "4096*2160 0p": { "VENC": 5 },
++    "4096*2160 24p": { "VENC": 5 },
++    "4096*2160 30p": { "VENC": 5 },
++    "4096*2304 0p": { "VENC": 8 },
++    "4096*2304 15p": { "VENC": 8 }
++  }
++}

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0002-Update-webos-connman-adapter.role.json.in-Add-permis.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0002-Update-webos-connman-adapter.role.json.in-Add-permis.patch
@@ -1,8 +1,9 @@
-From 2660526b18cc9e2294e3f935c7c289ef56c76183 Mon Sep 17 00:00:00 2001
+From 945966a779ba7404fce318619fb1acd00c25bd1d Mon Sep 17 00:00:00 2001
 From: Herrie <Github.com@herrie.org>
 Date: Mon, 2 Oct 2023 10:29:27 +0200
 Subject: [PATCH] Update webos-connman-adapter.role.json.in: Add permissions to
- com.webos.service.downloadmanager|location and com.webos.lunasend-*
+ com.webos.service.downloadmanager|location and
+ com.webos.lunasend-*|com.webos.surfacemanager-*
 
 Fixes:
 
@@ -41,14 +42,14 @@ Upstream-Status: Submitted [https://github.com/webosose/webos-connman-adapter/pu
 
 Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
 ---
- files/sysbus/webos-connman-adapter.role.json.in | 15 ++++++++++++---
- 1 file changed, 15 insertions(+), 3 deletions(-)
+ .../sysbus/webos-connman-adapter.role.json.in | 21 ++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
 
 diff --git a/files/sysbus/webos-connman-adapter.role.json.in b/files/sysbus/webos-connman-adapter.role.json.in
-index 917c391..9a54aac 100644
+index 917c391..871409c 100644
 --- a/files/sysbus/webos-connman-adapter.role.json.in
 +++ b/files/sysbus/webos-connman-adapter.role.json.in
-@@ -10,10 +10,14 @@
+@@ -10,10 +10,15 @@
                          "com.webos.service.config",
                          "com.webos.service.connectionmanager",
                          "com.webos.service.eventmonitor",
@@ -60,11 +61,12 @@ index 917c391..9a54aac 100644
 +                        "com.webos.settingsservice",
 +                        "com.webos.service.downloadmanager",
 +                        "com.webos.lunasend-*",
++                        "com.webos.surfacemanager-*",
 +                        "org.webosports.service.update"]
          },
          {
              "service":"com.webos.service.connectionmanager",
-@@ -21,10 +24,14 @@
+@@ -21,10 +26,15 @@
                          "com.webos.service.config",
                          "com.webos.service.connectionmanager",
                          "com.webos.service.eventmonitor",
@@ -76,11 +78,12 @@ index 917c391..9a54aac 100644
 +                        "com.webos.settingsservice",
 +                        "com.webos.service.downloadmanager",
 +                        "com.webos.lunasend-*",
++                        "com.webos.surfacemanager-*",
 +                        "org.webosports.service.update"]
          },
          {
              "service":"com.webos.service.wan",
-@@ -32,10 +38,14 @@
+@@ -32,10 +42,15 @@
                          "com.webos.service.config",
                          "com.webos.service.connectionmanager",
                          "com.webos.service.eventmonitor",
@@ -92,6 +95,7 @@ index 917c391..9a54aac 100644
 +                        "com.webos.settingsservice",
 +                        "com.webos.service.downloadmanager",
 +                        "com.webos.lunasend-*",
++                        "com.webos.surfacemanager-*",
 +                        "org.webosports.service.update"]
          }
      ]


### PR DESCRIPTION
OSE made these device specific and therefore only support qemux86(-64) and RPi. Removed the device specific conditions and added support for other targets as well. These are mainly placeholders for now, but it will allow building and inclusion on images.