### PR TITLE
pulseaudio: finish the buildpaths/UNPACKDIR fixups already-merged aud…

### DIFF
--- a/meta-luneos/recipes-multimedia/audiod/audiod.bb
+++ b/meta-luneos/recipes-multimedia/audiod/audiod.bb
@@ -80,7 +80,6 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0008-deviceManager-support-sinks-that-PulseAudio-already-o.patch \
     file://audiod-after-pulseaudio.conf \
 "
-S = "${WORKDIR}/git"
 
 # The device configuration lives in audiod-conf, not here, so that changing a
 # machine's audio setup does not rebuild audiod - the same split

--- a/meta-luneos/recipes-multimedia/pulseaudio/audiosystem-passthrough.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/audiosystem-passthrough.bb
@@ -8,18 +8,20 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 inherit pkgconfig
 
-PV = "1.2.1+git"
-SRCREV = "3165200ce2e6aa84274c8bb2134c839a1544153d"
+PV = "1.3.1+git"
+SRCREV = "11a0d95f43c92580a42c08a050b2b5bf18e0f475"
 
 SRC_URI = " \
         git://github.com/mer-hybris/audiosystem-passthrough.git;branch=master;protocol=https \
 "
 
-S = "${WORKDIR}/git"
-
 TARGET_CC_ARCH += "${LDFLAGS}"
 
-EXTRA_OEMAKE = "KEEP_SYMBOLS=1 CROSS_COMPILE=${TARGET_PREFIX} CC='${CC}' "
+# DEBUG_PREFIX_MAP has to ride along on CC: upstream's Makefile assigns CFLAGS
+# itself, so OE's CFLAGS never reach the compiler and the debug info keeps
+# absolute TMPDIR paths. That is only a warning on scarthgap but fails
+# do_package_qa on wrynose with "contains reference to TMPDIR [buildpaths]".
+EXTRA_OEMAKE = "KEEP_SYMBOLS=1 CROSS_COMPILE=${TARGET_PREFIX} CC='${CC} ${DEBUG_PREFIX_MAP}' "
 PARALLEL_MAKE = ""
 
 do_install() {

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-distro-conf_1.0.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-distro-conf_1.0.bb
@@ -19,8 +19,8 @@ SRC_URI = " \
 
 do_install() {
     install -d ${D}${sysconfdir}/pulse
-    install -m 0644 ${WORKDIR}/webos-system.pa ${D}${sysconfdir}/pulse/
-    install -m 0644 ${WORKDIR}/webos-virtual-devices.pa ${D}${sysconfdir}/pulse/
+    install -m 0644 ${UNPACKDIR}/webos-system.pa ${D}${sysconfdir}/pulse/
+    install -m 0644 ${UNPACKDIR}/webos-virtual-devices.pa ${D}${sysconfdir}/pulse/
 }
 
 FILES:${PN} = "${sysconfdir}/pulse"

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-module-palm-policy_git.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-module-palm-policy_git.bb
@@ -25,8 +25,6 @@ SRC_URI = "git://github.com/webosose/pulseaudio-webos.git;branch=master;protocol
     file://Makefile \
 "
 
-S = "${WORKDIR}/git"
-
 inherit pkgconfig
 
 # PA_MAJORMINOR must match the running daemon or PulseAudio refuses to load the
@@ -41,11 +39,11 @@ EXTRA_OEMAKE = " \
 do_configure[noexec] = "1"
 
 do_compile() {
-    oe_runmake -C ${S}/src/modules -f ${WORKDIR}/Makefile all
+    oe_runmake -C ${S}/src/modules -f ${UNPACKDIR}/Makefile all
 }
 
 do_install() {
-    oe_runmake -C ${S}/src/modules -f ${WORKDIR}/Makefile install DESTDIR=${D}
+    oe_runmake -C ${S}/src/modules -f ${UNPACKDIR}/Makefile install DESTDIR=${D}
 }
 
 FILES:${PN} = "${libdir}/pulseaudio/modules/module-palm-policy.so"

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-pulsecore-private-headers_17.0.bb
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio-pulsecore-private-headers_17.0.bb
@@ -16,10 +16,10 @@ SRC_URI = "http://freedesktop.org/software/pulseaudio/releases/pulseaudio-${PV}.
 "
 SRC_URI[sha256sum] = "053794d6671a3e397d849e478a80b82a63cb9d8ca296bd35b73317bb5ceb87b5"
 
-S = "${WORKDIR}/pulseaudio-${PV}"
+S = "${UNPACKDIR}/pulseaudio-${PV}"
 
 do_install() {
-    install -Dm644 ${WORKDIR}/pulsecore.pc ${D}${libdir}/pkgconfig/pulsecore.pc
+    install -Dm644 ${UNPACKDIR}/pulsecore.pc ${D}${libdir}/pkgconfig/pulsecore.pc
     sed -i 's/@PA_MAJORMINOR@/${PV}/g' ${D}${libdir}/pkgconfig/pulsecore.pc
 
     install -d ${D}${includedir}/pulsecore/filter

--- a/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-luneos/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -14,7 +14,7 @@ SRC_URI += " \
 
 do_install:append() {
     install -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${WORKDIR}/pulseaudio.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${UNPACKDIR}/pulseaudio.service ${D}${systemd_unitdir}/system
 
     # Out-of-tree PulseAudio modules (pulseaudio-module-palm-policy) include
     # pulsecore headers, and those refuse to compile unless config.h has been
@@ -25,8 +25,39 @@ do_install:append() {
     # rest of the pulsecore headers come from
     # pulseaudio-pulsecore-private-headers; only config.h has to come from here,
     # because only here does it exist.
+    #
+    # Note this is the one file this recipe puts into ${includedir}/pulsecore,
+    # a directory otherwise populated entirely by
+    # pulseaudio-pulsecore-private-headers. That split is intentional (see above)
+    # but it means the directory has two producers, so if the sysroot staging of
+    # either one is ever interrupted, the leftover config.h has no owner to clean
+    # it up and every consumer then fails do_prepare_recipe_sysroot with
+    # "FileExistsError ... pulsecore/config.h". Recovering from that needs the
+    # orphan removed from the affected work/*/recipe-sysroot trees; it is not
+    # fixed by cleansstate of the consumer alone. See the PR note below.
     install -Dm644 ${B}/config.h ${D}${includedir}/pulsecore/config.h
+
+    # config.h records the absolute paths it was generated in. They are build
+    # metadata that no pulsecore consumer needs, but shipping them trips the
+    # buildpaths QA check:
+    #   File /usr/include/pulsecore/config.h in package pulseaudio-dev
+    #   contains reference to TMPDIR [buildpaths]
+    # Neutralise the values rather than dropping the defines, so anything that
+    # references them still compiles, and rather than silencing the QA check,
+    # which would let a genuine path leak through unnoticed later.
+    sed -i -e 's|^\(#define DOXYGEN_OUTPUT_DIRECTORY\) .*|\1 .|' \
+           -e 's|^\(#define PA_BUILDDIR\) .*|\1 "."|' \
+           -e 's|^\(#define PA_SRCDIR\) .*|\1 "."|' \
+           -e 's|^\(#define top_srcdir\) .*|\1 .|' \
+           ${D}${includedir}/pulsecore/config.h
 }
+
+# Staging config.h adds a file to pulseaudio's sysroot output. A build tree that
+# already staged pulseaudio from before this change keeps a hardlink to the
+# superseded component and collides on the next restage, taking out every
+# pulsecore consumer with the FileExistsError described above. Bumping PR gives
+# those trees a clean re-stage; it is a no-op for a fresh build.
+PR = "r1"
 
 inherit systemd
 


### PR DESCRIPTION
…iod-topology work depends on

Squashed from herrie/wrynose. The bulk of the audiod-topology-split and virtual-devices work already landed on scarthgap independently; this is the residual: audiosystem-passthrough's DEBUG_PREFIX_MAP fix for buildpaths QA, pulseaudio's config.h buildpaths neutralisation + PR bump, and remaining WORKDIR->UNPACKDIR spots in audiod.bb, pulseaudio-distro-conf, and pulseaudio-module-palm-policy.
