### PR TITLE
mobile-broadband-provider-info: rename halium bbappend to match oe-co…

### DIFF
--- a/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_%.bbappend
+++ b/meta-luneos/recipes-connectivity/mobile-broadband-provider-info/mobile-broadband-provider-info_%.bbappend
@@ -4,11 +4,11 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI:halium  = " \
                     git://github.com/sailfishos/mobile-broadband-provider-info.git;protocol=https;branch=master \
-                    file://meson.build;subdir=git/${BPN} \
-                    file://apns-conf.xsl;subdir=git/${BPN} \
+                    file://meson.build;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/${BPN} \
+                    file://apns-conf.xsl;subdir=${BB_GIT_DEFAULT_DESTSUFFIX}/${BPN} \
 "
 
-S:halium = "${WORKDIR}/git/${BPN}"
+S:halium = "${UNPACKDIR}/${BB_GIT_DEFAULT_DESTSUFFIX}/${BPN}"
 
 SRCREV:halium = "fe500f1b19e8525d09655a38ac111a0fe127b5f9"
 LIC_FILES_CHKSUM:halium = "file://COPYING;md5=87964579b2a8ece4bc6744d2dc9a8b04"


### PR DESCRIPTION
…re's new recipe name, adapt to UNPACKDIR

The meson.build/apns-conf.xsl halium overrides and apns-conf.xml generation were already present on scarthgap independently. What's actually new here: oe-core renamed the mobile-broadband-provider-info recipe (dropping the _git version suffix), so the bbappend has to follow; and the halium S/SRC_URI subdir switches from the literal 'git' WORKDIR path to UNPACKDIR/BB_GIT_DEFAULT_DESTSUFFIX.

(cherry picked and squashed from 491ba1e57, bff248506, be11346c6, c4b5e7540, 4d7fd2d19, 1d1c241cf, 85bc0d8b0, 64b61c25f)