### PR TITLE
com.webos.service.mediarecorder: Fix build for Halium targets

### DIFF
--- a/meta-luneos/recipes-webos-ose/com.webos.service.mediarecorder/com.webos.service.mediarecorder.bb
+++ b/meta-luneos/recipes-webos-ose/com.webos.service.mediarecorder/com.webos.service.mediarecorder.bb
@@ -33,7 +33,7 @@ inherit webos_systemd
 WEBOS_SYSTEMD_SERVICE = "com.webos.service.mediarecorder.service"
 
 # Build a native app for testing the media recorder
-PACKAGECONFIG[test-apps] = "-DWITH_CAMERA_TEST=ON,-DWITH_CAMERA_TEST=OFF, webos-wayland-extensions mesa jpeg, ${PN}-test-apps"
+PACKAGECONFIG[test-apps] = "-DWITH_CAMERA_TEST=ON,-DWITH_CAMERA_TEST=OFF, webos-wayland-extensions virtual/mesa jpeg, ${PN}-test-apps"
 
 PACKAGES += "${PN}-test-apps"
 


### PR DESCRIPTION
Since mesa is provided by virtual/mesa by libhybris for Android/Halium targets.