### PR TITLE
mobile-broadband-provide-info: Split off Halium variant

### DIFF
--- a/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info-halium_git.bb
+++ b/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info-halium_git.bb
@@ -1,0 +1,22 @@
+#Mer uses their own version of MBPI which has some elements added. So we want to use their version only in case we're using their oFono version. In other cases where we use upstream oFono we want to use the regular MBPI from Yocto.
+
+SUMMARY = "Mobile Broadband Service Provider Database"
+HOMEPAGE = "http://live.gnome.org/NetworkManager/MobileBroadband/ServiceProviders"
+DESCRIPTION = "Mobile Broadband Service Provider Database stores service provider specific information. When this Database is available the information can be fetched there"
+SECTION = "network"
+LICENSE = "PD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=87964579b2a8ece4bc6744d2dc9a8b04"
+
+PV = "20131125"
+PE = "1"
+
+inherit autotools
+
+DEPENDS += "libxslt-native"
+
+SRC_URI  = "git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master"
+S = "${WORKDIR}/git/mobile-broadband-provider-info"
+
+SRCREV = "4a1617295360c10331e748e3a9f42311fbe3325c"
+
+FILES:${PN} += "${datadir}/mobile-broadband-provider-info"

--- a/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_git.bbappend
+++ b/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_git.bbappend
@@ -1,7 +1,0 @@
-#Mer uses their own version of MBPI which has some elements added. So we want to use their version only in case we're using their oFono version. In other cases where we use upstream oFono we want to use the regular MBPI from Yocto.
-
-SRC_URI:halium  = "git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master"
-S:halium = "${WORKDIR}/git/${PN}"
-
-SRCREV:halium = "fe500f1b19e8525d09655a38ac111a0fe127b5f9"
-LIC_FILES_CHKSUM:halium = "file://COPYING;md5=87964579b2a8ece4bc6744d2dc9a8b04"

--- a/meta-luneos/recipes-connectivity/ofono/ofono-halium_1.29.bb
+++ b/meta-luneos/recipes-connectivity/ofono/ofono-halium_1.29.bb
@@ -27,7 +27,7 @@ PV = "1.29+git"
 
 DEPENDS += "dbus-glib libmce-glib"
 # For Halium 9 devices we want to use the ofono-binder-plugin, for older devices we might want to use ofono-ril-plugin
-RDEPENDS:${PN} += "mobile-broadband-provider-info ofono-conf ofono-binder-plugin"
+RDEPENDS:${PN} += "mobile-broadband-provider-info-halium ofono-conf ofono-binder-plugin"
 
 S = "${WORKDIR}/git/ofono"
 # Can't build out of tree right now so we have to build in tree


### PR DESCRIPTION
Upstream uses Meson, Halium still uses Autotools.

This seems to be the easiest way to keep both working.