### PR TITLE
presage: correct 'format not a string literal' problem

### DIFF
--- a/meta-luneos/recipes-upstreamable/presage/presage/0006-correct-mvprintw-compile-error.patch
+++ b/meta-luneos/recipes-upstreamable/presage/presage/0006-correct-mvprintw-compile-error.patch
@@ -1,0 +1,77 @@
+From 1f343eff3e8860231530bc55e3931aba257af6b9 Mon Sep 17 00:00:00 2001
+From: gujie <jie.gu@leica-geosystems.com.cn>
+Date: Fri, 7 Nov 2025 13:39:48 +0800
+Subject: [PATCH] correct mvprintw compile error
+
+When building it, it reports "error: format not a string literal and
+no format arguments [-Werror=format-security]".
+
+Try to correct it.
+
+Signed-off-by: gujie <jie.gu@leica-geosystems.com.cn>
+Upstream-Status: Pending
+---
+ src/tools/presageDemo.cpp | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/tools/presageDemo.cpp b/src/tools/presageDemo.cpp
+index 5cfd55d..2289b00 100644
+--- a/src/tools/presageDemo.cpp
++++ b/src/tools/presageDemo.cpp
+@@ -173,7 +173,7 @@ int main(int argc, char** argv)
+ 	    // key corresponding to desired token. selecting
+ 	    // suggestion.
+ 	    std::string message = "Last selected word: " + words[c - KEY_F0 - 1];
+-	    mvprintw(LINES - 3, 0, message.c_str());
++	    mvprintw(LINES - 3, 0, "%s", message.c_str());
+             clrtoeol();
+ 	    move(LINES, COLS);
+
+@@ -213,7 +213,7 @@ void draw_context_win(WINDOW* win, std::string str)
+ {
+     wclear( win );
+     box( win, 0, 0 );
+-    mvwprintw( win, 1, 1, str.c_str() );
++    mvwprintw( win, 1, 1, "%s", str.c_str() );
+     wrefresh( win );
+ }
+
+@@ -226,7 +226,7 @@ void drawMsgWin( WINDOW* win, std::vector<std::string> words )
+     int i = 1;
+     std::vector<std::string>::const_iterator j = words.begin();
+     while( j != words.end() ) {
+-	mvwprintw( win, i, 1, j->c_str() );
++	mvwprintw( win, i, 1, "%s", j->c_str() );
+ 	i++;
+ 	j++;
+     }
+@@ -241,7 +241,7 @@ void draw_function_keys(WINDOW* win)
+     for (int i = 1; i <= atoi(suggestions.c_str()); i++) {
+         std::stringstream ss;
+         ss << 'F' << i;
+-        mvwprintw(win, i, 1, ss.str().c_str());
++        mvwprintw(win, i, 1, "%s", ss.str().c_str());
+     }
+     wrefresh(win);
+ }
+@@ -291,7 +291,7 @@ void draw_previous_suggestions(std::vector<std::string> words, bool contextChang
+ 	     strit != listit->end();
+ 	     strit++) {
+
+-	    mvwprintw(win, line, 1, strit->c_str());
++	    mvwprintw(win, line, 1, "%s", strit->c_str());
+ 	    line++;
+ 	}
+
+@@ -352,7 +352,7 @@ void draw_title_win(WINDOW* title_win)
+ {
+     wclear(title_win);
+     box(title_win, 0, 0);
+-    mvwprintw(title_win, 1, 1, "Presage Demo ", VERSION);
++    mvwprintw(title_win, 1, 1, "Presage Demo %s", VERSION);
+     mvwprintw(title_win, 2, 1, "Copyright (C) Matteo Vescovi");
+     mvwprintw(title_win, 3, 1, "This is free software; see the source for copying conditions.  There is NO");
+     mvwprintw(title_win, 4, 1, "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.");
+--
+2.34.1
+

--- a/meta-luneos/recipes-upstreamable/presage/presage_0.9.1.bb
+++ b/meta-luneos/recipes-upstreamable/presage/presage_0.9.1.bb
@@ -23,6 +23,7 @@ SRC_URI = " \
     file://0003-predictors-Fix-build-with-gcc-7.patch \
     file://0004-Fix-build-with-gcc-11.patch \
     file://0005-configure.ac-don-t-use-L-usr-local-lib-in-LDFLAGS.patch \
+    file://0006-correct-mvprintw-compile-error.patch \
 "
 
 SRC_URI[md5sum] = "9667be297912fa0d432e748526d8dd9e"


### PR DESCRIPTION
During the Yocto build, '-Werror=format-security' is enabled by default, which causes the error: ‘format not a string literal and no format arguments [-Werror=format-security]’.
To address this, switch to a proper format string.