### PR TITLE
webruntime: add Halium specific patch for DRI

### DIFF
--- a/meta-luneos/recipes-webos-ose/chromium/files/0001-Halium-Disable-DRI-build.patch
+++ b/meta-luneos/recipes-webos-ose/chromium/files/0001-Halium-Disable-DRI-build.patch
@@ -1,0 +1,25 @@
+From 8f71dc75b95351e9aa187aa7d5e69cf20cd42662 Mon Sep 17 00:00:00 2001
+From: Christophe Chapuis <chris.chapuis@gmail.com>
+Date: Sun, 15 Jun 2025 12:51:52 +0200
+Subject: [PATCH] Halium: disable DRI build
+
+DRI support is disabled when building with Halium, so don't require it
+
+Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
+---
+Upstream-Status: Inappropriate [Halium specific]
+---
+
+diff --git a/src/media/gpu/sandbox/BUILD.gn b/src/media/gpu/sandbox/BUILD.gn
+index cfcb7fa80e..7e2c67e1ed 100644
+--- a/src/media/gpu/sandbox/BUILD.gn
++++ b/src/media/gpu/sandbox/BUILD.gn
+@@ -33,6 +33,6 @@ source_set("sandbox") {
+   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_linux &&
+       !is_castos) {
+     # For DRI_DRIVER_DIR.
+-    configs += [ "//build/config/linux/dri" ]
++    # configs += [ "//build/config/linux/dri" ]
+   }
+ }
+

--- a/meta-luneos/recipes-webos-ose/chromium/webruntime-repo_120.inc
+++ b/meta-luneos/recipes-webos-ose/chromium/webruntime-repo_120.inc
@@ -20,3 +20,7 @@ SRC_URI += " \
     file://0007-app_shell-override-default-OnWindowHostClose-to-clos.patch \
     file://0008-wayland_touch-apply-device_scale_factor-to-events.patch \
 "
+# Halium specific patch for DRI
+SRC_URI:append:halium = " \
+    file://0001-Halium-Disable-DRI-build.patch \
+"


### PR DESCRIPTION
On the Halium build, no DRI is available