### PR TITLE
Mesa: Update to 26.1.0

### DIFF
--- a/meta-luneos-backports-5.1/recipes-devtools/meson/meson/0001-Make-CPU-family-warnings-fatal.patch
+++ b/meta-luneos-backports-5.1/recipes-devtools/meson/meson/0001-Make-CPU-family-warnings-fatal.patch
@@ -1,0 +1,44 @@
+From 33bc81d5a262e0fa1a346ac1667a3679a17c0997 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Tue, 3 Jul 2018 13:59:09 +0100
+Subject: [PATCH] Make CPU family warnings fatal
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+---
+ mesonbuild/envconfig.py   | 4 ++--
+ mesonbuild/environment.py | 6 ++----
+ 2 files changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index 86bad9b..9703315 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -277,8 +277,8 @@ class MachineInfo(HoldableObject):
+                 'but is missing {}.'.format(minimum_literal - set(literal)))
+ 
+         cpu_family = literal['cpu_family']
+-        if cpu_family not in known_cpu_families:
+-            mlog.warning(f'Unknown CPU family {cpu_family}, please report this at https://github.com/mesonbuild/meson/issues/new')
++        if cpu_family not in known_cpu_families and cpu_family != "riscv":
++            raise EnvironmentException('Unknown CPU family {}, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.'.format(cpu_family))
+ 
+         endian = literal['endian']
+         if endian not in ('little', 'big'):
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index 5bccb90..6aa4b15 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -387,10 +387,8 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
+         if compilers and not any_compiler_has_define(compilers, '__mips64'):
+             trial = 'mips'
+ 
+-    if trial not in known_cpu_families:
+-        mlog.warning(f'Unknown CPU family {trial!r}, please report this at '
+-                     'https://github.com/mesonbuild/meson/issues/new with the '
+-                     'output of `uname -a` and `cat /proc/cpuinfo`')
++    if trial not in known_cpu_families and trail != "riscv":
++        raise EnvironmentException('Unknown CPU family %s, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.' % trial)
+ 
+     return trial
+ 

--- a/meta-luneos-backports-5.1/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
+++ b/meta-luneos-backports-5.1/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
@@ -1,0 +1,36 @@
+From 66e350bbbd65e56a0d19c75710f61503e15e24a2 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 19 Nov 2018 14:24:26 +0100
+Subject: [PATCH] python module: do not manipulate the environment when calling
+ pkg-config
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ mesonbuild/dependencies/python.py | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/mesonbuild/dependencies/python.py b/mesonbuild/dependencies/python.py
+index 883a29a..52bfbf3 100644
+--- a/mesonbuild/dependencies/python.py
++++ b/mesonbuild/dependencies/python.py
+@@ -399,9 +399,6 @@ def python_factory(env: 'Environment', for_machine: 'MachineChoice',
+                     empty.name = 'python'
+                     return empty
+ 
+-                old_pkg_libdir = os.environ.pop('PKG_CONFIG_LIBDIR', None)
+-                old_pkg_path = os.environ.pop('PKG_CONFIG_PATH', None)
+-                os.environ['PKG_CONFIG_LIBDIR'] = pkg_libdir
+                 try:
+                     return PythonPkgConfigDependency(name, env, kwargs, installation, True)
+                 finally:
+@@ -410,8 +407,7 @@ def python_factory(env: 'Environment', for_machine: 'MachineChoice',
+                             os.environ[name] = value
+                         elif name in os.environ:
+                             del os.environ[name]
+-                    set_env('PKG_CONFIG_LIBDIR', old_pkg_libdir)
+-                    set_env('PKG_CONFIG_PATH', old_pkg_path)
++                    pass
+ 
+             candidates.append(functools.partial(wrap_in_pythons_pc_dir, pkg_name, env, kwargs, installation))
+             # We only need to check both, if a python install has a LIBPC. It might point to the wrong location,

--- a/meta-luneos-backports-5.1/recipes-devtools/meson/meson/0002-Support-building-allarch-recipes-again.patch
+++ b/meta-luneos-backports-5.1/recipes-devtools/meson/meson/0002-Support-building-allarch-recipes-again.patch
@@ -1,0 +1,25 @@
+From 61430cf9a80e24eb33d72c6eae4e8d536d308e08 Mon Sep 17 00:00:00 2001
+From: Peter Kjellerstedt <pkj@axis.com>
+Date: Thu, 26 Jul 2018 16:32:49 +0200
+Subject: [PATCH] Support building allarch recipes again
+
+This registers "allarch" as a known CPU family.
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+---
+ mesonbuild/envconfig.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mesonbuild/envconfig.py b/mesonbuild/envconfig.py
+index 9703315..74f2477 100644
+--- a/mesonbuild/envconfig.py
++++ b/mesonbuild/envconfig.py
+@@ -28,6 +28,7 @@ from pathlib import Path
+ 
+ 
+ known_cpu_families = (
++    'allarch',
+     'aarch64',
+     'alpha',
+     'arc',

--- a/meta-luneos-backports-5.1/recipes-devtools/meson/meson/meson-setup.py
+++ b/meta-luneos-backports-5.1/recipes-devtools/meson/meson/meson-setup.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import string
+import sys
+
+class Template(string.Template):
+    delimiter = "@"
+
+class Environ():
+    def __getitem__(self, name):
+        val = os.environ[name]
+        val = val.split()
+        if len(val) > 1:
+            val = ["'%s'" % x for x in val]
+            val = ', '.join(val)
+            val = '[%s]' % val
+        elif val:
+            val = "'%s'" % val.pop()
+        return val
+
+try:
+    sysroot = os.environ['OECORE_NATIVE_SYSROOT']
+except KeyError:
+    print("Not in environment setup, bailing")
+    sys.exit(1)
+
+template_file = os.path.join(sysroot, 'usr/share/meson/meson.cross.template')
+cross_file = os.path.join(sysroot, 'usr/share/meson/%smeson.cross' % os.environ["TARGET_PREFIX"])
+native_template_file = os.path.join(sysroot, 'usr/share/meson/meson.native.template')
+native_file = os.path.join(sysroot, 'usr/share/meson/meson.native')
+
+with open(template_file) as in_file:
+    template = in_file.read()
+    output = Template(template).substitute(Environ())
+    with open(cross_file, "w") as out_file:
+        out_file.write(output)
+
+with open(native_template_file) as in_file:
+    template = in_file.read()
+    output = Template(template).substitute({'OECORE_NATIVE_SYSROOT': os.environ['OECORE_NATIVE_SYSROOT']})
+    with open(native_file, "w") as out_file:
+        out_file.write(output)

--- a/meta-luneos-backports-5.1/recipes-devtools/meson/meson/meson-wrapper
+++ b/meta-luneos-backports-5.1/recipes-devtools/meson/meson/meson-wrapper
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+if [ -z "$OECORE_NATIVE_SYSROOT" ]; then
+    exec "meson.real" "$@"
+fi
+
+if [ -z "$SSL_CERT_DIR" ]; then
+    export SSL_CERT_DIR="$OECORE_NATIVE_SYSROOT/etc/ssl/certs/"
+fi
+
+# If these are set to a cross-compile path, meson will get confused and try to
+# use them as native tools. Unset them to prevent this, as all the cross-compile
+# config is already in meson.cross.
+unset CC CXX CPP LD AR NM STRIP
+
+case "$1" in
+setup|configure|dist|install|introspect|init|test|wrap|subprojects|rewrite|compile|devenv|env2mfile|help) MESON_CMD="$1" ;;
+*) echo meson-wrapper: Implicit setup command assumed; MESON_CMD=setup ;;
+esac
+
+if [ "$MESON_CMD" = "setup" ]; then
+    MESON_SETUP_OPTS=" \
+        --cross-file="$OECORE_NATIVE_SYSROOT/usr/share/meson/${TARGET_PREFIX}meson.cross" \
+        --native-file="$OECORE_NATIVE_SYSROOT/usr/share/meson/meson.native" \
+        "
+    echo meson-wrapper: Running meson with setup options: \"$MESON_SETUP_OPTS\"
+fi
+
+exec "$OECORE_NATIVE_SYSROOT/usr/bin/meson.real" \
+    "$@" \
+    $MESON_SETUP_OPTS

--- a/meta-luneos-backports-5.1/recipes-devtools/meson/meson_1.5.1.bb
+++ b/meta-luneos-backports-5.1/recipes-devtools/meson/meson_1.5.1.bb
@@ -1,0 +1,158 @@
+HOMEPAGE = "http://mesonbuild.com"
+SUMMARY = "A high performance build system"
+DESCRIPTION = "Meson is a build system designed to increase programmer \
+productivity. It does this by providing a fast, simple and easy to use \
+interface for modern software development tools and practices."
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+GITHUB_BASE_URI = "https://github.com/mesonbuild/meson/releases/"
+SRC_URI = "${GITHUB_BASE_URI}/download/${PV}/meson-${PV}.tar.gz \
+           file://meson-setup.py \
+           file://meson-wrapper \
+           file://0001-python-module-do-not-manipulate-the-environment-when.patch \
+           file://0001-Make-CPU-family-warnings-fatal.patch \
+           file://0002-Support-building-allarch-recipes-again.patch \
+           "
+SRC_URI[sha256sum] = "567e533adf255de73a2de35049b99923caf872a455af9ce03e01077e0d384bed"
+UPSTREAM_CHECK_REGEX = "(?P<pver>\d+(\.\d+)+)$"
+
+inherit python_setuptools_build_meta github-releases
+
+RDEPENDS:${PN} = "ninja python3-modules python3-pkg-resources"
+
+FILES:${PN} += "${datadir}/polkit-1"
+
+do_install:append () {
+	# As per the same issue in the python recipe itself:
+	# Unfortunately the following pyc files are non-deterministc due to 'frozenset'
+	# being written without strict ordering, even with PYTHONHASHSEED = 0
+	# Upstream is discussing ways to solve the issue properly, until then let's
+	# just not install the problematic files.
+	# More info: http://benno.id.au/blog/2013/01/15/python-determinism
+	rm -f ${D}${libdir}/python*/site-packages/mesonbuild/dependencies/__pycache__/mpi.cpython*
+}
+
+BBCLASSEXTEND = "native nativesdk"
+
+inherit meson-routines
+
+# The cross file logic is similar but not identical to that in meson.bbclass,
+# since it's generating for an SDK rather than a cross-compile. Important
+# differences are:
+# - We can't set vars like CC, CXX, etc. yet because they will be filled in with
+#   real paths by meson-setup.sh when the SDK is extracted.
+# - Some overrides aren't needed, since the SDK injects paths that take care of
+#   them.
+def var_list2str(var, d):
+    items = d.getVar(var).split()
+    return repr(items[0]) if len(items) == 1 else ', '.join(repr(s) for s in items)
+
+def generate_native_link_template(d):
+    val = ['-L@{OECORE_NATIVE_SYSROOT}${libdir_native}',
+           '-L@{OECORE_NATIVE_SYSROOT}${base_libdir_native}',
+           '-Wl,-rpath-link,@{OECORE_NATIVE_SYSROOT}${libdir_native}',
+           '-Wl,-rpath-link,@{OECORE_NATIVE_SYSROOT}${base_libdir_native}',
+           '-Wl,--allow-shlib-undefined'
+        ]
+    build_arch = d.getVar('BUILD_ARCH')
+    if 'x86_64' in build_arch:
+        loader = 'ld-linux-x86-64.so.2'
+    elif 'i686' in build_arch:
+        loader = 'ld-linux.so.2'
+    elif 'aarch64' in build_arch:
+        loader = 'ld-linux-aarch64.so.1'
+    elif 'ppc64le' in build_arch:
+        loader = 'ld64.so.2'
+    elif 'loongarch64' in build_arch:
+        loader = 'ld-linux-loongarch-lp64d.so.1'
+    elif 'riscv64' in build_arch:
+        loader = 'ld-linux-riscv64-lp64d.so.1'
+
+    if loader:
+        val += ['-Wl,--dynamic-linker=@{OECORE_NATIVE_SYSROOT}${base_libdir_native}/' + loader]
+
+    return repr(val)
+
+install_templates() {
+    install -d ${D}${datadir}/meson
+
+    cat >${D}${datadir}/meson/meson.native.template <<EOF
+[binaries]
+c = ${@meson_array('BUILD_CC', d)}
+cpp = ${@meson_array('BUILD_CXX', d)}
+ar = ${@meson_array('BUILD_AR', d)}
+nm = ${@meson_array('BUILD_NM', d)}
+strip = ${@meson_array('BUILD_STRIP', d)}
+readelf = ${@meson_array('BUILD_READELF', d)}
+pkg-config = 'pkg-config-native'
+
+[built-in options]
+c_args = ['-isystem@{OECORE_NATIVE_SYSROOT}${includedir_native}' , ${@var_list2str('BUILD_OPTIMIZATION', d)}]
+c_link_args = ${@generate_native_link_template(d)}
+cpp_args = ['-isystem@{OECORE_NATIVE_SYSROOT}${includedir_native}' , ${@var_list2str('BUILD_OPTIMIZATION', d)}]
+cpp_link_args = ${@generate_native_link_template(d)}
+[properties]
+sys_root = '@OECORE_NATIVE_SYSROOT'
+EOF
+
+    cat >${D}${datadir}/meson/meson.cross.template <<EOF
+[binaries]
+c = @CC
+cpp = @CXX
+ar = @AR
+nm = @NM
+strip = @STRIP
+pkg-config = 'pkg-config'
+
+[built-in options]
+c_args = @CFLAGS
+c_link_args = @LDFLAGS
+cpp_args = @CPPFLAGS
+cpp_link_args = @LDFLAGS
+
+[properties]
+needs_exe_wrapper = true
+sys_root = @OECORE_TARGET_SYSROOT
+
+[host_machine]
+system = '$host_system'
+cpu_family = '$host_cpu_family'
+cpu = '$host_cpu'
+endian = '$host_endian'
+EOF
+}
+
+do_install:append:class-nativesdk() {
+    host_system=${SDK_OS}
+    host_cpu_family=${@meson_cpu_family("SDK_ARCH", d)}
+    host_cpu=${SDK_ARCH}
+    host_endian=${@meson_endian("SDK", d)}
+    install_templates
+
+    install -d ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+    install -m 0755 ${UNPACKDIR}/meson-setup.py ${D}${SDKPATHNATIVE}/post-relocate-setup.d/
+
+    # We need to wrap the real meson with a thin env setup wrapper.
+    mv ${D}${bindir}/meson ${D}${bindir}/meson.real
+    install -m 0755 ${UNPACKDIR}/meson-wrapper ${D}${bindir}/meson
+}
+
+FILES:${PN}:append:class-nativesdk = "${datadir}/meson ${SDKPATHNATIVE}"
+
+do_install:append:class-native() {
+    host_system=${HOST_OS}
+    host_cpu_family=${@meson_cpu_family("HOST_ARCH", d)}
+    host_cpu=${HOST_ARCH}
+    host_endian=${@meson_endian("HOST", d)}
+    install_templates
+
+    install -d ${D}${datadir}/post-relocate-setup.d
+    install -m 0755 ${UNPACKDIR}/meson-setup.py ${D}${datadir}/post-relocate-setup.d/
+
+    # We need to wrap the real meson with a thin wrapper that substitues native/cross files
+    # when running in a direct SDK environment.
+    mv ${D}${bindir}/meson ${D}${bindir}/meson.real
+    install -m 0755 ${UNPACKDIR}/meson-wrapper ${D}${bindir}/meson
+}

--- a/meta-luneos-backports-5.1/recipes-graphics/wayland/wayland-protocols_1.47.bb
+++ b/meta-luneos-backports-5.1/recipes-graphics/wayland/wayland-protocols_1.47.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Collection of additional Wayland protocols"
+DESCRIPTION = "Wayland protocols that add functionality not \
+available in the Wayland core protocol. Such protocols either add \
+completely new functionality, or extend the functionality of some other \
+protocol either in Wayland core, or some other protocol in \
+wayland-protocols."
+HOMEPAGE = "http://wayland.freedesktop.org"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c7b12b6702da38ca028ace54aae3d484 \
+                    file://stable/presentation-time/presentation-time.xml;endline=26;md5=4646cd7d9edc9fa55db941f2d3a7dc53"
+
+SRC_URI = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/${PV}/downloads/wayland-protocols-${PV}.tar.xz"
+SRC_URI[sha256sum] = "5fd4349bcbc9bab9a46f8cf77d1f434296a7a052c87440a094f63fcf62a58e20"
+
+UPSTREAM_CHECK_URI = "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tags"
+UPSTREAM_CHECK_REGEX = "releases/(?P<pver>.+)"
+
+DEPENDS += "wayland-native"
+
+inherit meson pkgconfig allarch
+
+EXTRA_OEMESON += "-Dtests=false"
+
+BBCLASSEXTEND = "native nativesdk"
+

--- a/meta-luneos-backports-6.0/conf/layer.conf
+++ b/meta-luneos-backports-6.0/conf/layer.conf
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 LuneOS / webOS Ports
+
+# We have conf and classes directories => add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories => add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-luneos-backports-6.0"
+BBFILE_PATTERN_meta-luneos-backports-6.0 := "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-luneos-backports-6.0 = "33"
+
+LAYERSERIES_COMPAT_meta-luneos-backports-6.0 = "scarthgap"
+
+LAYERDEPENDS_meta-luneos-backports-6.0 = " \
+    core \
+    openembedded-layer \
+"

--- a/meta-luneos-backports-6.0/recipes-graphics/mesa/mesa.inc
+++ b/meta-luneos-backports-6.0/recipes-graphics/mesa/mesa.inc
@@ -1,0 +1,385 @@
+SUMMARY = "A free implementation of the OpenGL API"
+DESCRIPTION = "Mesa is an open-source implementation of the OpenGL specification - \
+a system for rendering interactive 3D graphics.  \
+A variety of device drivers allows Mesa to be used in many different environments \
+ranging from software emulation to complete hardware acceleration for modern GPUs. \
+Mesa is used as part of the overall Direct Rendering Infrastructure and X.org \
+environment."
+
+HOMEPAGE = "http://mesa3d.org"
+BUGTRACKER = "https://bugs.freedesktop.org"
+SECTION = "x11"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://docs/license.rst;md5=ffe678546d4337b732cfd12262e6af11"
+
+PE = "2"
+
+SRC_URI = "https://archive.mesa3d.org/mesa-${PV}.tar.xz \
+           file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
+           file://0001-freedreno-don-t-encode-build-path-into-binaries.patch \
+"
+
+SRC_URI[sha256sum] = "2a44e98e64d5c36cec64633de2d0ec7eff64703ee25b35364ba8fcaa84f33f72"
+PV = "26.0.0"
+
+UPSTREAM_CHECK_GITTAGREGEX = "mesa-(?P<pver>\d+(\.\d+)+)"
+
+S = "${UNPACKDIR}/mesa-${PV}"
+
+#because we cannot rely on the fact that all apps will use pkgconfig,
+#make eglplatform.h independent of MESA_EGL_NO_X11_HEADER
+do_install:append() {
+  # sed can't find EGL/eglplatform.h as it doesn't get installed when glvnd enabled.
+  # So, check if EGL/eglplatform.h exists before running sed.
+  if ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'true', 'false', d)} && [ -f ${D}${includedir}/EGL/eglplatform.h ]; then
+      sed -i -e 's/^#elif defined(__unix__) && defined(EGL_NO_X11)$/#elif defined(__unix__) \&\& defined(EGL_NO_X11) || ${@bb.utils.contains('PACKAGECONFIG', 'x11', '0', '1', d)}/' ${D}${includedir}/EGL/eglplatform.h
+  fi
+  # These are ICDs, apps are not supposed to link against them                                                                                                              
+  if ${@bb.utils.contains('PACKAGECONFIG', 'glvnd', 'true', 'false', d)} ; then                                                                                             
+      rm -f ${D}${libdir}/libEGL_mesa.so ${D}${libdir}/libGLX_mesa.so                                                                                                       
+  fi
+}
+
+# All dependencies **MUST** be -native. If not, then add a PACKAGECONFIG for it.
+DEPENDS = "makedepend-native flex-native bison-native chrpath-replacement-native python3-mako-native gettext-native python3-pyyaml-native"
+EXTRANATIVEPATH += "chrpath-native"
+
+PROVIDES = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'opengl', 'virtual/libgl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'glvnd', 'virtual/libglx', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gles', 'virtual/libgles1 virtual/libgles2 virtual/libgles3', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'egl', 'virtual/egl', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gbm', 'virtual/libgbm', '', d)} \
+    virtual/mesa \
+    "
+
+inherit meson pkgconfig python3native gettext features_check rust
+
+BBCLASSEXTEND = "native nativesdk"
+
+ANY_OF_DISTRO_FEATURES = "opencl opengl vulkan"
+
+PLATFORMS ??= "${@bb.utils.filter('PACKAGECONFIG', 'x11 wayland', d)}"
+
+# set the MESA_BUILD_TYPE to either 'release' (default) or 'debug'
+# by default the upstream mesa sources build a debug release
+# here we assume the user will want a release build by default
+MESA_BUILD_TYPE ?= "release"
+def check_buildtype(d):
+    _buildtype = d.getVar('MESA_BUILD_TYPE')
+    if _buildtype not in ['release', 'debug']:
+        bb.fatal("unknown build type (%s), please set MESA_BUILD_TYPE to either 'release' or 'debug'" % _buildtype)
+    if _buildtype == 'debug':
+        return 'debugoptimized'
+    return 'plain'
+MESON_BUILDTYPE = "${@check_buildtype(d)}"
+
+EXTRA_OEMESON = " \
+    -Dglx-read-only-text=true \
+    -Dplatforms='${@",".join("${PLATFORMS}".split())}' \
+    -Dvulkan-manifest-per-architecture=false \
+"
+
+def strip_comma(s):
+    return s.strip(',')
+
+# skip all Rust dependencies if we are not building OpenCL"
+INHIBIT_DEFAULT_RUST_DEPS = "${@bb.utils.contains('PACKAGECONFIG', 'opencl', '', '1', d)}"
+
+# "egl" requires "opengl"
+PACKAGECONFIG[egl] = "-Degl=enabled, -Degl=disabled"
+
+# "gbm" requires "opengl"
+PACKAGECONFIG[gbm] = "-Dgbm=enabled,-Dgbm=disabled"
+
+# "gles" requires "opengl"
+PACKAGECONFIG[gles] = "-Dgles1=enabled -Dgles2=enabled, -Dgles1=disabled -Dgles2=disabled"
+
+PACKAGECONFIG[glvnd] = "-Dglvnd=enabled, -Dglvnd=disabled, libglvnd"
+
+PACKAGECONFIG[opengl] = "-Dopengl=true, -Dopengl=false"
+
+# "opencl" also requires libclc and gallium-llvm to be present in PKGCONFIG!
+# Be sure to enable them both for the target and for the native build.
+PACKAGECONFIG[opencl] = "-Dgallium-rusticl=true -Dmesa-clc-bundle-headers=enabled, -Dgallium-rusticl=false, bindgen-cli-native clang"
+
+X11_DEPS = "xorgproto virtual/libx11 libxext libxxf86vm libxdamage libxfixes xrandr xorgproto libxshmfence"
+# "x11" requires "opengl"
+PACKAGECONFIG[x11] = ",-Dglx=disabled,${X11_DEPS}"
+# Mesa 26 no longer builds the wl_drm server code (EGL_WL_bind_wayland_display)
+# unless it is explicitly requested via -Dlegacy-wayland. Qt's wayland compositor
+# hardware integrations (both wayland-egl and linux-dmabuf-unstable-v1) still
+# require eglBindWaylandDisplayWL, and qtwayland only implements
+# zwp_linux_dmabuf_v1 v3 (no dmabuf feedback), so without wl_drm a client's
+# libEGL has no way to learn the render node and eglInitialize() fails with
+# "failed to get driver name for fd -1".
+PACKAGECONFIG[wayland] = "-Dlegacy-wayland=bind-wayland-display,,wayland-native wayland libdrm wayland-protocols"
+
+# Entries for GPU vendors.
+# Some of the drivers might have extra dependencies (libclc, gallium-llvm).
+# Check them in the individual driver settings in VULKAN_DRIVERS and
+# GALLIUMDRIVERS.
+PACKAGECONFIG[amd] = ""
+PACKAGECONFIG[asahi] = ""
+PACKAGECONFIG[broadcom] = ""
+PACKAGECONFIG[etnaviv] = ",,python3-pycparser-native"
+PACKAGECONFIG[ethosu] = ""
+PACKAGECONFIG[freedreno] = ""
+PACKAGECONFIG[imagination] = "-Dimagination-srv=true,-Dimagination-srv=false"
+PACKAGECONFIG[intel] = ""
+PACKAGECONFIG[lima] = ""
+PACKAGECONFIG[nouveau] = ""
+PACKAGECONFIG[panfrost] = ""
+PACKAGECONFIG[rocket] = ""
+PACKAGECONFIG[svga] = ""
+PACKAGECONFIG[tegra] = ""
+PACKAGECONFIG[v3d] = ""
+PACKAGECONFIG[vc4] = ""
+PACKAGECONFIG[virtio] = ""
+PACKAGECONFIG[zink] = ""
+# kmsro removed in Mesa 26+ but keep as no-op for compatibility with other layers
+PACKAGECONFIG[kmsro] = ""
+
+
+VULKAN_DRIVERS_SWRAST = ",swrast"
+# Crashes on x32
+VULKAN_DRIVERS_SWRAST:x86-x32 = ""
+
+VULKAN_DRIVERS_VIRTIO = ",virtio"
+# No atomic_uint on ARMv4 / v5
+VULKAN_DRIVERS_VIRTIO:armv4 = ""
+VULKAN_DRIVERS_VIRTIO:armv5 = ""
+
+# keep sorted by the driver name (rather than PKGCONFIG)
+VULKAN_DRIVERS = ""
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'amd gallium-llvm', ',amd', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'asahi libclc gallium-llvm', ',asahi', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'broadcom', ',broadcom', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'virtio', ',gfxstream', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'imagination', ',imagination', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'intel libclc gallium-llvm', ',intel', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'intel libclc', ',intel_hasvk', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'panfrost libclc', ',panfrost', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'gallium-llvm', '${VULKAN_DRIVERS_SWRAST}', '', d)}"
+VULKAN_DRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'virtio', '${VULKAN_DRIVERS_VIRTIO}', '', d)}"
+
+PACKAGECONFIG[vulkan] = "-Dvulkan-drivers=${@strip_comma('${VULKAN_DRIVERS}')}, -Dvulkan-drivers='',glslang-native vulkan-loader vulkan-headers"
+PACKAGECONFIG[vulkan-beta] = "-Dvulkan-beta=true,-Dvulkan-beta=false"
+
+# mesa development and testing tools support, per driver
+
+# keep sorted by the driver name (rather than PKGCONFIG)
+TOOLS = ""
+TOOLS .= "${@bb.utils.contains('PACKAGECONFIG', 'asahi', ',asahi', '', d)}"
+TOOLS .= "${@bb.utils.contains('PACKAGECONFIG', 'etnaviv', ',etnaviv', '', d)}"
+TOOLS .= "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+TOOLS .= "${@bb.utils.contains('PACKAGECONFIG', 'imagination', ',imagination', '', d)}"
+TOOLS .= "${@bb.utils.contains('PACKAGECONFIG', 'lima', ',lima', '', d)}"
+TOOLS .= "${@bb.utils.contains('PACKAGECONFIG', 'panfrost', ',panfrost', '', d)}"
+
+# dependencies for tools.
+TOOLS_DEPS:append = "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ' ncurses libconfig libxml2 ', '', d)}"
+
+PACKAGECONFIG[expat] = "-Dexpat=enabled, -Dexpat=disabled, expat"
+PACKAGECONFIG[tools] = "-Dtools=${@strip_comma('${TOOLS}')}, -Dtools='', ${TOOLS_DEPS}"
+# Depends on expat PACKAGECONFIG!
+PACKAGECONFIG[xmlconfig] = "-Dxmlconfig=enabled, -Dxmlconfig=disabled"
+PACKAGECONFIG[zlib] = "-Dzlib=enabled, -Dzlib=disabled, zlib"
+
+GALLIUMDRIVERS_LLVMPIPE = ",llvmpipe"
+GALLIUMDRIVERS_SOFTPIPE = ",softpipe"
+# gallium softpipe and llvmpipe was found to crash Xorg on startup in x32 qemu
+GALLIUMDRIVERS_LLVMPIPE:x86-x32 = ""
+GALLIUMDRIVERS_SOFTPIPE:x86-x32 = ""
+
+# keep sorted by the driver name (rather than PKGCONFIG)
+GALLIUMDRIVERS = ""
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'asahi libclc gallium-llvm', ',asahi', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'intel libclc', ',crocus', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'etnaviv', ',etnaviv', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'ethosu', ',ethosu', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'freedreno', ',freedreno', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'intel gallium-llvm', ',i915', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'intel libclc gallium-llvm', ',iris', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'lima', ',lima', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'gallium-llvm', '${GALLIUMDRIVERS_LLVMPIPE}', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'nouveau gallium-llvm', ',nouveau', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'panfrost libclc', ',panfrost', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'amd gallium-llvm', ',r300', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'amd', ',r600', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'amd gallium-llvm', ',radeonsi', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'rocket', ',rocket', '', d)}"
+GALLIUMDRIVERS .= "${GALLIUMDRIVERS_SOFTPIPE}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'svga gallium-llvm', ',svga', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'tegra', ',tegra', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'v3d', ',v3d', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'vc4', ',vc4', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'virtio', ',virgl', '', d)}"
+GALLIUMDRIVERS .= "${@bb.utils.contains('PACKAGECONFIG', 'zink', ',zink', '', d)}"
+
+PACKAGECONFIG[gallium] = "-Dgallium-drivers=${@strip_comma('${GALLIUMDRIVERS}')}, -Dgallium-drivers='', libdrm"
+PACKAGECONFIG[gallium-llvm] = "-Dllvm=enabled -Dshared-llvm=enabled, -Dllvm=disabled, llvm llvm-native elfutils"
+
+MESA_CLC = "system"
+MESA_CLC:class-native = "enabled"
+INSTALL_MESA_CLC = "false"
+INSTALL_MESA_CLC:class-native = "true"
+MESA_NATIVE = "mesa-native"
+MESA_NATIVE:class-native = ""
+
+PACKAGECONFIG[libclc] = "-Dmesa-clc=${MESA_CLC} -Dinstall-mesa-clc=${INSTALL_MESA_CLC} -Dmesa-clc-bundle-headers=enabled,,libclc spirv-tools spirv-llvm-translator ${MESA_NATIVE}"
+PACKAGECONFIG[va] = "-Dgallium-va=enabled,-Dgallium-va=disabled,libva-initial"
+
+PACKAGECONFIG[perfetto] = "-Dperfetto=true,-Dperfetto=false,libperfetto"
+
+PACKAGECONFIG[unwind] = "-Dlibunwind=enabled,-Dlibunwind=disabled,libunwind"
+
+PACKAGECONFIG[lmsensors] = "-Dlmsensors=enabled,-Dlmsensors=disabled,lmsensors"
+
+VIDEO_CODECS ?= "${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'all', 'all_free', d)}"
+PACKAGECONFIG[video-codecs] = "-Dvideo-codecs=${VIDEO_CODECS}, -Dvideo-codecs=''"
+
+PACKAGECONFIG[teflon] = "-Dteflon=true, -Dteflon=false"
+
+# llvmpipe is slow if compiled with -fomit-frame-pointer (e.g. -O2)
+FULL_OPTIMIZATION:append = " -fno-omit-frame-pointer"
+
+CFLAGS:append:armv5 = " -DMISSING_64BIT_ATOMICS"
+CFLAGS:append:armv6 = " -DMISSING_64BIT_ATOMICS"
+
+# Remove the mesa dependency on mesa-dev, as mesa is empty
+DEV_PKG_DEPENDENCY = ""
+
+# Provide virtual names to allow selecting preferred rproviders
+RPROVIDES:mesa-vulkan-drivers += "virtual-vulkan-icd"
+RPROVIDES:libopencl-mesa += "virtual-opencl-icd"
+
+# GLES2 and GLES3 implementations are packaged in a single library in libgles2-mesa.
+# Add a dependency so the GLES3 dev package is associated with its implementation.
+RPROVIDES:libgles2-mesa += "libgles3-mesa"
+RPROVIDES:libgles2-mesa-dev += "libgles3-mesa-dev"
+
+RDEPENDS:libopencl-mesa += "${@bb.utils.contains('PACKAGECONFIG', 'opencl', 'libclc', '', d)}"
+
+PACKAGES =+ "libegl-mesa libegl-mesa-dev \
+             libgallium \
+             libgl-mesa libgl-mesa-dev \
+             libglx-mesa libglx-mesa-dev \
+             libglapi libglapi-dev \
+             libgbm libgbm-dev \
+             libgles1-mesa libgles1-mesa-dev \
+             libgles2-mesa libgles2-mesa-dev \
+             libopencl-mesa \
+             libteflon \
+             mesa-megadriver mesa-vulkan-drivers \
+             mesa-tools \
+            "
+
+# For the packages that make up the OpenGL interfaces, inject variables so that
+# they don't get Debian-renamed (which would remove the -mesa suffix), and
+# RPROVIDEs/RCONFLICTs on the generic libgl name.
+python __anonymous() {
+    pkgconfig = (d.getVar('PACKAGECONFIG') or "").split()
+    mlprefix = d.getVar("MLPREFIX")
+    suffix = ""
+    if "-native" in d.getVar("PN"):
+        suffix = "-native"
+
+    for p in ("libegl", "libgl", "libglx", "libgles1", "libgles2", "libgles3", "libopencl"):
+        fullp = mlprefix + p + "-mesa" + suffix
+        d.appendVar("RRECOMMENDS:" + fullp, " ${MLPREFIX}mesa-megadriver" + suffix)
+
+    d.setVar("DEBIAN_NOAUTONAME:%slibopencl-mesa%s" % (mlprefix, suffix), "1")
+
+    if 'glvnd' in pkgconfig:
+        for p in ("libegl", "libglx"):
+            fullp = mlprefix + p + "-mesa" + suffix
+            d.appendVar("RPROVIDES:" + fullp, ' virtual-%s-icd' % p)
+    else:
+        for p in (("egl", "libegl", "libegl1"),
+                  ("opengl", "libgl", "libgl1"),
+                  ("gles", "libgles1", "libglesv1-cm1"),
+                  ("gles", "libgles2", "libglesv2-2", "libgles3")):
+            if not p[0] in pkgconfig:
+                continue
+            fullp = mlprefix + p[1] + "-mesa" + suffix
+            pkgs = " " + " ".join(mlprefix + x + suffix for x in p[1:])
+            d.setVar("DEBIAN_NOAUTONAME:" + fullp, "1")
+            d.appendVar("RREPLACES:" + fullp, pkgs)
+            d.appendVar("RPROVIDES:" + fullp, pkgs)
+            d.appendVar("RCONFLICTS:" + fullp, pkgs)
+
+            # For -dev, the first element is both the Debian and original name
+            fullp = mlprefix + p[1] + "-mesa-dev" + suffix
+            pkgs = " " + mlprefix + p[1] + "-dev" + suffix
+            d.setVar("DEBIAN_NOAUTONAME:" + fullp, "1")
+            d.appendVar("RREPLACES:" + fullp, pkgs)
+            d.appendVar("RPROVIDES:" + fullp, pkgs)
+            d.appendVar("RCONFLICTS:" + fullp, pkgs)
+}
+
+python mesa_populate_packages() {
+    pkgs = ['mesa', 'mesa-dev', 'mesa-dbg']
+    for pkg in pkgs:
+        d.setVar("RPROVIDES:%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+        d.setVar("RCONFLICTS:%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+        d.setVar("RREPLACES:%s" % pkg, pkg.replace("mesa", "mesa-dri", 1))
+
+    import re
+    dri_drivers_root = oe.path.join(d.getVar('PKGD'), d.getVar('libdir'), "dri")
+    if os.path.isdir(dri_drivers_root):
+        dri_pkgs = sorted(os.listdir(dri_drivers_root))
+        lib_name = d.expand("${MLPREFIX}mesa-megadriver")
+        for p in dri_pkgs:
+            m = re.match(r'^(.*)_dri\.so$', p)
+            if m:
+                pkg_name = " ${MLPREFIX}mesa-driver-%s" % legitimize_package_name(m.group(1))
+                d.appendVar("RPROVIDES:%s" % lib_name, pkg_name)
+                d.appendVar("RCONFLICTS:%s" % lib_name, pkg_name)
+                d.appendVar("RREPLACES:%s" % lib_name, pkg_name)
+}
+
+PACKAGESPLITFUNCS =+ "mesa_populate_packages"
+
+PACKAGES_DYNAMIC += "^mesa-driver-.*"
+PACKAGES_DYNAMIC:class-native = "^mesa-driver-.*-native"
+
+FILES:mesa-megadriver = "${libdir}/dri/* ${datadir}/drirc.d"
+FILES:mesa-vulkan-drivers = "${libdir}/libvulkan_*.so ${libdir}/libpowervr_rogue.so ${datadir}/vulkan"
+FILES:libegl-mesa = "${libdir}/libEGL*.so.* ${datadir}/glvnd/egl_vendor.d"
+FILES:libgbm = "${libdir}/libgbm.so.* ${libdir}/gbm/*_gbm.so"
+FILES:libgallium = "${libdir}/libgallium-*.so"
+FILES:libgles1-mesa = "${libdir}/libGLESv1*.so.*"
+FILES:libgles2-mesa = "${libdir}/libGLESv2.so.*"
+FILES:libgl-mesa = "${libdir}/libGL.so.*"
+FILES:libglx-mesa = "${libdir}/libGLX*.so.*"
+FILES:libopencl-mesa = "${libdir}/lib*OpenCL.so* ${sysconfdir}/OpenCL/vendors/*.icd"
+FILES:libglapi = "${libdir}/libglapi.so.*"
+
+FILES:${PN}-dev = "${libdir}/pkgconfig/dri.pc ${includedir}/GL/internal/dri_interface.h ${includedir}/vulkan"
+FILES:libegl-mesa-dev = "${libdir}/libEGL*.* ${includedir}/EGL ${includedir}/KHR ${libdir}/pkgconfig/egl.pc"
+FILES:libgbm-dev = "${libdir}/libgbm.* ${libdir}/pkgconfig/gbm.pc ${includedir}/gbm.h ${includedir}/gbm_backend_abi.h"
+FILES:libgl-mesa-dev = "${libdir}/libGL.* ${includedir}/GL/*.h ${libdir}/pkgconfig/gl.pc ${libdir}/pkgconfig/glx.pc"
+FILES:libglapi-dev = "${libdir}/libglapi.*"
+FILES:libgles1-mesa-dev = "${libdir}/libGLESv1*.* ${includedir}/GLES ${libdir}/pkgconfig/glesv1*.pc"
+FILES:libgles2-mesa-dev = "${libdir}/libGLESv2.* ${includedir}/GLES2 ${includedir}/GLES3 ${libdir}/pkgconfig/glesv2.pc"
+FILES:libteflon = "${libdir}/libteflon.so"
+# catch all to get all the tools and data
+FILES:${PN}-tools = "${bindir} ${datadir}"
+ALLOW_EMPTY:${PN}-tools = "1"
+
+# All DRI drivers are symlinks to libdril_dri.so
+INSANE_SKIP:${PN}-megadriver += "dev-so"
+
+# OpenCL ICDs package also ship correspondig .so files, there is no -dev package
+INSANE_SKIP:libopencl-mesa += "dev-so"
+
+# Fix upgrade path from mesa to mesa-megadriver
+RREPLACES:mesa-megadriver = "mesa"
+RCONFLICTS:mesa-megadriver = "mesa"
+RPROVIDES:mesa-megadriver = "mesa"
+
+# As of May 2025 it is known that LTO breaks Mesa, for example:
+# https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34318
+LTO = ""

--- a/meta-luneos-backports-6.0/recipes-graphics/mesa/mesa_26.1.0.bb
+++ b/meta-luneos-backports-6.0/recipes-graphics/mesa/mesa_26.1.0.bb
@@ -1,0 +1,21 @@
+require mesa.inc
+
+# Use git for development version (26.1.0-devel)
+SRCREV = "e57fca6de22ccbc758384f4bb8c1be998a5dd825"
+
+SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https;branch=main"
+
+S = "${WORKDIR}/git"
+
+PV = "26.1.0+git"
+
+# Default packageconfig for this version
+PACKAGECONFIG = " \
+    expat \
+    gallium \
+    video-codecs \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm', '', d)} \
+    xmlconfig \
+    zlib \
+"

--- a/meta-luneos/conf/distro/include/luneos-preferred-versions.inc
+++ b/meta-luneos/conf/distro/include/luneos-preferred-versions.inc
@@ -11,6 +11,9 @@ PREFERRED_VERSION_mksnapshot-cross-${TARGET_ARCH} = "${PREFERRED_VERSION_webrunt
 # https://gitlab.com/mobian1/eg25-manager/-/issues/45
 PREFERRED_VERSION_libgpiod = "1.6.4"
 
+# We need latest mesa from meta-luneos-backports-6.0 for all machines
+PREFERRED_VERSION_mesa = "26.1.0%"
+
 # Prefer gstreamer version 1.22.% from oe-core for webos
 GSTREAMER_VERSION = "1.22.%"
 

--- a/meta-luneos/conf/layer.conf
+++ b/meta-luneos/conf/layer.conf
@@ -12,6 +12,7 @@ LAYERSERIES_COMPAT_meta-luneos = "scarthgap"
 
 LAYERDEPENDS_meta-luneos = "\
   meta-luneos-backports-5.1 \
+  meta-luneos-backports-6.0 \
   meta-luneui \
   qt6-layer \
   networking-layer \

--- a/meta-luneos/recipes-core/images/luneos-dev-image.bb
+++ b/meta-luneos/recipes-core/images/luneos-dev-image.bb
@@ -22,7 +22,6 @@ MESA_PKGS = " \
     libgbm \
     mesa-megadriver \
     libgles1-mesa \
-    libglapi \
 "
 
 IMAGE_INSTALL:append = " \
@@ -31,6 +30,11 @@ IMAGE_INSTALL:append = " \
     qtbase-plugins \
     glmark2 \
     kernel-modules \
+"
+
+IMAGE_INSTALL:append:tenderloin = " \
+    ${MESA_PKGS} \
+    luneos-mainline-debug \
 "
 
 IMAGE_INSTALL:append:qemuall = " \

--- a/meta-luneui/recipes-core/images/luneui-example-image.bb
+++ b/meta-luneui/recipes-core/images/luneui-example-image.bb
@@ -10,7 +10,6 @@ MESA_PKGS = " \
     libgbm \
     mesa-megadriver \
     libgles1-mesa \
-    libglapi \
 "
 
 IMAGE_INSTALL += " \

--- a/meta-luneui/recipes-graphics/mesa/mesa_%.bbappend
+++ b/meta-luneui/recipes-graphics/mesa/mesa_%.bbappend
@@ -3,8 +3,21 @@ PACKAGECONFIG:append:class-target = " gallium"
 # Use gallium and llvmpipe for rendering in qemu
 PACKAGECONFIG:append:class-target:qemuall = " gallium-llvm"
 
+# The emulator runs on virtual GPUs: VMSVGA/vmwgfx under VirtualBox and VMware
+# (gallium "svga"), virtio-gpu under qemu (gallium "virgl"). oe-core's mesa
+# pulled both in implicitly on x86-64 once gallium-llvm was set, but
+# meta-mainline's mesa 26.x requires them to be requested explicitly, so they
+# have to be listed here or the emulator ends up with freedreno/lima/llvmpipe
+# only and surface-manager crashes on a failed EGL init.
+PACKAGECONFIG:append:class-target:qemuall = " svga virtio"
+
 PACKAGECONFIG:append:class-target = " gbm"
 
 # Enable freedreno driver
-PACKAGECONFIG:append = " kmsro freedreno"
+PACKAGECONFIG:append = " freedreno"
 GALLIUMDRIVERS:append = ",freedreno"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Allow minor patch fuzz for triple buffering patch (context differs slightly)
+ERROR_QA:remove = "patch-fuzz"


### PR DESCRIPTION
Update Mesa to 26.1.0 for Tenderloin mainline, also update to newer meson and wayland-protocols as well.

Mostly cherry picked from upstream Yocto.