### PR TITLE
Frameworks: Implement scaffolding for Mojo support

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-webos-extended.bb
@@ -72,6 +72,13 @@ WEBOS_PACKAGESET_ENYO_1 = " \
     luna-init-fonts \
 "
 
+# Mojo 1, for applications predating Enyo. mojo-framework needs a tarball
+# extracted from a legacy webOS image (Mojo was never open-sourced), so it is
+# left out of the default set - see mojo-framework.bb. Add it with:
+#     WEBOS_PACKAGESET_MOJO_1:append = " mojo-framework"
+# or by setting MOJO_FRAMEWORK_TARBALL and adding mojo-framework directly.
+WEBOS_PACKAGESET_MOJO_1 ?= ""
+
 WEBOS_PACKAGESET_SYSTEMAPPS = " \
     ${VIRTUAL-RUNTIME_unifiedsearch} \
     luna-systemui \
@@ -154,6 +161,7 @@ RDEPENDS:${PN} = " \
     configd \
     configurator \
     ${WEBOS_PACKAGESET_ENYO_1} \
+    ${WEBOS_PACKAGESET_MOJO_1} \
     event-monitor \
     filecache \
     gssdp \

--- a/meta-luneos/recipes-webos-owo/frameworks/mojo-framework.bb
+++ b/meta-luneos/recipes-webos-owo/frameworks/mojo-framework.bb
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 Herman van Hazendonk
+
+SUMMARY = "Mojo 1.0 JavaScript application framework"
+DESCRIPTION = "Palm's Mojo framework (submission 506, as shipped in webOS 3.0.5), \
+adapted to run on WebAppMgr's Chromium instead of LunaSysMgr's WebKit. Provides \
+/usr/palm/frameworks/mojo for applications whose index.html carries \
+<script src=\"/usr/palm/frameworks/mojo/mojo.js\" x-mojo-version=\"1\">."
+SECTION = "webos/frameworks"
+
+# Mojo was never open-sourced. Open webOS released Enyo; Mojo stayed
+# proprietary to Palm/HP, so this recipe cannot fetch it the way enyo-1.0.bb
+# fetches from git - the framework is extracted from a webOS image the builder
+# already holds a licence to use. Nothing Palm-authored is redistributed by
+# this layer: the tarball is supplied locally, and our own changes ship as a
+# patch plus two new files.
+LICENSE = "CLOSED"
+
+PV = "1.0-506"
+PR = "r0"
+
+inherit webos_filesystem_paths
+inherit allarch
+
+# Produce the tarball with extract-mojo-framework.sh (next to this recipe).
+# A bare "file://name" is looked up on FILESPATH, which only covers the
+# recipe's own directories - and nothing Palm-authored belongs in the layer -
+# so the path has to be absolute. It defaults to DL_DIR, where the extraction
+# script suggests putting it; override either half in local.conf.
+MOJO_FRAMEWORK_TARBALL ?= "mojo-framework-${PV}.tar.gz"
+MOJO_FRAMEWORK_DIR ?= "${DL_DIR}"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/mojo-framework:"
+
+SRC_URI = " \
+    file://${MOJO_FRAMEWORK_DIR}/${MOJO_FRAMEWORK_TARBALL} \
+    file://0001-mojo.js-load-the-framework-builtins-from-disk.patch;patchdir=${S}/mojo;striplevel=1 \
+    file://mojo-compat.js \
+    file://denativize.py \
+    file://extract-mojo-framework.sh \
+"
+
+S = "${UNPACKDIR}/mojo-framework-${PV}"
+
+# denativize.py is a build-time tool only; nothing needs python at runtime.
+DEPENDS = "python3-native"
+
+# Prototype 1.6.0.3 replaces the builtin Prototype rewrite, and mojo.core is
+# reached through mojoloader.
+RDEPENDS:${PN} += "mojoloader"
+
+do_compile() {
+    # The builtin blobs were compiled into LunaSysMgr's WebKit as V8 natives.
+    # Their trailers call %SetProperty(global, ...), a privileged intrinsic
+    # that makes Chromium reject the whole file at parse time. Rewrite the
+    # trailer into a plain global assignment; a classic script publishes the
+    # declaration anyway.
+    for blob in ${S}/mojo/builtins/palmInitFramework*.js; do
+        [ -e "$blob" ] || continue
+        bbnote "de-nativizing $(basename $blob)"
+        python3 ${UNPACKDIR}/denativize.py "$blob" "$blob.new"
+        mv "$blob.new" "$blob"
+    done
+}
+
+do_install() {
+    install -d ${D}${webos_frameworksdir}
+
+    # -a: the submission's templates and images symlink into ../mojocommon
+    # with relative paths that only resolve if both land side by side.
+    cp -a ${S}/mojo ${D}${webos_frameworksdir}/
+    cp -a ${S}/mojocommon ${D}${webos_frameworksdir}/
+    cp -a ${S}/mojo.core ${D}${webos_frameworksdir}/
+    cp -a ${S}/prototype ${D}${webos_frameworksdir}/
+    install -m 0644 ${S}/mojo-core.js ${D}${webos_frameworksdir}/mojo-core.js
+
+    # Compensates for behaviour Mojo relied on in 2011 WebKit: the missing
+    # border-style on every -webkit-border-image rule, and the PalmSystem
+    # members WebAppMgr does not implement. Loaded by the patched mojo.js.
+    install -m 0644 ${UNPACKDIR}/mojo-compat.js ${D}${webos_frameworksdir}/mojo/mojo-compat.js
+
+    # cp -a keeps the uid/gid the tarball was created with, which is whoever
+    # unpacked the webOS image. Those ids mean nothing on the target and make
+    # do_package fail its host-contamination check.
+    chown -R root:root ${D}${webos_frameworksdir}
+}
+
+FILES:${PN} += "${webos_frameworksdir}"
+
+# The framework blobs are minified JavaScript with very long lines; nothing
+# here is ELF, so the usual QA passes have nothing to inspect.
+INSANE_SKIP:${PN} += "arch"
+
+python do_fetch:prepend() {
+    import os
+    path = os.path.join(d.getVar("MOJO_FRAMEWORK_DIR"), d.getVar("MOJO_FRAMEWORK_TARBALL"))
+    if not os.path.exists(path):
+        bb.fatal(
+            "%s is missing.\n"
+            "Mojo was never open-sourced, so it has to be extracted from a webOS\n"
+            "image you hold a licence to use:\n\n"
+            "    meta-luneos/recipes-webos-owo/frameworks/mojo-framework/"
+            "extract-mojo-framework.sh \\\n"
+            "        /path/to/unpacked-webos-rootfs %s\n\n"
+            "Set MOJO_FRAMEWORK_DIR / MOJO_FRAMEWORK_TARBALL in local.conf to put it "
+            "elsewhere." % (path, d.getVar("MOJO_FRAMEWORK_DIR")))
+}

--- a/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/0001-mojo.js-load-the-framework-builtins-from-disk.patch
+++ b/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/0001-mojo.js-load-the-framework-builtins-from-disk.patch
@@ -1,0 +1,114 @@
+From: LuneOS
+Subject: [PATCH] mojo.js: load the framework builtins from disk
+
+LunaSysMgr compiled Prototype and the Mojo framework into WebKit as V8
+builtins and injected them into every application's global object before any
+app script ran, so mojo.js only had to call an init function that was already
+there. WebAppMgr has no equivalent injection hook, leaving window
+[palmInitFramework506] undefined and sending mojo.js down its source-tree
+fallback -- a javascripts/ directory released submissions do not ship.
+
+Fetch the same code as ordinary scripts instead. These have to be
+parser-blocking document.write()s rather than appended <script> elements:
+everything after the mojo.js tag assumes the framework is fully initialised,
+which only holds if they run before parsing resumes. Using script tags rather
+than eval() also keeps V8's code cache covering the 812KB blob.
+
+The builtin Prototype is a natives-context rewrite that cannot be parsed
+outside it, so stock Prototype 1.6.0.3 -- which ships in the same rootfs and
+is what the builtin was derived from -- is loaded in its place.
+
+mojo-compat.js is loaded ahead of the framework because the PalmSystem
+members it fills in are read during initialisation.
+
+Upstream-Status: Inappropriate [no upstream; Mojo was never open-sourced]
+
+--- a/mojo.js
++++ b/mojo.js
+@@ -141,10 +141,15 @@
+ 		if (builtinFrameworkInit) {
+ 			console.log("=========> Calling " + builtinFrameworkName);
+ 			builtinFrameworkInit(window,navigator,document);
++		} else if (Mojo.Version.use !== 'trunk') {
++			// No host-injected builtin, and released submissions ship the
++			// framework only as a builtin blob (there is no javascripts/
++			// source tree under submissions/NNN). Pull the blob off disk.
++			Mojo.writeBuiltinScripts(builtinFrameworkName);
+ 		} else {
+ 			// if prototype is built-in, pull in framework directly, rather than loader that pulls in
+ 			// prototype then framework. This is a little hacky, since it depends on knowing what's in
+-			// loader.js, but it will work correctly for all the old submissions. 
++			// loader.js, but it will work correctly for all the old submissions.
+ 			if (window.palmInitPrototype || window.InstallPrototypeBuiltIn) {
+ 				initialFileName = 'framework';
+ 			} else {
+@@ -158,6 +163,69 @@
+ 	},
+ 
+ 	/**
++	* @private
++	* Load the framework the way LunaSysMgr used to provide it.
++	*
++	* LunaSysMgr compiled Prototype and the framework into WebKit as V8
++	* builtins and injected them into every app's global object before any
++	* app script ran, so mojo.js only ever had to call the init function.
++	* WebAppMgr has no equivalent injection hook, so fetch the same code as
++	* ordinary scripts.
++	*
++	* These have to be parser-blocking document.write()s rather than
++	* appended <script> elements: everything after the mojo.js tag - the
++	* app's own markup and inline scripts - assumes the framework is fully
++	* initialised, which only holds if these run before parsing resumes.
++	*/
++	writeBuiltinScripts: function(builtinFrameworkName) {
++		var builtins = '/usr/palm/frameworks/mojo/builtins/';
++
++		// The builtin Prototype is a natives-context rewrite that cannot be
++		// parsed outside it; the stock 1.6.0.3 it was derived from exposes
++		// the same API and loads as a normal script.
++		if (!window.palmInitPrototype && !window.InstallPrototypeBuiltIn) {
++			document.write('<script type="text/javascript" onerror="Mojo.reportLoadError();"' +
++				' src="/usr/palm/frameworks/prototype/prototype-1.6.0.3.js"><\/script>');
++		}
++
++		// Modern-Blink fixups. Loaded ahead of the framework because the
++		// PalmSystem members it fills in are read during initialisation;
++		// its stylesheet pass is deferred and picks up Mojo's sheets as
++		// they are attached.
++		document.write('<script type="text/javascript"' +
++			' src="/usr/palm/frameworks/mojo/mojo-compat.js"><\/script>');
++
++		document.write('<script type="text/javascript" onerror="Mojo.reportLoadError();" src="' +
++			builtins + builtinFrameworkName + '.js"><\/script>');
++
++		// Runs once the blob above has been evaluated and has published its
++		// init function onto window.
++		document.write('<script type="text/javascript">Mojo.initBuiltinFramework(' +
++			JSON.stringify(builtinFrameworkName) + ');<\/script>');
++	},
++
++	/**
++	* @private
++	* @param {String} builtinFrameworkName
++	*/
++	initBuiltinFramework: function(builtinFrameworkName) {
++		var builtinFrameworkInit = window[builtinFrameworkName];
++		if (!builtinFrameworkInit) {
++			Mojo.reportLoadError();
++			return;
++		}
++		if (typeof window.Prototype === 'undefined') {
++			if (window.InstallPrototypeBuiltIn) {
++				InstallPrototypeBuiltIn(window);
++			} else if (window.palmInitPrototype) {
++				palmInitPrototype(window, navigator, document);
++			}
++		}
++		console.log("=========> Calling " + builtinFrameworkName);
++		builtinFrameworkInit(window, navigator, document);
++	},
++
++	/**
+ 	* @private
+ 	* @param {Object} event
+ 	*/

--- a/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/denativize.py
+++ b/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/denativize.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Strip V8 "natives syntax" from legacy webOS builtin framework blobs.
+
+The blobs under /usr/palm/frameworks/mojo/builtins were compiled into
+LunaSysMgr's WebKit as V8 natives, so their trailers use privileged
+runtime intrinsics (%SetProperty, %ToFastProperties, %FunctionSetPrototype)
+and the natives-context `global` object. Neither is valid in an ordinary
+script, so Chromium refuses to parse the file at all.
+
+Every blob follows the same shape: plain JavaScript that declares the payload
+as a top-level function/object, followed by a small Setup* trailer that
+publishes it onto `global`. Loading the file as a classic script already
+publishes top-level declarations onto `window`, so the trailer only needs to
+be replaced with an explicit global assignment.
+"""
+import re
+import sys
+from pathlib import Path
+
+# `%SetProperty(global, "<name>", <value>, <attrs>)` names the global the blob
+# is meant to publish, and what it publishes.
+SET_PROPERTY = re.compile(
+    r'%SetProperty\(\s*global\s*,\s*["\'](?P<name>[\w$]+)["\']\s*,\s*(?P<value>[\w$]+)\s*,')
+
+
+def denativize(src: str, path: Path) -> str:
+    m = SET_PROPERTY.search(src)
+    if not m:
+        raise SystemExit(f"{path}: no %SetProperty(global, ...) trailer found")
+    name, value = m.group("name"), m.group("value")
+
+    # The trailer begins at the last top-level statement before the Setup
+    # function that we must not keep: either `const $<name> = <name>;` or the
+    # `function Setup...` declaration itself, whichever comes first.
+    alias = re.search(r'^\s*(?:const|var)\s+\$%s\s*=' % re.escape(name), src, re.M)
+    setup = re.search(r'^\s*function\s+Setup\w*\s*\(', src, re.M)
+    starts = [m2.start() for m2 in (alias, setup) if m2]
+    if not starts:
+        raise SystemExit(f"{path}: found %SetProperty but no recognisable trailer start")
+    cut = min(starts)
+
+    body = src[:cut].rstrip()
+
+    # `$<name>` is the natives-side alias for the payload; outside the natives
+    # context the payload is reachable under its own declared name. The blobs
+    # that publish an `exports` object build it inside the Setup* function, so
+    # for those the whole wrapper has to be retained and merely re-published.
+    published = value[1:] if value.startswith("$") else value
+    if not re.search(r'^\s*(?:function|var|const|let)\s+%s\b' % re.escape(published), body, re.M):
+        raise SystemExit(
+            f"{path}: trailer publishes {value!r}, but no top-level declaration of "
+            f"{published!r} survives the cut - needs manual handling")
+
+    return (body + "\n\n"
+            "/* de-nativized for Chromium: the original trailer published this via\n"
+            " * %SetProperty(global, ...), a V8 natives intrinsic unavailable to\n"
+            " * ordinary scripts. Classic-script evaluation already puts the\n"
+            " * declaration on the global object; assign explicitly to be safe. */\n"
+            f"if (typeof window !== 'undefined') {{ window.{name} = {published}; }}\n")
+
+
+def main():
+    if len(sys.argv) < 3:
+        raise SystemExit(f"usage: {sys.argv[0]} <src.js> <dest.js>")
+    src, dest = Path(sys.argv[1]), Path(sys.argv[2])
+    out = denativize(src.read_text(encoding="utf-8", errors="surrogateescape"), src)
+    dest.write_text(out, encoding="utf-8", errors="surrogateescape")
+    print(f"{src.name}: {src.stat().st_size} -> {len(out.encode('utf-8', 'surrogateescape'))} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/extract-mojo-framework.sh
+++ b/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/extract-mojo-framework.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Build the source tarball mojo-framework.bb expects, from a legacy webOS
+# root filesystem.
+#
+# Mojo was never open-sourced - Open webOS released Enyo and kept Mojo
+# proprietary to Palm/HP - so there is no repository for the recipe to fetch.
+# The framework has to come off a webOS 3.0.5 image you already hold a licence
+# to use.  Point this script at an unpacked rootfs (or a mounted doctor image)
+# and drop the result into your downloads directory.
+#
+#   ./extract-mojo-framework.sh /path/to/nova-cust-image-*.rootfs ~/downloads
+#
+# Only the pieces the framework needs at runtime are taken:
+#
+#   mojo/         mojo.js, the submission's assets and the builtin blobs
+#   mojocommon/   shared images and templates; mojo/ symlinks into it
+#   mojo.core/    loadable framework behind mojo-core.js
+#   prototype/    stock Prototype 1.6.0.3, used instead of the builtin rewrite
+#
+set -e
+
+ROOTFS="$1"
+OUTDIR="${2:-.}"
+SUBMISSION="${MOJO_SUBMISSION:-506}"
+
+if [ -z "$ROOTFS" ]; then
+    echo "usage: $0 <webos-rootfs-dir> [output-dir]" >&2
+    exit 1
+fi
+
+FW="$ROOTFS/usr/palm/frameworks"
+if [ ! -d "$FW/mojo/submissions/$SUBMISSION" ]; then
+    echo "error: $FW/mojo/submissions/$SUBMISSION not found." >&2
+    echo "       Is '$ROOTFS' an unpacked webOS root filesystem?" >&2
+    exit 1
+fi
+
+VERSION="1.0-$SUBMISSION"
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+DEST="$STAGE/mojo-framework-$VERSION"
+mkdir -p "$DEST"
+
+# -a keeps the relative symlinks under mojo/submissions/NNN that point into
+# mojocommon; they resolve once both are installed side by side.
+for part in mojo mojocommon mojo.core prototype; do
+    if [ ! -e "$FW/$part" ]; then
+        echo "error: missing $FW/$part" >&2
+        exit 1
+    fi
+    cp -a "$FW/$part" "$DEST/"
+done
+cp -a "$FW/mojo-core.js" "$DEST/"
+
+# Other submissions and the Mojo 2 tree are dead weight for LuneOS, which
+# builds x-mojo-version="1" only.
+find "$DEST/mojo/submissions" -mindepth 1 -maxdepth 1 -type d \
+     ! -name "$SUBMISSION" -exec rm -rf {} +
+
+# Only the two framework blobs survive de-nativization; the per-library
+# builtins publish an object built inside their trailer and have loadable
+# equivalents under /usr/palm/frameworks anyway.
+find "$DEST/mojo/builtins" -type f -name '*.js' \
+     ! -name 'palmInitFramework*.js' -delete
+
+TARBALL="$OUTDIR/mojo-framework-$VERSION.tar.gz"
+mkdir -p "$OUTDIR"
+tar -czf "$TARBALL" -C "$STAGE" "mojo-framework-$VERSION"
+
+echo "wrote $TARBALL"
+echo
+echo "Add to your build, e.g. in conf/local.conf:"
+echo "    MOJO_FRAMEWORK_TARBALL = \"mojo-framework-$VERSION.tar.gz\""
+echo "and make sure $OUTDIR is on DL_DIR or FILESEXTRAPATHS."
+echo
+echo "sha256sum:"
+sha256sum "$TARBALL"

--- a/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/mojo-compat.js
+++ b/meta-luneos/recipes-webos-owo/frameworks/mojo-framework/mojo-compat.js
@@ -1,0 +1,513 @@
+/*--------------------------------------------------------------------------
+*  Mojo compatibility shim for modern Blink/Chromium
+*
+*  Loaded by mojo.js immediately after the framework blob. Everything here
+*  compensates for behaviour the framework relied on in LunaSysMgr's WebKit
+*  (circa 2011) that current Chromium implements differently.
+*--------------------------------------------------------------------------*/
+/*globals Mojo */
+
+(function () {
+	"use strict";
+
+	/*
+	 * -webkit-border-image without border-style
+	 * ------------------------------------------
+	 * Practically every framed surface in Mojo - grouped lists, buttons,
+	 * dialogs, menus, selection highlights - is drawn with
+	 *
+	 *     border-width: 40px 18px 18px 18px;
+	 *     -webkit-border-image: url(palm-group.png) 40 18 18 18 repeat repeat;
+	 *
+	 * and never sets border-style. The 2011 WebKit painted the border image
+	 * regardless. CSS says border-width computes to 0 when border-style is
+	 * none, so Blink resolves those widths to 0 and paints nothing at all:
+	 * the chrome disappears and only bare text is left on the background.
+	 *
+	 * Blink still accepts the -webkit-border-image shorthand and resolves it
+	 * to the standard border-image-* longhands, so the images themselves are
+	 * fine. Only the missing border-style needs supplying.
+	 *
+	 * This is done over the CSSOM rather than by rewriting the framework
+	 * stylesheets because apps ship their own CSS in exactly the same style
+	 * (overriding the images while reusing the framework's classes), and
+	 * those files are outside anything we package.
+	 *
+	 * border-color is forced transparent so that if an image ever fails to
+	 * load the result is the old invisible border rather than a solid slab
+	 * of the inherited text colour.
+	 */
+	var patchedSheets = typeof WeakSet === "function" ? new WeakSet() : null;
+
+	/*
+	 * "" when the rule says nothing about a border image, "none" when it
+	 * explicitly turns one off, otherwise the image value.
+	 */
+	function declaredBorderImage(style) {
+		return style.getPropertyValue("border-image-source") ||
+			style.getPropertyValue("-webkit-border-image") || "";
+	}
+
+	function hasBorderImage(style) {
+		var source = declaredBorderImage(style);
+		return !!source && source !== "none" && source !== "initial";
+	}
+
+	function clearsBorderImage(style) {
+		var source = declaredBorderImage(style);
+		return source === "none" || source === "initial";
+	}
+
+	function patchRuleList(rules) {
+		if (!rules) {
+			return 0;
+		}
+		var patched = 0;
+		for (var i = 0; i < rules.length; i++) {
+			var rule = rules[i];
+
+			// @import pulls in a whole further stylesheet, reached through
+			// .styleSheet rather than .cssRules. Nearly all of Mojo's styling
+			// arrives this way - global.css is little more than nine imports
+			// (menus, lists, buttons, textfields, ...) - so skipping these
+			// silently leaves most of the framework unpatched.
+			if (rule.styleSheet) {
+				patched += patchStyleSheet(rule.styleSheet);
+				continue;
+			}
+
+			// @media / @supports and friends nest further rules.
+			if (rule.cssRules && !rule.style) {
+				patched += patchRuleList(rule.cssRules);
+				continue;
+			}
+			if (!rule.style) {
+				continue;
+			}
+
+			/*
+			 * The legacy shorthand worked both ways: setting an image made
+			 * the border paint, and "-webkit-border-image: none" put the
+			 * border back to nothing. Apps lean on the second half - the
+			 * Device Info override replaces the page header's image with a
+			 * plain background:
+			 *
+			 *     .palm-page-header {
+			 *       background: url(toolbar_light_top.png) bottom left repeat-x;
+			 *       -webkit-border-image: none;
+			 *     }
+			 *
+			 * Restoring border-style on the framework rule without honouring
+			 * this leaves the header with real 35px/13px transparent borders
+			 * that nothing paints, and its title is pushed out of view.
+			 */
+			if (clearsBorderImage(rule.style)) {
+				if (!rule.style.getPropertyValue("border-style")) {
+					rule.style.setProperty("border-style", "none");
+				}
+				if (!rule.style.getPropertyValue("border-width")) {
+					rule.style.setProperty("border-width", "0");
+				}
+				patched++;
+				continue;
+			}
+
+			if (!hasBorderImage(rule.style)) {
+				continue;
+			}
+			// Respect an author who did specify a style; only fill the gap.
+			if (rule.style.getPropertyValue("border-style")) {
+				continue;
+			}
+			rule.style.setProperty("border-style", "solid");
+			if (!rule.style.getPropertyValue("border-color")) {
+				rule.style.setProperty("border-color", "transparent");
+			}
+			patched++;
+		}
+		return patched;
+	}
+
+	function patchStyleSheet(sheet) {
+		if (!sheet || (patchedSheets && patchedSheets.has(sheet))) {
+			return 0;
+		}
+		var rules;
+		try {
+			rules = sheet.cssRules;
+		} catch (e) {
+			// Opaque sheet (should not happen for file:// but be safe).
+			return 0;
+		}
+		if (!rules) {
+			return 0;			// still loading; the load event brings us back
+		}
+		if (patchedSheets) {
+			patchedSheets.add(sheet);
+		}
+		return patchRuleList(rules);
+	}
+
+	function patchAllStyleSheets() {
+		var total = 0;
+		var sheets = document.styleSheets;
+		for (var i = 0; i < sheets.length; i++) {
+			total += patchStyleSheet(sheets[i]);
+		}
+		return total;
+	}
+
+	/*
+	 * Mojo pulls scene and app stylesheets in after startup (and each stage
+	 * gets its own document), so one pass at load time is not enough. Watch
+	 * for new style/link nodes and patch each as it becomes readable.
+	 */
+	function watchForNewStyleSheets() {
+		if (typeof MutationObserver !== "function") {
+			return;
+		}
+		var observer = new MutationObserver(function (records) {
+			for (var i = 0; i < records.length; i++) {
+				var added = records[i].addedNodes;
+				for (var j = 0; j < added.length; j++) {
+					var node = added[j];
+					if (!node.tagName) {
+						continue;
+					}
+					var tag = node.tagName.toLowerCase();
+					if (tag !== "link" && tag !== "style") {
+						continue;
+					}
+					if (node.sheet) {
+						patchStyleSheet(node.sheet);
+					} else {
+						node.addEventListener("load", function () {
+							patchStyleSheet(this.sheet);
+						});
+					}
+				}
+			}
+		});
+		observer.observe(document.documentElement, {childList: true, subtree: true});
+	}
+
+	function run() {
+		var patched = patchAllStyleSheets();
+		if (window.Mojo && Mojo.Log && Mojo.Log.info) {
+			Mojo.Log.info("Mojo compat: applied border-style to " + patched + " border-image rules");
+		}
+	}
+
+	// External stylesheets referenced in <head> are not necessarily parsed
+	// when this script runs, so patch at every point where more may have
+	// arrived, and keep watching afterwards.
+	run();
+	watchForNewStyleSheets();
+	document.addEventListener("DOMContentLoaded", run, false);
+	window.addEventListener("load", run, false);
+
+	/*
+	 * PalmSystem members LunaSysMgr had and WebAppMgr does not
+	 * ---------------------------------------------------------
+	 * Mojo calls some of these without checking for them first, so a missing
+	 * one is not a degraded feature but a TypeError that aborts whatever was
+	 * in progress - scene transitions and the app menu among them.
+	 *
+	 * Mojo carries its own desktop-host stand-in for PalmSystem (the object
+	 * with version "mojo-host"), which is Palm's own statement of what each
+	 * of these should do when the compositor cannot. Those semantics are
+	 * reused here, and anything WebAppMgr can genuinely back is wired up
+	 * rather than stubbed.
+	 *
+	 * Deliberately NOT defined, because Mojo already guards them and reports
+	 * their absence honestly:
+	 *   encrypt / decrypt        - Mojo.Model logs "not implemented"
+	 *   crossAppSceneActive      - cross-app scenes need compositor support
+	 *   runCrossAppTransition    - Mojo falls back to no transition
+	 */
+	/* Duration and curve chosen to sit close to the card transition sysmgr
+	 * used to run; long enough to read as movement, short enough that it
+	 * never delays a tap. */
+	var TRANSITION_MS = 220;
+	var TRANSITION_EASING = "cubic-bezier(0.25, 0.1, 0.25, 1)";
+	var currentAnimation = null;
+
+	function reduceMotion() {
+		return !!(window.matchMedia &&
+			window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+	}
+
+	/*
+	 * Animate whichever scene has just become the top one. Deferred by a
+	 * frame because Mojo runs the transition before the scene stack settles.
+	 */
+	function animateIncomingScene(fromScale) {
+		if (typeof window.requestAnimationFrame !== "function") {
+			return;
+		}
+		window.requestAnimationFrame(function () {
+			var element = topSceneContainer();
+			if (!element || typeof element.animate !== "function") {
+				return;
+			}
+			if (currentAnimation) {
+				// A second push landing mid-flight: drop the old one rather
+				// than leaving two transforms fighting over one element.
+				currentAnimation.cancel();
+			}
+			try {
+				currentAnimation = element.animate([
+					{opacity: 0, transform: "scale(" + fromScale + ")"},
+					{opacity: 1, transform: "scale(1)"}
+				], {
+					duration: TRANSITION_MS,
+					easing: TRANSITION_EASING
+					// fill defaults to "none", so the element is left with
+					// exactly the styles Mojo gave it once this finishes.
+				});
+				currentAnimation.onfinish = function () { currentAnimation = null; };
+				currentAnimation.oncancel = function () { currentAnimation = null; };
+			} catch (e) {
+				currentAnimation = null;
+			}
+		});
+	}
+
+	function topSceneContainer() {
+		try {
+			var stage = window.Mojo && Mojo.Controller && Mojo.Controller.stageController;
+			var scene = stage && stage.topScene && stage.topScene();
+			var element = scene && scene.sceneElement;
+			// The scene div sits inside its scroller; animating the scroller
+			// moves the scene's chrome along with its content.
+			return (element && element.parentNode) || element;
+		} catch (e) {
+			return null;
+		}
+	}
+
+	/*
+	 * PalmSystem.deviceInfo is missing the layout metrics
+	 * ----------------------------------------------------
+	 * LunaSysMgr reported maximumCardWidth, maximumCardHeight, touchableRows,
+	 * keyboardAvailable and keyboardSlider alongside the model and version.
+	 * WebAppMgr reports only the model, the platform version and a
+	 * screenWidth/screenHeight pair that are both 0.
+	 *
+	 * Mojo derives touchableRows from maximumCardHeight when the host does
+	 * not supply it:
+	 *
+	 *     touchableRows = Math.floor((maximumCardHeight - 28) / 48)
+	 *
+	 * With maximumCardHeight undefined that is NaN, and the menu widget
+	 * writes the result straight into a class name - the app menu comes up as
+	 * "palm-popup-container palm-touch-rows-NaN". That class is what carries
+	 * the menu's frame:
+	 *
+	 *     #palm-app-menu.palm-touch-rows-7 {
+	 *       -webkit-border-image: url(system-menu-background-solid.png) 30 28 35 28 ...
+	 *     }
+	 *
+	 * so with NaN the menu loses its 30px top and 35px bottom frame while
+	 * .palm-popup-content keeps its matching 31px/26px insets, and the rows
+	 * spill past both ends of the popup - the top and bottom items drop off.
+	 *
+	 * touchableRows is pinned to 7 rather than computed: submission 506 ships
+	 * styling for palm-touch-rows-7 and nothing else, so any other value
+	 * leaves the menu unstyled no matter how large the display is. Seven rows
+	 * (capped at 286px, then scrolling) is what the framework's own artwork is
+	 * cut for.
+	 */
+	var TOUCHABLE_ROWS = 7;
+
+	function installDeviceInfoShim() {
+		var ps = window.PalmSystem;
+		if (!ps) {
+			return;
+		}
+		var raw = ps.deviceInfo;
+		var info;
+		try {
+			info = JSON.parse(raw);
+		} catch (e) {
+			return;			// unrecognisable; leave it alone
+		}
+
+		// Resolved on read: Mojo fetches deviceInfo lazily, by which point
+		// the window has its real size.
+		function augmented() {
+			var out = {};
+			for (var key in info) {
+				if (Object.prototype.hasOwnProperty.call(info, key)) {
+					out[key] = info[key];
+				}
+			}
+			if (!out.screenWidth) {
+				out.screenWidth = window.screen ? window.screen.width : window.innerWidth;
+			}
+			if (!out.screenHeight) {
+				out.screenHeight = window.screen ? window.screen.height : window.innerHeight;
+			}
+			// The card, not the display: this is the area an app is given.
+			if (!out.maximumCardWidth) {
+				out.maximumCardWidth = window.innerWidth || out.screenWidth;
+			}
+			if (!out.maximumCardHeight) {
+				out.maximumCardHeight = window.innerHeight || out.screenHeight;
+			}
+			if (!out.touchableRows) {
+				out.touchableRows = TOUCHABLE_ROWS;
+			}
+			return JSON.stringify(out);
+		}
+
+		try {
+			Object.defineProperty(ps, "deviceInfo", {
+				get: augmented, configurable: true, enumerable: true
+			});
+		} catch (e) {
+			// Not redefinable; nothing further we can do here.
+		}
+	}
+
+	function installPalmSystemShim() {
+		var ps = window.PalmSystem;
+		if (!ps) {
+			return;			// desktop host; Mojo installs its own
+		}
+
+		function define(name, value) {
+			if (ps[name] === undefined) {
+				try {
+					ps[name] = value;
+				} catch (e) {
+					// Some builds expose PalmSystem members as accessors on a
+					// frozen prototype; fall back to an own property.
+					Object.defineProperty(ps, name, {
+						value: value, writable: true, configurable: true
+					});
+				}
+			}
+		}
+
+		var noop = function () {};
+
+		/* --- scene transitions -------------------------------------------
+		 * Legacy transitions ran in the compositor: prepareSceneTransition()
+		 * had sysmgr snapshot the card, and runSceneTransition() animated
+		 * from that snapshot to the live content. WebAppMgr offers nothing
+		 * equivalent, and Mojo calls both unguarded.
+		 *
+		 * We cannot snapshot, but we do not need to: both scenes are
+		 * ordinary elements in one document. By the time Mojo calls
+		 * runSceneTransition() the incoming scene is already display:block
+		 * and the outgoing one is display:none (on a pop it is gone from the
+		 * DOM entirely), so there is nothing to animate *out* - animating
+		 * the incoming scene in is the whole effect that survives.
+		 *
+		 * The scene stack has not caught up at call time (on a push the new
+		 * scene is not in getScenes() yet), so the element is picked up one
+		 * frame later, when topScene() is the scene that just arrived.
+		 *
+		 * Mojo does not wait for us: it calls finish.defer() immediately
+		 * after. That is fine - the animation is decorative and runs
+		 * alongside whatever the scene's activate handler does.
+		 */
+		define("prepareSceneTransition", noop);
+
+		define("runSceneTransition", function (type, isPop) {
+			if (type === "none" || reduceMotion()) {
+				return;
+			}
+			// Direction reads as depth: a pushed scene settles back from
+			// slightly too close, a pop rises from slightly too far.
+			var from = (type === "cross-fade") ? 1 : (isPop ? 0.94 : 1.06);
+			animateIncomingScene(from);
+		});
+
+		define("cancelSceneTransition", function () {
+			if (currentAnimation) {
+				currentAnimation.cancel();
+				currentAnimation = null;
+			}
+		});
+		define("cancelCrossAppScene", noop);
+
+		/* --- window properties --------------------------------------------
+		 * WebAppMgr exposes the singular setWindowProperty(key, value);
+		 * Mojo wants the plural bulk form.
+		 */
+		define("setWindowProperties", function (props) {
+			if (!props || typeof ps.setWindowProperty !== "function") {
+				return;
+			}
+			for (var key in props) {
+				if (Object.prototype.hasOwnProperty.call(props, key)) {
+					ps.setWindowProperty(key, String(props[key]));
+				}
+			}
+		});
+
+		/* --- smart-zoom animation driver -----------------------------------
+		 * PalmSystem drove this loop natively. requestAnimationFrame gives
+		 * the same shape: step callbacks with an eased 0..1 progress, then a
+		 * completion callback.
+		 */
+		define("runAnimationLoop", function (target, stepMethod, completeMethod,
+		                                     curve, duration, from, to) {
+			var start = null;
+			var ms = (duration || 0.3) * 1000;
+			var easeOut = function (t) { return 1 - Math.pow(1 - t, 3); };
+			var ease = (curve === "linear") ? function (t) { return t; } : easeOut;
+
+			function frame(now) {
+				if (start === null) {
+					start = now;
+				}
+				var t = Math.min(1, (now - start) / ms);
+				var value = from + (to - from) * ease(t);
+				try {
+					if (target && typeof target[stepMethod] === "function") {
+						target[stepMethod](value);
+					}
+					if (t >= 1) {
+						if (target && typeof target[completeMethod] === "function") {
+							target[completeMethod]();
+						}
+						return;
+					}
+				} catch (e) {
+					return;
+				}
+				window.requestAnimationFrame(frame);
+			}
+			window.requestAnimationFrame(frame);
+		});
+
+		/* --- text and sound ------------------------------------------------ */
+		// Called unguarded when the app menu opens.
+		define("hideSpellingWidget", noop);
+		// Mojo.Format.runTextIndexer expects the text back unchanged.
+		define("runTextIndexer", function (text) { return text; });
+		define("receivePageUpDownInLandscape", noop);
+		define("playSoundNotification", noop);
+		define("setAlertSound", noop);
+
+		/* --- identity ------------------------------------------------------- */
+		define("version", (function () {
+			try {
+				return JSON.parse(ps.deviceInfo).platformVersion || "webappmgr";
+			} catch (e) {
+				return "webappmgr";
+			}
+		}()));
+		// Falsy on a real device; Mojo uses it to pick the emulator input path.
+		define("simulated", false);
+	}
+
+	installDeviceInfoShim();
+	installPalmSystemShim();
+
+	// Exposed so a scene that injects styles by hand can re-run the pass.
+	window.MojoCompat = {patchStyleSheets: patchAllStyleSheets};
+}());


### PR DESCRIPTION
Bring back (optional) support for Mojo apps.

Framework itself cannot be distributed due to closed source licensing, therefore only provided as reference that can be used to generate the required files.