### PR TITLE
lttng-modules: Fix compilation with our Android Frankenkernels

### DIFF
--- a/meta-luneos/recipes-kernel/lttng/lttng-modules/0001-sched.h-Fix-compile-error-with-HMP-scheduler-used-in.patch
+++ b/meta-luneos/recipes-kernel/lttng/lttng-modules/0001-sched.h-Fix-compile-error-with-HMP-scheduler-used-in.patch
@@ -1,0 +1,39 @@
+From e9b8cd9dcd39f6f864eea2e12856e65cb3a82442 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Fri, 10 May 2024 08:34:29 +0200
+Subject: [PATCH] sched.h: Fix compile error with HMP scheduler used in the MSM
+ 4.9 kernels (tissot, mido, rosy, sargo)
+
+HMP scheduler which seems MSM kernel specific was introduced in the Mido, Tissot, Rosy and Sargo kernels with https://github.com/shr-distribution/linux/commit/dddcab78bdda9d63b5cf6ddcdc30f815d98e8d98 or similar commit such as https://github.com/shr-distribution/linux/commit/c662231a6bfe77e202254913f9c51d9377650e8f. However HMP support never made it in this way to mainline kernel in this way and lttng-modules doesn't accommodate for it.
+
+Simply patch it in here.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [LuneOS Specific]
+
+ include/instrumentation/events/sched.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/include/instrumentation/events/sched.h b/include/instrumentation/events/sched.h
+index 24cf37c8..ef7ac2f6 100644
+--- a/include/instrumentation/events/sched.h
++++ b/include/instrumentation/events/sched.h
+@@ -434,14 +434,15 @@ LTTNG_TRACEPOINT_EVENT(sched_switch,
+  */
+ LTTNG_TRACEPOINT_EVENT(sched_migrate_task,
+ 
+-	TP_PROTO(struct task_struct *p, int dest_cpu),
++	TP_PROTO(struct task_struct *p, int dest_cpu, unsigned int load),
+ 
+-	TP_ARGS(p, dest_cpu),
++	TP_ARGS(p, dest_cpu, load),
+ 
+ 	TP_FIELDS(
+ 		ctf_array_text(char, comm, p->comm, TASK_COMM_LEN)
+ 		ctf_integer(pid_t, tid, p->pid)
+ 		ctf_integer(int, prio, p->prio - MAX_RT_PRIO)
++		ctf_integer(unsigned int, load, load )
+ 		ctf_integer(int, orig_cpu, task_cpu(p))
+ 		ctf_integer(int, dest_cpu, dest_cpu)
+ 	)

--- a/meta-luneos/recipes-kernel/lttng/lttng-modules/0002-mm_vmscan.h-Update-the-kernel-version-check-for-mm_v.patch
+++ b/meta-luneos/recipes-kernel/lttng/lttng-modules/0002-mm_vmscan.h-Update-the-kernel-version-check-for-mm_v.patch
@@ -1,0 +1,28 @@
+From 2fab84f654cc1e120135426ad6fbabba866bd909 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Fri, 10 May 2024 09:27:30 +0200
+Subject: [PATCH] mm_vmscan.h: Update the kernel version check for
+ mm_vmscan_lru_isolate
+
+Seems that we have mm_vmscan_lru_isolate for Tissot, Mido and Sargo in 4.9 kernel due to https://github.com/shr-distribution/linux/commit/e6a14ff915c2cb0fb6f58d7d55efaa5e3b3f0fc5, even though this only hit in 4.11 in mainline kernel (https://github.com/torvalds/linux/commit/30b9aed8cd576964bff71a6c5f022ca30ac4c3b7).
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+Upstream-Status: Inappropriate [LuneOS Specific]
+
+ include/instrumentation/events/mm_vmscan.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/instrumentation/events/mm_vmscan.h b/include/instrumentation/events/mm_vmscan.h
+index ea6f4b78..6578f313 100644
+--- a/include/instrumentation/events/mm_vmscan.h
++++ b/include/instrumentation/events/mm_vmscan.h
+@@ -395,7 +395,7 @@ LTTNG_TRACEPOINT_EVENT(mm_vmscan_lru_isolate,
+ 		ctf_integer(int, lru, lru)
+ 	)
+ )
+-#elif (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(4,11,0))
++#elif (LTTNG_LINUX_VERSION_CODE >= LTTNG_KERNEL_VERSION(4,9,0))
+ LTTNG_TRACEPOINT_EVENT(mm_vmscan_lru_isolate,
+ 
+ 	TP_PROTO(int classzone_idx,

--- a/meta-luneos/recipes-kernel/lttng/lttng-modules_%.bbappend
+++ b/meta-luneos/recipes-kernel/lttng/lttng-modules_%.bbappend
@@ -1,0 +1,23 @@
+# Our Android Frankenkernels have some backports of patches and exotic patches that aren't in mainline, therefore patch lttng-modules in order to accomodate this.
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:mido-halium = " \
+    file://0001-sched.h-Fix-compile-error-with-HMP-scheduler-used-in.patch \
+    file://0002-mm_vmscan.h-Update-the-kernel-version-check-for-mm_v.patch \
+"
+
+SRC_URI:append:rosy = " \
+    file://0001-sched.h-Fix-compile-error-with-HMP-scheduler-used-in.patch \
+    file://0002-mm_vmscan.h-Update-the-kernel-version-check-for-mm_v.patch \
+"
+
+SRC_URI:append:sargo = " \
+    file://0001-sched.h-Fix-compile-error-with-HMP-scheduler-used-in.patch \
+    file://0002-mm_vmscan.h-Update-the-kernel-version-check-for-mm_v.patch \
+"
+
+SRC_URI:append:tissot = " \
+    file://0001-sched.h-Fix-compile-error-with-HMP-scheduler-used-in.patch \
+    file://0002-mm_vmscan.h-Update-the-kernel-version-check-for-mm_v.patch \
+"


### PR DESCRIPTION
Our Android Frankenkernels have some patches that aren't in mainline kernel or landed in a newer version, so lttng's kernel version check isn't valid.

Fixes the following for Mido, Rosy, Sargo and Tissot:

In file included from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/define_trace.h:87,
                 from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/instrumentation/events/sched.h:729,
                 from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/lttng-probe-sched.c:28:
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/tracepoint-event-impl.h:133:6: error: conflicting types for 'trace_sched_migrate_task'; have 'void(struct task_struct *, int)'
  133 | void trace_##_name(_proto);
      |      ^~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/tracepoint-event-impl.h:45:9: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP'
   45 |         LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP(map, name, map, PARAMS(proto), PARAMS(args))
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/tracepoint-event-impl.h:87:9: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_MAP'
   87 |         LTTNG_TRACEPOINT_EVENT_MAP(name, name,                          \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/instrumentation/events/sched.h:435:1: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT'
  435 | LTTNG_TRACEPOINT_EVENT(sched_migrate_task,
      | ^~~~~~~~~~~~~~~~~~~~~~
In file included from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/trace/events/sched.h:8,
                 from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/lttng-probe-sched.c:17:
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/linux/tracepoint.h:183:28: note: previous definition of 'trace_sched_migrate_task' with type 'void(struct task_struct *, int,  unsigned int)'
  183 |         static inline void trace_##name(proto)                          \
      |                            ^~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/linux/tracepoint.h:348:9: note: in expansion of macro '__DECLARE_TRACE'
  348 |         __DECLARE_TRACE(name, PARAMS(proto), PARAMS(args),              \
      |         ^~~~~~~~~~~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/linux/tracepoint.h:484:9: note: in expansion of macro 'DECLARE_TRACE'
  484 |         DECLARE_TRACE(name, PARAMS(proto), PARAMS(args))
      |         ^~~~~~~~~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/trace/events/sched.h:872:1: note: in expansion of macro 'TRACE_EVENT'
  872 | TRACE_EVENT(sched_migrate_task,
      | ^~~~~~~~~~~
In file included from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/define_trace.h:87,
                 from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/instrumentation/events/mm_vmscan.h:854,
                 from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/lttng-probe-vmscan.c:29:
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/tracepoint-event-impl.h:133:6: error: conflicting types for 'trace_mm_vmscan_lru_isolate'; have 'void(int,  int,  long unsigned int,  long unsigned int,  long unsigned int,  isolate_mode_t,  int)' {aka 'void(int,  int,  long unsigned int,  long unsigned int,  long unsigned int,  unsigned int,  int)'}
  133 | void trace_##_name(_proto);
      |      ^~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/lttng/tracepoint-event-impl.h:98:9: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP'
   98 |         LTTNG_TRACEPOINT_EVENT_INSTANCE_MAP(template, name, name, PARAMS(proto), PARAMS(args))
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/../../include/instrumentation/events/mm_vmscan.h:454:1: note: in expansion of macro 'LTTNG_TRACEPOINT_EVENT_INSTANCE'
  454 | LTTNG_TRACEPOINT_EVENT_INSTANCE(mm_vmscan_lru_isolate_template, mm_vmscan_lru_isolate,
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/trace/events/vmscan.h:8,
                 from /media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work/sargo-webos-linux/lttng-modules/2.13.12/lttng-modules-2.13.12/src/probes/lttng-probe-vmscan.c:18:
/media/herrie/LuneOS/scarthgap/webos-ports/tmp-glibc/work-shared/sargo/kernel-source/include/linux/tracepoint.h:183:28: note: previous definition of 'trace_mm_vmscan_lru_isolate' with type 'void(int,  int,  long unsigned int,  long unsigned int,  long unsigned int,  long unsigned int,  isolate_mode_t,  int)' {aka 'void(int,  int,  long unsigned int,  long unsigned int,  long unsigned int,  long unsigned int,  unsigned int,  int)'}