### PR TITLE
Fix zram on modern kernels

### DIFF
--- a/meta-luneos/recipes-core/initscripts/webos-initscripts.bb
+++ b/meta-luneos/recipes-core/initscripts/webos-initscripts.bb
@@ -31,6 +31,16 @@ inherit webos_public_repo
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE}"
 S = "${WORKDIR}/git"
 
+# Fix zram-on.sh for modern kernels (Linux 5.x/6.x)
+# - Suppress grep errors for missing optional config file
+# - Skip deprecated max_comp_streams sysfs file
+# - Handle comp_algorithm gracefully
+
+SRC_URI:append = " \
+    file://0001-zram-on.sh-fix-for-modern-kernels.patch \
+"
+
+
 #EXTRA_OECMAKE += "-DWEBOS_QTTESTABILITY_ENABLED:BOOL=${@ '1' if d.getVar('WEBOS_DISTRO_PRERELEASE') != '' else '0'}"
 
 FILES:${PN} += "${base_libdir}"

--- a/meta-luneos/recipes-core/initscripts/webos-initscripts/0001-zram-on.sh-fix-for-modern-kernels.patch
+++ b/meta-luneos/recipes-core/initscripts/webos-initscripts/0001-zram-on.sh-fix-for-modern-kernels.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Thu, 20 Feb 2026 23:00:00 +0100
+Subject: [PATCH] zram-on.sh: fix for modern kernels (Linux 5.x/6.x)
+
+Fix several issues with zram initialization on modern kernels:
+
+1. Suppress grep errors when optional config file doesn't exist
+   (/home/root/zramswap.conf is optional but grep errors were noisy)
+
+2. Check if max_comp_streams exists before writing - this sysfs file
+   was deprecated in Linux 5.x and removed in newer kernels
+
+3. Only write comp_algorithm if the file exists and is writable
+
+Upstream-Status: Pending
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ common/lib/systemd/system/scripts/zram-on.sh.in | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/common/lib/systemd/system/scripts/zram-on.sh.in b/common/lib/systemd/system/scripts/zram-on.sh.in
+index 1234567..abcdefg 100644
+--- a/common/lib/systemd/system/scripts/zram-on.sh.in
++++ b/common/lib/systemd/system/scripts/zram-on.sh.in
+@@ -57,7 +57,7 @@ if [ -d $ZRAM_PATH ]; then
+         done
+     fi
+
+-    DISKSIZE=`grep disksize $ZRAM_CONF | awk -F":" '{print $2}'`
++    DISKSIZE=`grep disksize $ZRAM_CONF 2>/dev/null | awk -F":" '{print $2}'`
+     if [ -z $DISKSIZE ]; then
+         ZRAM_RATIO=25
+         ZRAM_MIN_DISKSIZE=350
+@@ -97,9 +97,12 @@ if [ -d $ZRAM_PATH ]; then
+     fi
+     ZRAM_SIZE=$(($DISKSIZE*1024*1024))
+
+-    echo $MAX_COMP_STREAMS > $ZRAM_PATH/max_comp_streams || true
+-    if [ ! -z $COMP_ALGORITHM ]; then
+-        echo $COMP_ALGORITHM   > $ZRAM_PATH/comp_algorithm || true
++    # max_comp_streams is deprecated in Linux 5.x+ (multi-stream is automatic)
++    if [ -f $ZRAM_PATH/max_comp_streams ] && [ -w $ZRAM_PATH/max_comp_streams ]; then
++        echo $MAX_COMP_STREAMS > $ZRAM_PATH/max_comp_streams 2>/dev/null || true
++    fi
++    if [ ! -z "$COMP_ALGORITHM" ] && [ -f $ZRAM_PATH/comp_algorithm ] && [ -w $ZRAM_PATH/comp_algorithm ]; then
++        echo $COMP_ALGORITHM > $ZRAM_PATH/comp_algorithm 2>/dev/null || true
+     fi
+     echo $ZRAM_SIZE        > $ZRAM_PATH/disksize
+ fi
+--
+2.34.1


### PR DESCRIPTION
Fix several issues with zram initialization on modern kernels:

1. Suppress grep errors when optional config file doesn't exist (/home/root/zramswap.conf is optional but grep errors were noisy)

2. Check if max_comp_streams exists before writing - this sysfs file was deprecated in Linux 5.x and removed in newer kernels

3. Only write comp_algorithm if the file exists and is writable

Upstream-Status: Pending