### PR TITLE
luna-sysmgr-conf:hammerhead: disable ALS

### DIFF
--- a/meta-luneos/recipes-webos-owo/luna-sysmgr-conf/luna-sysmgr-conf/hammerhead/luna-platform.conf
+++ b/meta-luneos/recipes-webos-owo/luna-sysmgr-conf/luna-sysmgr-conf/hammerhead/luna-platform.conf
@@ -28,7 +28,8 @@ DPI=445
 GridUnit=26
 
 [Display]
-EnableALS=true
+# the tls2772 mainline driver doesn't provide any illuminance_raw values for hammerhead
+EnableALS=false
 
 [Hardware]
 Type=device


### PR DESCRIPTION
The ALS iio sensor isn't correctly handled by sensorfw for now, so disable ALS on hammerhead to avoid getting a dark screen all the time.