### PR TITLE
mobile-broadband-provider-info: Add meson.build for Halium

### DIFF
--- a/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provide-info/meson.build
+++ b/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provide-info/meson.build
@@ -1,0 +1,50 @@
+project(
+  'mobile-broadband-provider-info',
+  'c',
+  version: '20131125',
+  license: 'CERTIFICATION 1.0 US Deed ',
+  meson_version: '>= 1.0.0',
+)
+
+prefix = get_option('prefix')
+datadir = prefix / get_option('datadir')
+pkgdatadir = datadir / 'mobile-broadband-provider-info'
+database = pkgdatadir / 'serviceproviders.xml'
+sp_xml_db = meson.global_source_root() / 'serviceproviders.xml'
+
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  name: 'mobile-broadband-provider-info',
+  description: 'Mobile Broadband Service Provider Information Database',
+  variables: [
+    'pkgdatadir=@0@'.format(pkgdatadir),
+    'database=${pkgdatadir}/serviceproviders.xml',
+  ],
+  dataonly: true,
+)
+
+custom_target('build-apns-conf',
+  build_by_default: true,
+  output: 'apns-conf.xml',
+  input: 'apns-conf.xsl',
+  command: [find_program('xsltproc'), '--output', '@OUTPUT@', '@INPUT@', sp_xml_db],
+  install: true,
+  install_dir: pkgdatadir,
+)
+
+install_data(
+  [sp_xml_db, 'serviceproviders.2.dtd'],
+  install_dir: pkgdatadir,
+)
+
+test('check-blanks',
+     find_program('grep'),
+     args: ['^[[:blank:]]* [[:blank:]]*<\|[[:blank:]]$$', sp_xml_db],
+     # There shouldn't be any matches
+     should_fail: true,
+)
+
+test('xmllint',
+     find_program('xmllint'),
+     args: ['--valid', sp_xml_db])

--- a/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_git.bbappend
+++ b/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_git.bbappend
@@ -1,6 +1,10 @@
 #Mer uses their own version of MBPI which has some elements added. So we want to use their version only in case we're using their oFono version. In other cases where we use upstream oFono we want to use the regular MBPI from Yocto.
 
-SRC_URI:halium  = "git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master"
+SRC_URI:halium  = " \
+                    git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master \
+                    file://meson.build \
+"
+
 S:halium = "${WORKDIR}/git/${PN}"
 
 SRCREV:halium = "fe500f1b19e8525d09655a38ac111a0fe127b5f9"


### PR DESCRIPTION
Seeing upstream switched to Meson instead of Autotools, neeed to provide a meson.build.

Simply taken from upstream and changed the version string to match the one from Mer.

This will also install apns-conf.xml which we might want to use in oFono, similar to what UBPorts does using this plugin: https://gitlab.com/ubports/development/core/ofono-apndb-plugin