### PR TITLE
systemd: hold back to 257.8, the last release with cgroup v1

### DIFF
--- a/meta-luneos-holdbacks-5.3/README
+++ b/meta-luneos-holdbacks-5.3/README
@@ -1,0 +1,86 @@
+meta-luneos-holdbacks-5.3
+=========================
+
+Recipes held back from oe-core *whinlatter* (Yocto 5.3) while the rest of the
+build is on *wrynose* (Yocto 6.0). This is the opposite direction to the
+meta-luneos-backports-* layers, which carry recipes NEWER than the base
+release -- hence the different name. Everything here is a verbatim copy from
+openembedded-core@whinlatter unless noted.
+
+Contents
+--------
+
+  recipes-core/systemd/systemd_257.8.bb        <- oe-core whinlatter, verbatim
+  recipes-core/systemd/systemd-257.inc         <- oe-core whinlatter systemd.inc, RENAMED
+  recipes-core/systemd/dlopen-deps-257.inc     <- oe-core whinlatter dlopen-deps.inc, RENAMED
+  recipes-core/systemd/systemd/                <- oe-core whinlatter, verbatim (36 files)
+
+Only systemd itself is held back. systemd-boot, systemd-systemctl-native,
+systemd-conf, systemd-serialgetty, systemd-machine-units and systemd-bootconf
+all stay on the wrynose versions.
+
+Why the two .inc files are renamed
+----------------------------------
+
+oe-core's systemd.inc is required by systemd_259.5.bb, systemd-boot_259.5.bb
+and systemd-systemctl-native_259.5.bb. This layer has a higher BBFILE_PRIORITY
+than oe-core, so shipping a file literally named systemd.inc would shadow
+oe-core's for all three -- silently handing the two 259.5 recipes we are NOT
+holding back the 257 SRCREV, SRCBRANCH and tag. Renaming to systemd-257.inc /
+dlopen-deps-257.inc and repointing the two `require` lines in systemd_257.8.bb
+keeps the hold-back scoped to exactly one recipe.
+
+Why systemd is held back at all
+-------------------------------
+
+systemd 258 removed cgroup v1 ('legacy' and 'hybrid' hierarchies) outright and
+always mounts cgroup2 during early boot; it also raised the minimum kernel
+baseline to 5.4. 257 is the last release that can run on a cgroup-v1-only
+kernel.
+
+LuneOS' armv7a halium MACHINEs -- tenderloin-halium, hammerhead-halium, mako,
+onyx -- run 3.4 kernels from shr-distribution/linux (branches
+<machine>/3.4/halium-9.0). Those trees have no cgroup v2 at all. Checked at the
+pinned SRCREVs: kernel/cgroup.c is the v1 monolith with a single
+file_system_type and zero occurrences of cgroup2 / sane_behavior /
+CFTYPE_ONLY_ON_DFL, and fs/kernfs -- which cgroup v2 is built on, and which
+landed in 3.14 -- does not exist. Backporting cgroup v2 would mean backporting
+kernfs first.
+
+The kernels do already carry systemd-enabling backports (PR_SET_CHILD_SUBREAPER,
+packetized pipes, seq_show_option, fanotify close-on-exec), which is why they
+run systemd 255 today. cgroup v2 is the one gap that config cannot close.
+
+Getting cgroup v1 actually enabled at runtime
+---------------------------------------------
+
+Since systemd 256, cgroup v1 is refused by default even when the build supports
+it. systemd 257's src/shared/cgroup-setup.c requires BOTH of these on the kernel
+command line:
+
+    systemd.unified_cgroup_hierarchy=0 SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
+
+Note there is deliberately no build-time hierarchy change here: -Ddefault-hierarchy=
+is deprecated in 257 and only 'unified' can be selected as the build-time
+default, so one systemd build serves every MACHINE and only the 3.4 boxes need
+the two extra cmdline arguments. That keeps systemd out of MACHINE_ARCH.
+
+For the mkbootimg-based machines the place to add them is ANDROID_BOOTIMG_CMDLINE
+in the kernel recipe, e.g. meta-smartphone/meta-lg/recipes-kernel/linux/
+linux-lg-hammerhead-halium_git.bb. tenderloin-halium boots a uImage via moboot
+rather than mkbootimg, so its command line comes from the bootloader instead.
+
+Retiring this layer
+-------------------
+
+Drop the layer from bblayers.conf. Nothing else references it -- the
+PREFERRED_VERSION pin lives in conf/layer.conf precisely so that adding and
+removing the layer is the whole operation. That becomes possible once the
+armv7a halium MACHINEs are retired or move to a kernel with cgroup v2.
+
+Maintenance warning
+-------------------
+
+whinlatter is not an LTS and is at or near end of life, so there is no upstream
+stable stream feeding systemd 257 fixes. For as long as this layer is in
+bblayers.conf, LuneOS owns systemd CVE triage for it.

--- a/meta-luneos-holdbacks-5.3/conf/layer.conf
+++ b/meta-luneos-holdbacks-5.3/conf/layer.conf
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 LuneOS / webOS Ports
+
+# We have conf and classes directories => add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories => add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-luneos-holdbacks-5.3"
+BBFILE_PATTERN_meta-luneos-holdbacks-5.3 := "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-luneos-holdbacks-5.3 = "34"
+
+LAYERSERIES_COMPAT_meta-luneos-holdbacks-5.3 = "wrynose"
+
+LAYERDEPENDS_meta-luneos-holdbacks-5.3 = " \
+    core \
+"
+
+# This layer HOLDS BACK systemd, it does not forward-port it. Unlike
+# meta-luneos-backports-*, which carry recipes newer than the base release, the
+# recipes here are older: taken verbatim from oe-core whinlatter (Yocto 5.3).
+#
+# Why: systemd 258 removed cgroup v1 outright and always mounts cgroup2 during
+# early boot. 257 is the last release that can run on a cgroup-v1-only kernel.
+# LuneOS' armv7a halium MACHINEs (tenderloin-halium, hammerhead-halium, mako,
+# onyx) run 3.4 kernels that have no cgroup v2 at all -- not just disabled, but
+# absent: kernel/cgroup.c is the v1 monolith and fs/kernfs, which cgroup v2 is
+# built on and which landed in 3.14, does not exist in that tree. Backporting
+# cgroup v2 would mean backporting kernfs first.
+#
+# Pinning here rather than in meta-luneos/conf/distro/include so that the whole
+# hold-back is applied and reverted by adding/removing this one layer.
+PREFERRED_VERSION_systemd = "257.8"
+
+# Only systemd itself is held back. systemd-boot, systemd-systemctl-native,
+# systemd-conf, systemd-serialgetty and systemd-machine-units all stay on the
+# wrynose versions, which is why systemd.inc and dlopen-deps.inc are carried
+# here under -257 names: an unrenamed systemd.inc in a higher-priority layer
+# would shadow oe-core's for systemd-boot_259.5.bb and
+# systemd-systemctl-native_259.5.bb too, and silently give them 257 metadata.

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/dlopen-deps-257.inc
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/dlopen-deps-257.inc
@@ -1,0 +1,81 @@
+PACKAGEFUNCS =+ "package_generate_dlopen_deps"
+
+python package_generate_dlopen_deps() {
+    # https://systemd.io/ELF_DLOPEN_METADATA/
+
+    import struct, json
+
+    def extract_segment(filename, segment):
+        """
+        Return the named segment from the ELF.
+        """
+        import tempfile, subprocess
+
+        with tempfile.NamedTemporaryFile() as f:
+            try:
+                cmd = [d.getVar("OBJCOPY"), "--dump-section", f"{segment}={f.name}", filename]
+                subprocess.run(cmd, check=True)
+                with open(f.name, "rb") as f2:
+                    return f2.read()
+            except subprocess.CalledProcessError as e:
+                # binutils-objcopy has 0 exit code if the segment can't be found, but llvm-objcopy
+                # does not. Assume the failure isn't critical and ignore errors.
+                if e.returncode == 1:
+                    return b""
+                raise e
+
+    def parse(buffer, is_little):
+        deps = []
+        offset = 0
+        while offset < len(buffer):
+            format = f"{'<' if is_little else '>'}iii"
+            name_size, desc_size, note_type = struct.unpack_from(format, buffer, offset)
+            offset += struct.calcsize(format)
+
+            format = f"{name_size}s0i{desc_size}s0i"
+            if note_type == 0x407c0c0a:
+                name_b, desc_b = struct.unpack_from(format, buffer, offset)
+                name = name_b.strip(b"\x00").decode("ascii")
+                if name == "FDO":
+                    desc = desc_b.strip(b"\x00").decode("utf-8")
+                    deps.append(*json.loads(desc))
+            offset += struct.calcsize(format)
+        return deps
+
+    dep_map = {
+        "required": "RDEPENDS",
+        "recommended": "RRECOMMENDS",
+        "suggested": "RSUGGESTS"
+    }
+
+    shlibs = oe.package.read_shlib_providers(d)
+
+    for pkg, files in pkgfiles.items():
+        # Skip -dbg packages as we won't need to generate dependencies for those
+        # but scanning can take time
+        if pkg.endswith("-dbg"):
+            continue
+
+        for f in files:
+            # Skip symlinks, just look for real libraries
+            if cpath.islink(f):
+                continue
+
+            if ".so." in f or f.endswith(".so"):
+                try:
+                    elf = oe.qa.ELFFile(f)
+                    elf.open()
+                    for dep in parse(extract_segment(f, ".note.dlopen"), elf.isLittleEndian()):
+                        for soname in dep["soname"]:
+                            if soname in shlibs:
+                                # TODO assumes the first match is good
+                                package, version = list(shlibs[soname].values())[0]
+                                dependency = dep_map[dep["priority"]]
+                                bb.note(f"{pkg}: adding {dependency} on {package} via .note.dlopen")
+                                d.appendVar(f"{dependency}:{pkg}", f" {package} (>= {version})")
+                            else:
+                                bb.warn(f"cannot find {soname}")
+                except oe.qa.NotELFFileError as e:
+                    bb.note(f"Cannot extract ELF notes: {e}")
+                    pass
+}

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd-257.inc
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd-257.inc
@@ -1,0 +1,24 @@
+SUMMARY = "A System and service manager"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/systemd"
+
+DESCRIPTION = "systemd is a system and service manager for Linux, compatible with \
+SysV and LSB init scripts. systemd provides aggressive parallelization \
+capabilities, uses socket and D-Bus activation for starting services, \
+offers on-demand starting of daemons, keeps track of processes using \
+Linux cgroups, supports snapshotting and restoring of the system \
+state, maintains mount and automount points and implements an \
+elaborate transactional dependency-based service control logic. It can \
+work as a drop-in replacement for sysvinit."
+
+LICENSE = "GPL-2.0-only & LGPL-2.1-or-later"
+LICENSE:libsystemd = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://LICENSE.GPL2;md5=751419260aa954499f7abaabaa882bbe \
+                    file://LICENSE.LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
+
+SRCREV = "5e38d199a623563698ab4a69acbbe3afa9135198"
+SRCBRANCH = "v257-stable"
+SRC_URI = "git://github.com/systemd/systemd.git;protocol=https;branch=${SRCBRANCH};tag=v${PV} \
+    file://0001-errno-list-filter-out-EFSBADCRC-and-EFSCORRUPTED.patch \
+"
+
+CVE_PRODUCT = "systemd"

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/00-create-volatile.conf
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/00-create-volatile.conf
@@ -1,0 +1,9 @@
+# This goes hand-in-hand with the base-files of OE-Core. The file must
+# be sorted before 'systemd.conf' because this attempts to create a file
+# inside /var/log.
+
+
+d		/run/lock		1777	-	-	-
+d		/var/volatile/log		-	-	-	-
+d		/var/volatile/tmp		1777	-	-
+L		/var/tmp		-	-	-	-	/var/volatile/tmp

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/00-hostnamed-network-user.conf
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/00-hostnamed-network-user.conf
@@ -1,0 +1,6 @@
+[Service]
+# By running with these options instead of root, networkd is allowed to request
+# a hostname change via DBUS when policykit is not present
+User=systemd-network
+Group=systemd-hostname
+AmbientCapabilities=CAP_SYS_ADMIN

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-Do-not-create-var-log-README.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-Do-not-create-var-log-README.patch
@@ -1,0 +1,30 @@
+From 425ad51e727058b48dd4580fd6afe7e51e96a28a Mon Sep 17 00:00:00 2001
+From: Peter Kjellerstedt <pkj@axis.com>
+Date: Tue, 21 Jan 2025 05:02:00 +0100
+Subject: [PATCH] Do not create /var/log/README
+
+/var/log/README is a link to /usr/share/doc/systemd/README.logs. The
+latter is packaged in systemd-doc and likely not installed, which leaves
+/var/log/README as a dead link. Since /var/log/README is not very
+useful, just remove it.
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+---
+ tmpfiles.d/legacy.conf.in | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/tmpfiles.d/legacy.conf.in b/tmpfiles.d/legacy.conf.in
+index b475500e58..650c91a8da 100644
+--- a/tmpfiles.d/legacy.conf.in
++++ b/tmpfiles.d/legacy.conf.in
+@@ -13,9 +13,6 @@
+ 
+ d /run/lock 0755 root root -
+ L /var/lock - - - - ../run/lock
+-{% if CREATE_LOG_DIRS %}
+-L$ /var/log/README - - - - ../..{{DOC_DIR}}/README.logs
+-{% endif %}
+ 
+ {% if HAVE_SYSV_COMPAT %}
+ # /run/lock/subsys is used for serializing SysV service execution, and

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-binfmt-Don-t-install-dependency-links-at-install-tim.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-binfmt-Don-t-install-dependency-links-at-install-tim.patch
@@ -1,0 +1,79 @@
+From e5fd143f215f072404c544f694cb026a4231503e Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Thu, 21 Feb 2019 16:23:24 +0800
+Subject: [PATCH 01/26] binfmt: Don't install dependency links at install time
+ for the binfmt services
+
+use [Install] blocks so that they get created when the service is enabled
+like a traditional service.
+
+The [Install] blocks were rejected upstream as they don't have a way to
+"enable" it on install without static symlinks which can't be disabled,
+only masked. We however can do that in a postinst.
+
+Upstream-Status: Denied
+
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ units/meson.build                       | 2 --
+ units/proc-sys-fs-binfmt_misc.automount | 3 +++
+ units/systemd-binfmt.service.in         | 4 ++++
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/units/meson.build b/units/meson.build
+index 96f4852741..0a3a4fee67 100644
+--- a/units/meson.build
++++ b/units/meson.build
+@@ -156,7 +156,6 @@ units = [
+         {
+           'file' : 'proc-sys-fs-binfmt_misc.automount',
+           'conditions' : ['ENABLE_BINFMT'],
+-          'symlinks' : ['sysinit.target.wants/'],
+         },
+         {
+           'file' : 'proc-sys-fs-binfmt_misc.mount',
+@@ -258,7 +257,6 @@ units = [
+         {
+           'file' : 'systemd-binfmt.service.in',
+           'conditions' : ['ENABLE_BINFMT'],
+-          'symlinks' : ['sysinit.target.wants/'],
+         },
+         {
+           'file' : 'systemd-bless-boot.service.in',
+diff --git a/units/proc-sys-fs-binfmt_misc.automount b/units/proc-sys-fs-binfmt_misc.automount
+index 7ec21e76c9..fee4d1345f 100644
+--- a/units/proc-sys-fs-binfmt_misc.automount
++++ b/units/proc-sys-fs-binfmt_misc.automount
+@@ -22,3 +22,6 @@ Before=shutdown.target
+ 
+ [Automount]
+ Where=/proc/sys/fs/binfmt_misc
++
++[Install]
++WantedBy=sysinit.target
+diff --git a/units/systemd-binfmt.service.in b/units/systemd-binfmt.service.in
+index 318bf8efc2..6ef684861d 100644
+--- a/units/systemd-binfmt.service.in
++++ b/units/systemd-binfmt.service.in
+@@ -14,6 +14,7 @@ Documentation=https://docs.kernel.org/admin-guide/binfmt-misc.html
+ Documentation=https://systemd.io/API_FILE_SYSTEMS
+ DefaultDependencies=no
+ Conflicts=shutdown.target
++Wants=proc-sys-fs-binfmt_misc.automount
+ After=proc-sys-fs-binfmt_misc.automount
+ After=proc-sys-fs-binfmt_misc.mount
+ After=local-fs.target
+@@ -31,3 +32,6 @@ RemainAfterExit=yes
+ ExecStart={{LIBEXECDIR}}/systemd-binfmt
+ ExecStop={{LIBEXECDIR}}/systemd-binfmt --unregister
+ TimeoutSec=90s
++
++[Install]
++WantedBy=sysinit.target
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-errno-list-filter-out-EFSBADCRC-and-EFSCORRUPTED.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-errno-list-filter-out-EFSBADCRC-and-EFSCORRUPTED.patch
@@ -1,0 +1,34 @@
+From fb146f6d2c5118410fd19907651fd8f7310bf69e Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Tue, 24 Feb 2026 20:19:45 +0900
+Subject: [PATCH] errno-list: filter out EFSBADCRC and EFSCORRUPTED
+
+These are introduced in kernel v7.0.
+
+Upstream-Status: Backport [https://github.com/systemd/systemd/commit/3cfb16998808a6ec8012a6120d0a82f0e1a0c8bb]
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+---
+ src/basic/generate-errno-list.sh | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/src/basic/generate-errno-list.sh b/src/basic/generate-errno-list.sh
+index f756b2e020..491fa1b6e3 100755
+--- a/src/basic/generate-errno-list.sh
++++ b/src/basic/generate-errno-list.sh
+@@ -3,9 +3,13 @@
+ set -eu
+ set -o pipefail
+ 
+-# In kernel's arch/parisc/include/uapi/asm/errno.h, ECANCELLED and EREFUSED are defined as aliases of
+-# ECANCELED and ECONNREFUSED, respectively. Let's drop them.
++# In kernel's arch/parisc/include/uapi/asm/errno.h, The following aliases are defined:
++# ECANCELLED → ECANCELED
++# EREFUSED → ECONNREFUSED
++# EFSBADCRC → EBADMSG
++# EFSCORRUPTED → EUCLEAN
++# Let's drop them.
+ 
+ ${1:?} -dM -include errno.h - </dev/null | \
+-       grep -Ev '^#define[[:space:]]+(ECANCELLED|EREFUSED)' | \
++       grep -Ev '^#define[[:space:]]+(ECANCELLED|EREFUSED|EFSBADCRC|EFSCORRUPTED)' | \
+        awk '/^#define[ \t]+E[^ _]+[ \t]+/ { print $2; }'

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-systemctl-Call-systemd-sysv-install-without-path.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0001-systemctl-Call-systemd-sysv-install-without-path.patch
@@ -1,0 +1,37 @@
+From 34c8551a8b16bf235a1ebe8d9cb1a3474a7c975e Mon Sep 17 00:00:00 2001
+From: Peter Kjellerstedt <pkj@axis.com>
+Date: Fri, 22 Aug 2025 18:07:28 +0200
+Subject: [PATCH] systemctl: Call systemd-sysv-install without path
+
+Expect to find systemd-sysv-install in $PATH instead of hardcoding the
+path to it, as the latter does not work when running systemctl from a
+recipe sysroot.
+
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+Upstream-Status: Inappropriate [OE specific]
+---
+ src/systemctl/systemctl-sysv-compat.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/systemctl/systemctl-sysv-compat.c b/src/systemctl/systemctl-sysv-compat.c
+index cb9c43e3dc..e44ef9f64e 100644
+--- a/src/systemctl/systemctl-sysv-compat.c
++++ b/src/systemctl/systemctl-sysv-compat.c
+@@ -140,7 +140,7 @@ int enable_sysv_units(const char *verb, char **args) {
+         while (args[f]) {
+ 
+                 const char *argv[] = {
+-                        LIBEXECDIR "/systemd-sysv-install",
++                        "systemd-sysv-install",
+                         NULL, /* --root= */
+                         NULL, /* verb */
+                         NULL, /* service */
+@@ -218,7 +218,7 @@ int enable_sysv_units(const char *verb, char **args) {
+                         return j;
+                 if (j == 0) {
+                         /* Child */
+-                        execv(argv[0], (char**) argv);
++                        execvp(argv[0], (char**) argv);
+                         log_error_errno(errno, "Failed to execute %s: %m", argv[0]);
+                         _exit(EXIT_FAILURE);
+                 }

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0002-implment-systemd-sysv-install-for-OE.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0002-implment-systemd-sysv-install-for-OE.patch
@@ -1,0 +1,40 @@
+From 4a5602ede9881fd8e578a3c8bc40dd5df7c4d802 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 5 Sep 2015 06:31:47 +0000
+Subject: [PATCH] implement systemd-sysv-install for OE
+
+Use update-rc.d for enabling/disabling and status command
+to check the status of the sysv service
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/systemctl/systemd-sysv-install.SKELETON | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/systemctl/systemd-sysv-install.SKELETON b/src/systemctl/systemd-sysv-install.SKELETON
+index cb58d8243b..eff3f5f579 100755
+--- a/src/systemctl/systemd-sysv-install.SKELETON
++++ b/src/systemctl/systemd-sysv-install.SKELETON
+@@ -34,17 +34,17 @@ case "$1" in
+     enable)
+         # call the command to enable SysV init script $NAME here
+         # (consider optional $ROOT)
+-        echo "IMPLEMENT ME: enabling SysV init.d script $NAME"
++        update-rc.d ${ROOT:+-r $ROOT} -f $NAME defaults
+         ;;
+     disable)
+         # call the command to disable SysV init script $NAME here
+         # (consider optional $ROOT)
+-        echo "IMPLEMENT ME: disabling SysV init.d script $NAME"
++        update-rc.d ${ROOT:+-r $ROOT} -f $NAME remove
+         ;;
+     is-enabled)
+         # exit with 0 if $NAME is enabled, non-zero if it is disabled
+         # (consider optional $ROOT)
+-        echo "IMPLEMENT ME: checking SysV init.d script $NAME"
++        /etc/init.d/$NAME status
+         ;;
+     *)
+         usage ;;

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0003-missing_type.h-add-comparison_fn_t.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0003-missing_type.h-add-comparison_fn_t.patch
@@ -1,0 +1,61 @@
+From f99ef6c4407b56e8d15455fe27eb732ada87215b Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 13:55:12 +0800
+Subject: [PATCH 03/26] missing_type.h: add comparison_fn_t
+
+Make it work with musl where comparison_fn_t and is not provided.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[Rebased for v244]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[Rebased for v250, Drop __compare_fn_t]
+Signed-off-by: Jiaqing Zhao <jiaqing.zhao@linux.intel.com>
+---
+ src/basic/missing_type.h            | 4 ++++
+ src/basic/sort-util.h               | 1 +
+ src/libsystemd/sd-journal/catalog.c | 1 +
+ 3 files changed, 6 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index 1d17705c35..fc33b76ec1 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -10,3 +10,7 @@
+ #if !HAVE_CHAR16_T
+ #  define char16_t uint16_t
+ #endif
++
++#ifndef __GLIBC__
++typedef int (*comparison_fn_t)(const void *, const void *);
++#endif
+diff --git a/src/basic/sort-util.h b/src/basic/sort-util.h
+index 9c818bd747..ef10c8be2c 100644
+--- a/src/basic/sort-util.h
++++ b/src/basic/sort-util.h
+@@ -4,6 +4,7 @@
+ #include <stdlib.h>
+ 
+ #include "macro.h"
++#include "missing_type.h"
+ 
+ /* This is the same as glibc's internal __compar_d_fn_t type. glibc exports a public comparison_fn_t, for the
+  * external type __compar_fn_t, but doesn't do anything similar for __compar_d_fn_t. Let's hence do that
+diff --git a/src/libsystemd/sd-journal/catalog.c b/src/libsystemd/sd-journal/catalog.c
+index 7dcc35d8d5..87b8d6aad6 100644
+--- a/src/libsystemd/sd-journal/catalog.c
++++ b/src/libsystemd/sd-journal/catalog.c
+@@ -29,6 +29,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "tmpfile-util.h"
++#include "missing_type.h"
+ 
+ const char * const catalog_file_dirs[] = {
+         "/usr/local/lib/systemd/catalog/",
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0004-add-fallback-parse_printf_format-implementation.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0004-add-fallback-parse_printf_format-implementation.patch
@@ -1,0 +1,434 @@
+From 34fe809cf686c1a81db5f3f027e33fece350ba0b Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 22 May 2021 20:26:24 +0200
+Subject: [PATCH 04/26] add fallback parse_printf_format implementation
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Emil Renner Berthing <systemd@esmil.dk>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ meson.build                              |   1 +
+ src/basic/meson.build                    |   5 +
+ src/basic/parse-printf-format.c          | 273 +++++++++++++++++++++++
+ src/basic/parse-printf-format.h          |  57 +++++
+ src/basic/stdio-util.h                   |   2 +-
+ src/libsystemd/sd-journal/journal-send.c |   2 +-
+ 6 files changed, 338 insertions(+), 2 deletions(-)
+ create mode 100644 src/basic/parse-printf-format.c
+ create mode 100644 src/basic/parse-printf-format.h
+
+diff --git a/meson.build b/meson.build
+index bffda86845..4146f4beef 100644
+--- a/meson.build
++++ b/meson.build
+@@ -770,6 +770,7 @@ foreach header : ['crypt.h',
+                   'linux/ioprio.h',
+                   'linux/memfd.h',
+                   'linux/time_types.h',
++                  'printf.h',
+                   'sys/auxv.h',
+                   'sys/sdt.h',
+                   'threads.h',
+diff --git a/src/basic/meson.build b/src/basic/meson.build
+index e02f787c75..9435df895d 100644
+--- a/src/basic/meson.build
++++ b/src/basic/meson.build
+@@ -188,6 +188,11 @@ endforeach
+ 
+ basic_sources += generated_gperf_headers
+ 
++if conf.get('HAVE_PRINTF_H') != 1
++        basic_sources += [files('parse-printf-format.c')]
++endif
++
++
+ ############################################################
+ 
+ arch_list = [
+diff --git a/src/basic/parse-printf-format.c b/src/basic/parse-printf-format.c
+new file mode 100644
+index 0000000000..49437e5445
+--- /dev/null
++++ b/src/basic/parse-printf-format.c
+@@ -0,0 +1,273 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the musl C library
++  Copyright 2005-2014 Rich Felker, et al.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#include <stddef.h>
++#include <string.h>
++
++#include "parse-printf-format.h"
++
++static const char *consume_nonarg(const char *fmt)
++{
++        do {
++                if (*fmt == '\0')
++                        return fmt;
++        } while (*fmt++ != '%');
++        return fmt;
++}
++
++static const char *consume_num(const char *fmt)
++{
++        for (;*fmt >= '0' && *fmt <= '9'; fmt++)
++                /* do nothing */;
++        return fmt;
++}
++
++static const char *consume_argn(const char *fmt, size_t *arg)
++{
++        const char *p = fmt;
++        size_t val = 0;
++
++        if (*p < '1' || *p > '9')
++                return fmt;
++        do {
++                val = 10*val + (*p++ - '0');
++        } while (*p >= '0' && *p <= '9');
++
++        if (*p != '$')
++                return fmt;
++        *arg = val;
++        return p+1;
++}
++
++static const char *consume_flags(const char *fmt)
++{
++        while (1) {
++                switch (*fmt) {
++                case '#':
++                case '0':
++                case '-':
++                case ' ':
++                case '+':
++                case '\'':
++                case 'I':
++                        fmt++;
++                        continue;
++                }
++                return fmt;
++        }
++}
++
++enum state {
++        BARE,
++        LPRE,
++        LLPRE,
++        HPRE,
++        HHPRE,
++        BIGLPRE,
++        ZTPRE,
++        JPRE,
++        STOP
++};
++
++enum type {
++        NONE,
++        PTR,
++        INT,
++        UINT,
++        ULLONG,
++        LONG,
++        ULONG,
++        SHORT,
++        USHORT,
++        CHAR,
++        UCHAR,
++        LLONG,
++        SIZET,
++        IMAX,
++        UMAX,
++        PDIFF,
++        UIPTR,
++        DBL,
++        LDBL,
++        MAXTYPE
++};
++
++static const short pa_types[MAXTYPE] = {
++        [NONE]   = PA_INT,
++        [PTR]    = PA_POINTER,
++        [INT]    = PA_INT,
++        [UINT]   = PA_INT,
++        [ULLONG] = PA_INT | PA_FLAG_LONG_LONG,
++        [LONG]   = PA_INT | PA_FLAG_LONG,
++        [ULONG]  = PA_INT | PA_FLAG_LONG,
++        [SHORT]  = PA_INT | PA_FLAG_SHORT,
++        [USHORT] = PA_INT | PA_FLAG_SHORT,
++        [CHAR]   = PA_CHAR,
++        [UCHAR]  = PA_CHAR,
++        [LLONG]  = PA_INT | PA_FLAG_LONG_LONG,
++        [SIZET]  = PA_INT | PA_FLAG_LONG,
++        [IMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [UMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [PDIFF]  = PA_INT | PA_FLAG_LONG_LONG,
++        [UIPTR]  = PA_INT | PA_FLAG_LONG,
++        [DBL]    = PA_DOUBLE,
++        [LDBL]   = PA_DOUBLE | PA_FLAG_LONG_DOUBLE
++};
++
++#define S(x) [(x)-'A']
++#define E(x) (STOP + (x))
++
++static const unsigned char states[]['z'-'A'+1] = {
++        { /* 0: bare types */
++                S('d') = E(INT), S('i') = E(INT),
++                S('o') = E(UINT),S('u') = E(UINT),S('x') = E(UINT), S('X') = E(UINT),
++                S('e') = E(DBL), S('f') = E(DBL), S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL), S('F') = E(DBL), S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(CHAR),S('C') = E(INT),
++                S('s') = E(PTR), S('S') = E(PTR), S('p') = E(UIPTR),S('n') = E(PTR),
++                S('m') = E(NONE),
++                S('l') = LPRE,   S('h') = HPRE, S('L') = BIGLPRE,
++                S('z') = ZTPRE,  S('j') = JPRE, S('t') = ZTPRE
++        }, { /* 1: l-prefixed */
++                S('d') = E(LONG), S('i') = E(LONG),
++                S('o') = E(ULONG),S('u') = E(ULONG),S('x') = E(ULONG),S('X') = E(ULONG),
++                S('e') = E(DBL),  S('f') = E(DBL),  S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL),  S('F') = E(DBL),  S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(INT),  S('s') = E(PTR),  S('n') = E(PTR),
++                S('l') = LLPRE
++        }, { /* 2: ll-prefixed */
++                S('d') = E(LLONG), S('i') = E(LLONG),
++                S('o') = E(ULLONG),S('u') = E(ULLONG),
++                S('x') = E(ULLONG),S('X') = E(ULLONG),
++                S('n') = E(PTR)
++        }, { /* 3: h-prefixed */
++                S('d') = E(SHORT), S('i') = E(SHORT),
++                S('o') = E(USHORT),S('u') = E(USHORT),
++                S('x') = E(USHORT),S('X') = E(USHORT),
++                S('n') = E(PTR),
++                S('h') = HHPRE
++        }, { /* 4: hh-prefixed */
++                S('d') = E(CHAR), S('i') = E(CHAR),
++                S('o') = E(UCHAR),S('u') = E(UCHAR),
++                S('x') = E(UCHAR),S('X') = E(UCHAR),
++                S('n') = E(PTR)
++        }, { /* 5: L-prefixed */
++                S('e') = E(LDBL),S('f') = E(LDBL),S('g') = E(LDBL), S('a') = E(LDBL),
++                S('E') = E(LDBL),S('F') = E(LDBL),S('G') = E(LDBL), S('A') = E(LDBL),
++                S('n') = E(PTR)
++        }, { /* 6: z- or t-prefixed (assumed to be same size) */
++                S('d') = E(PDIFF),S('i') = E(PDIFF),
++                S('o') = E(SIZET),S('u') = E(SIZET),
++                S('x') = E(SIZET),S('X') = E(SIZET),
++                S('n') = E(PTR)
++        }, { /* 7: j-prefixed */
++                S('d') = E(IMAX), S('i') = E(IMAX),
++                S('o') = E(UMAX), S('u') = E(UMAX),
++                S('x') = E(UMAX), S('X') = E(UMAX),
++                S('n') = E(PTR)
++        }
++};
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types)
++{
++        size_t i = 0;
++        size_t last = 0;
++
++        memset(types, 0, n);
++
++        while (1) {
++                size_t arg;
++                unsigned int state;
++
++                fmt = consume_nonarg(fmt);
++                if (*fmt == '\0')
++                        break;
++                if (*fmt == '%') {
++                        fmt++;
++                        continue;
++                }
++                arg = 0;
++                fmt = consume_argn(fmt, &arg);
++                /* flags */
++                fmt = consume_flags(fmt);
++                /* width */
++                if (*fmt == '*') {
++                        size_t warg = 0;
++                        fmt = consume_argn(fmt+1, &warg);
++                        if (warg == 0)
++                                warg = ++i;
++                        if (warg > last)
++                                last = warg;
++                        if (warg <= n && types[warg-1] == NONE)
++                                types[warg-1] = INT;
++                } else
++                        fmt = consume_num(fmt);
++                /* precision */
++                if (*fmt == '.') {
++                        fmt++;
++                        if (*fmt == '*') {
++                                size_t parg = 0;
++                                fmt = consume_argn(fmt+1, &parg);
++                                if (parg == 0)
++                                        parg = ++i;
++                                if (parg > last)
++                                        last = parg;
++                                if (parg <= n && types[parg-1] == NONE)
++                                        types[parg-1] = INT;
++                        } else {
++                                if (*fmt == '-')
++                                        fmt++;
++                                fmt = consume_num(fmt);
++                        }
++                }
++                /* length modifier and conversion specifier */
++                state = BARE;
++                do {
++                        unsigned char c = *fmt++;
++
++                        if (c < 'A' || c > 'z')
++                                continue;
++                        state = states[state]S(c);
++                        if (state == 0)
++                                continue;
++                } while (state < STOP);
++
++                if (state == E(NONE))
++                        continue;
++
++                if (arg == 0)
++                        arg = ++i;
++                if (arg > last)
++                        last = arg;
++                if (arg <= n)
++                        types[arg-1] = state - STOP;
++        }
++
++        if (last > n)
++                last = n;
++        for (i = 0; i < last; i++)
++                types[i] = pa_types[types[i]];
++
++        return last;
++}
+diff --git a/src/basic/parse-printf-format.h b/src/basic/parse-printf-format.h
+new file mode 100644
+index 0000000000..47be7522d7
+--- /dev/null
++++ b/src/basic/parse-printf-format.h
+@@ -0,0 +1,57 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the GNU C Library
++  Copyright 1991-2014 Free Software Foundation, Inc.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#pragma once
++
++#include "config.h"
++
++#if HAVE_PRINTF_H
++#include <printf.h>
++#else
++
++#include <stddef.h>
++
++enum {				/* C type: */
++  PA_INT,			/* int */
++  PA_CHAR,			/* int, cast to char */
++  PA_WCHAR,			/* wide char */
++  PA_STRING,			/* const char *, a '\0'-terminated string */
++  PA_WSTRING,			/* const wchar_t *, wide character string */
++  PA_POINTER,			/* void * */
++  PA_FLOAT,			/* float */
++  PA_DOUBLE,			/* double */
++  PA_LAST
++};
++
++/* Flag bits that can be set in a type returned by `parse_printf_format'.  */
++#define	PA_FLAG_MASK		0xff00
++#define	PA_FLAG_LONG_LONG	(1 << 8)
++#define	PA_FLAG_LONG_DOUBLE	PA_FLAG_LONG_LONG
++#define	PA_FLAG_LONG		(1 << 9)
++#define	PA_FLAG_SHORT		(1 << 10)
++#define	PA_FLAG_PTR		(1 << 11)
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types);
++
++#endif /* HAVE_PRINTF_H */
+diff --git a/src/basic/stdio-util.h b/src/basic/stdio-util.h
+index 0a2239d022..43a765dacd 100644
+--- a/src/basic/stdio-util.h
++++ b/src/basic/stdio-util.h
+@@ -1,12 +1,12 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
+-#include <printf.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <sys/types.h>
+ 
+ #include "macro.h"
++#include "parse-printf-format.h"
+ 
+ _printf_(3, 4)
+ static inline char* snprintf_ok(char *buf, size_t len, const char *format, ...) {
+diff --git a/src/libsystemd/sd-journal/journal-send.c b/src/libsystemd/sd-journal/journal-send.c
+index 7d02b57d7b..75e8e08add 100644
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -2,7 +2,6 @@
+ 
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <printf.h>
+ #include <stddef.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+@@ -28,6 +27,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tmpfile-util.h"
++#include "parse-printf-format.h"
+ 
+ #define SNDBUF_SIZE (8*1024*1024)
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0005-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0005-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
@@ -1,0 +1,156 @@
+From d368a0317c747961f69a455a09a3de3fd13410a2 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:56:21 +0800
+Subject: [PATCH 05/26] don't fail if GLOB_BRACE and GLOB_ALTDIRFUNC is not
+ defined
+
+If the standard library doesn't provide brace
+expansion users just won't get it.
+
+Dont use GNU GLOB extentions on non-glibc systems
+
+Conditionalize use of GLOB_ALTDIRFUNC
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/glob-util.c     | 12 ++++++++++++
+ src/test/test-glob-util.c | 16 ++++++++++++++++
+ src/tmpfiles/tmpfiles.c   | 10 ++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/src/basic/glob-util.c b/src/basic/glob-util.c
+index 802ca8c655..23818a67c6 100644
+--- a/src/basic/glob-util.c
++++ b/src/basic/glob-util.c
+@@ -12,6 +12,12 @@
+ #include "path-util.h"
+ #include "strv.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ static void closedir_wrapper(void* v) {
+         (void) closedir(v);
+ }
+@@ -19,6 +25,7 @@ static void closedir_wrapper(void* v) {
+ int safe_glob(const char *path, int flags, glob_t *pglob) {
+         int k;
+ 
++#ifdef GLOB_ALTDIRFUNC
+         /* We want to set GLOB_ALTDIRFUNC ourselves, don't allow it to be set. */
+         assert(!(flags & GLOB_ALTDIRFUNC));
+ 
+@@ -32,9 +39,14 @@ int safe_glob(const char *path, int flags, glob_t *pglob) {
+                 pglob->gl_lstat = lstat;
+         if (!pglob->gl_stat)
+                 pglob->gl_stat = stat;
++#endif
+ 
+         errno = 0;
++#ifdef GLOB_ALTDIRFUNC
+         k = glob(path, flags | GLOB_ALTDIRFUNC, NULL, pglob);
++#else
++        k = glob(path, flags, NULL, pglob);
++#endif
+         if (k == GLOB_NOMATCH)
+                 return -ENOENT;
+         if (k == GLOB_NOSPACE)
+diff --git a/src/test/test-glob-util.c b/src/test/test-glob-util.c
+index 49d71f15c7..0a49ebcc17 100644
+--- a/src/test/test-glob-util.c
++++ b/src/test/test-glob-util.c
+@@ -34,6 +34,12 @@ TEST(glob_first) {
+         ASSERT_NULL(first);
+ }
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ TEST(glob_exists) {
+         char name[] = "/tmp/test-glob_exists.XXXXXX";
+         int fd = -EBADF;
+@@ -61,11 +67,13 @@ TEST(glob_no_dot) {
+         const char *fn;
+ 
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_closedir = closedir_wrapper,
+                 .gl_readdir = (struct dirent *(*)(void *)) readdir_no_dot,
+                 .gl_opendir = (void *(*)(const char *)) opendir,
+                 .gl_lstat = lstat,
+                 .gl_stat = stat,
++#endif
+         };
+ 
+         int r;
+@@ -73,11 +81,19 @@ TEST(glob_no_dot) {
+         assert_se(mkdtemp(template));
+ 
+         fn = strjoina(template, "/*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+ 
+         fn = strjoina(template, "/.*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+ 
+         (void) rm_rf(template, REMOVE_ROOT|REMOVE_PHYSICAL);
+diff --git a/src/tmpfiles/tmpfiles.c b/src/tmpfiles/tmpfiles.c
+index 86bf16356d..da552dbaab 100644
+--- a/src/tmpfiles/tmpfiles.c
++++ b/src/tmpfiles/tmpfiles.c
+@@ -73,6 +73,12 @@
+ #include "user-util.h"
+ #include "virt.h"
+ 
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ /* This reads all files listed in /etc/tmpfiles.d/?*.conf and creates
+  * them in the file system. This is intended to be used to create
+  * properly owned directories beneath /tmp, /var/tmp, /run, which are
+@@ -2573,7 +2579,9 @@ finish:
+ 
+ static int glob_item(Context *c, Item *i, action_t action) {
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r;
+ 
+@@ -2601,7 +2609,9 @@ static int glob_item_recursively(
+                 fdaction_t action) {
+ 
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r;
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0006-add-missing-FTW_-macros-for-musl.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0006-add-missing-FTW_-macros-for-musl.patch
@@ -1,0 +1,44 @@
+From 54b6e10aea2b0fb52782c3a71f06654a89b46bff Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:00:06 +0800
+Subject: [PATCH 06/26] add missing FTW_ macros for musl
+
+This is to avoid build failures like below for musl.
+
+  locale-util.c:296:24: error: 'FTW_STOP' undeclared
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_type.h    | 4 ++++
+ src/test/test-recurse-dir.c | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index fc33b76ec1..34a36d83f0 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -14,3 +14,7 @@
+ #ifndef __GLIBC__
+ typedef int (*comparison_fn_t)(const void *, const void *);
+ #endif
++
++#ifndef FTW_CONTINUE
++#define FTW_CONTINUE 0
++#endif
+diff --git a/src/test/test-recurse-dir.c b/src/test/test-recurse-dir.c
+index 8684d064ec..70fc2b5376 100644
+--- a/src/test/test-recurse-dir.c
++++ b/src/test/test-recurse-dir.c
+@@ -8,6 +8,7 @@
+ #include "recurse-dir.h"
+ #include "strv.h"
+ #include "tests.h"
++#include "missing_type.h"
+ 
+ static char **list_nftw = NULL;
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0007-Use-uintmax_t-for-handling-rlim_t.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0007-Use-uintmax_t-for-handling-rlim_t.patch
@@ -1,0 +1,106 @@
+From 85d8c4c27e855d54c1740902a836c8f2aea9bebc Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:12:41 +0800
+Subject: [PATCH 07/26] Use uintmax_t for handling rlim_t
+
+PRIu{32,64} is not right format to represent rlim_t type
+therefore use %ju and typecast the rlim_t variables to
+uintmax_t.
+
+Fixes portablility errors like
+
+execute.c:3446:36: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'rlim_t {aka long long unsigned int}' [-Werror=format=]
+|                          fprintf(f, "%s%s: " RLIM_FMT "\n",
+|                                     ^~~~~~~~
+|                                  prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
+|                                                               ~~~~~~~~~~~~~~~~~~~~~~
+
+Upstream-Status: Denied [https://github.com/systemd/systemd/pull/7199]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Rebased for v241]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/format-util.h |  8 +-------
+ src/basic/rlimit-util.c | 12 ++++++------
+ src/core/execute.c      |  4 ++--
+ 3 files changed, 9 insertions(+), 15 deletions(-)
+
+diff --git a/src/basic/format-util.h b/src/basic/format-util.h
+index b528c005ca..41c4c095be 100644
+--- a/src/basic/format-util.h
++++ b/src/basic/format-util.h
+@@ -41,13 +41,7 @@ assert_cc(sizeof(gid_t) == sizeof(uint32_t));
+ #  error Unknown timex member size
+ #endif
+ 
+-#if SIZEOF_RLIM_T == 8
+-#  define RLIM_FMT "%" PRIu64
+-#elif SIZEOF_RLIM_T == 4
+-#  define RLIM_FMT "%" PRIu32
+-#else
+-#  error Unknown rlim_t size
+-#endif
++#define RLIM_FMT "%ju"
+ 
+ #if SIZEOF_DEV_T == 8
+ #  define DEV_FMT "%" PRIu64
+diff --git a/src/basic/rlimit-util.c b/src/basic/rlimit-util.c
+index a9f7b87f28..059c67731d 100644
+--- a/src/basic/rlimit-util.c
++++ b/src/basic/rlimit-util.c
+@@ -47,7 +47,7 @@ int setrlimit_closest(int resource, const struct rlimit *rlim) {
+             fixed.rlim_max == highest.rlim_max)
+                 return 0;
+ 
+-        log_debug("Failed at setting rlimit " RLIM_FMT " for resource RLIMIT_%s. Will attempt setting value " RLIM_FMT " instead.", rlim->rlim_max, rlimit_to_string(resource), fixed.rlim_max);
++        log_debug("Failed at setting rlimit " RLIM_FMT " for resource RLIMIT_%s. Will attempt setting value " RLIM_FMT " instead.", (uintmax_t)rlim->rlim_max, rlimit_to_string(resource), (uintmax_t)fixed.rlim_max);
+ 
+         return RET_NERRNO(setrlimit(resource, &fixed));
+ }
+@@ -310,13 +310,13 @@ int rlimit_format(const struct rlimit *rl, char **ret) {
+         if (rl->rlim_cur >= RLIM_INFINITY && rl->rlim_max >= RLIM_INFINITY)
+                 r = free_and_strdup(&s, "infinity");
+         else if (rl->rlim_cur >= RLIM_INFINITY)
+-                r = asprintf(&s, "infinity:" RLIM_FMT, rl->rlim_max);
++                r = asprintf(&s, "infinity:" RLIM_FMT, (uintmax_t)rl->rlim_max);
+         else if (rl->rlim_max >= RLIM_INFINITY)
+-                r = asprintf(&s, RLIM_FMT ":infinity", rl->rlim_cur);
++                r = asprintf(&s, RLIM_FMT ":infinity", (uintmax_t)rl->rlim_cur);
+         else if (rl->rlim_cur == rl->rlim_max)
+-                r = asprintf(&s, RLIM_FMT, rl->rlim_cur);
++                r = asprintf(&s, RLIM_FMT, (uintmax_t)rl->rlim_cur);
+         else
+-                r = asprintf(&s, RLIM_FMT ":" RLIM_FMT, rl->rlim_cur, rl->rlim_max);
++                r = asprintf(&s, RLIM_FMT ":" RLIM_FMT, (uintmax_t)rl->rlim_cur, (uintmax_t)rl->rlim_max);
+         if (r < 0)
+                 return -ENOMEM;
+ 
+@@ -425,7 +425,7 @@ int rlimit_nofile_safe(void) {
+         rl.rlim_max = MIN(rl.rlim_max, (rlim_t) read_nr_open());
+         rl.rlim_cur = MIN((rlim_t) FD_SETSIZE, rl.rlim_max);
+         if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
+-                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", rl.rlim_cur);
++                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
+ 
+         return 1;
+ }
+diff --git a/src/core/execute.c b/src/core/execute.c
+index 3d55b0b772..4824ff159e 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -1162,9 +1162,9 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
+         for (unsigned i = 0; i < RLIM_NLIMITS; i++)
+                 if (c->rlimit[i]) {
+                         fprintf(f, "%sLimit%s: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_max);
+                         fprintf(f, "%sLimit%sSoft: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_cur);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_cur);
+                 }
+ 
+         if (c->ioprio_set) {
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch
@@ -1,0 +1,34 @@
+From f4cd939c7cc1ce0a59bab2693768f2c95d9ced00 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 27 May 2018 08:36:44 -0700
+Subject: [PATCH 08/26] Define glibc compatible basename() for non-glibc
+ systems
+
+Fixes builds with musl, even though systemd is adamant about
+using non-posix basename implementation, we have a way out
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/string-util.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/basic/string-util.h b/src/basic/string-util.h
+index cc6aa183c0..0b035125cd 100644
+--- a/src/basic/string-util.h
++++ b/src/basic/string-util.h
+@@ -27,6 +27,10 @@
+ #define URI_UNRESERVED      ALPHANUMERICAL "-._~"       /* [RFC3986] */
+ #define URI_VALID           URI_RESERVED URI_UNRESERVED /* [RFC3986] */
+ 
++#if !defined(__GLIBC__)
++#define basename(src) (strrchr(src,'/') ? strrchr(src,'/')+1 : src)
++#endif
++
+ static inline char* strstr_ptr(const char *haystack, const char *needle) {
+         if (!haystack || !needle)
+                 return NULL;
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
@@ -1,0 +1,41 @@
+From 6959db351fdd551d46e22667deec6032552b2662 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 4 Jul 2018 15:00:44 +0800
+Subject: [PATCH 09/26] Do not disable buffering when writing to oom_score_adj
+
+On musl, disabling buffering when writing to oom_score_adj will
+cause the following error.
+
+  Failed to adjust OOM setting: Invalid argument
+
+This error appears for systemd-udevd.service and dbus.service.
+This is because kernel receives '-' instead of the whole '-900'
+if buffering is disabled.
+
+This is libc implementation specific, as glibc does not have this issue.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/process-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/process-util.c b/src/basic/process-util.c
+index 3253a9c3fb..772c4082a1 100644
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -1848,7 +1848,7 @@ int set_oom_score_adjust(int value) {
+         xsprintf(t, "%i", value);
+ 
+         return write_string_file("/proc/self/oom_score_adj", t,
+-                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE|WRITE_STRING_FILE_DISABLE_BUFFER);
++                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE);
+ }
+ 
+ int get_oom_score_adjust(int *ret) {
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
@@ -1,0 +1,76 @@
+From b7f6c245b4ae72999f23eecc2bbb6d6fb8db667c Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 10 Jul 2018 15:40:17 +0800
+Subject: [PATCH 10/26] distinguish XSI-compliant strerror_r from GNU-specifi
+ strerror_r
+
+XSI-compliant strerror_r and GNU-specifi strerror_r are different.
+
+       int strerror_r(int errnum, char *buf, size_t buflen);
+                   /* XSI-compliant */
+
+       char *strerror_r(int errnum, char *buf, size_t buflen);
+                   /* GNU-specific */
+
+We need to distinguish between them. Otherwise, we'll get an int value
+assigned to (char *) variable, resulting in segment fault.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/libsystemd/sd-bus/bus-error.c        | 11 ++++++++++-
+ src/libsystemd/sd-journal/journal-send.c |  5 +++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-bus/bus-error.c b/src/libsystemd/sd-bus/bus-error.c
+index 58c24d25c0..69a0d09d42 100644
+--- a/src/libsystemd/sd-bus/bus-error.c
++++ b/src/libsystemd/sd-bus/bus-error.c
+@@ -405,7 +405,12 @@ static void bus_error_strerror(sd_bus_error *e, int error) {
+                         return;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(error, m, k);
++                x = m;
++#else
+                 x = strerror_r(error, m, k);
++#endif
+                 if (errno == ERANGE || strlen(x) >= k - 1) {
+                         free(m);
+                         k *= 2;
+@@ -590,8 +595,12 @@ const char* _bus_error_message(const sd_bus_error *e, int error, char buf[static
+ 
+         if (e && e->message)
+                 return e->message;
+-
++#ifndef __GLIBC__
++        strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++        return buf;
++#else
+         return strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++#endif
+ }
+ 
+ static bool map_ok(const sd_bus_error_map *map) {
+diff --git a/src/libsystemd/sd-journal/journal-send.c b/src/libsystemd/sd-journal/journal-send.c
+index 75e8e08add..41e5c7c2b8 100644
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -361,7 +361,12 @@ static int fill_iovec_perror_and_send(const char *message, int skip, struct iove
+                 char* j;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++                j = buffer + 8 + k;
++#else
+                 j = strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++#endif
+                 if (errno == 0) {
+                         char error[STRLEN("ERRNO=") + DECIMAL_STR_MAX(int) + 1];
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0011-avoid-redefinition-of-prctl_mm_map-structure.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0011-avoid-redefinition-of-prctl_mm_map-structure.patch
@@ -1,0 +1,32 @@
+From 43b0269e850a2fbcb6ca615258aa8f8a9b4f6a9d Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:44:54 +0800
+Subject: [PATCH 11/26] avoid redefinition of prctl_mm_map structure
+
+Fix the following compile failure:
+error: redefinition of 'struct prctl_mm_map'
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_prctl.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/basic/missing_prctl.h b/src/basic/missing_prctl.h
+index 2c9f9f6c50..65a984b564 100644
+--- a/src/basic/missing_prctl.h
++++ b/src/basic/missing_prctl.h
+@@ -1,7 +1,9 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
++#ifdef __GLIBC__
+ #include <linux/prctl.h>
++#endif
+ 
+ #include "macro.h"
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0012-do-not-disable-buffer-in-writing-files.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0012-do-not-disable-buffer-in-writing-files.patch
@@ -1,0 +1,530 @@
+From eaf26fdad00448b8cd336eb5db51e0baa8d8e588 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 16 Dec 2024 14:37:25 +0800
+Subject: [PATCH 12/26] do not disable buffer in writing files
+
+Do not disable buffer in writing files, otherwise we get
+failure at boot for musl like below.
+
+  [!!!!!!] Failed to allocate manager object.
+
+And there will be other failures, critical or not critical.
+This is specific to musl.
+
+Upstream-Status: Inappropriate [musl]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+[rebased for systemd 254]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 255.1]
+---
+ src/basic/cgroup-util.c              |  4 ++--
+ src/basic/namespace-util.c           |  4 ++--
+ src/basic/procfs-util.c              |  4 ++--
+ src/basic/sysctl-util.c              |  2 +-
+ src/binfmt/binfmt.c                  |  6 +++---
+ src/core/cgroup.c                    |  2 +-
+ src/core/ipe-setup.c                 |  2 +-
+ src/core/main.c                      |  2 +-
+ src/core/smack-setup.c               |  6 +++---
+ src/home/homework.c                  |  2 +-
+ src/libsystemd/sd-device/sd-device.c |  2 +-
+ src/nspawn/nspawn-cgroup.c           |  2 +-
+ src/nspawn/nspawn.c                  |  6 +++---
+ src/shared/binfmt-util.c             |  2 +-
+ src/shared/cgroup-setup.c            | 12 ++++++------
+ src/shared/coredump-util.c           |  2 +-
+ src/shared/hibernate-util.c          |  4 ++--
+ src/shared/smack-util.c              |  2 +-
+ src/sleep/sleep.c                    |  2 +-
+ src/storagetm/storagetm.c            | 24 ++++++++++++------------
+ src/vconsole/vconsole-setup.c        |  2 +-
+ 21 files changed, 47 insertions(+), 47 deletions(-)
+
+diff --git a/src/basic/cgroup-util.c b/src/basic/cgroup-util.c
+index 309dccb45a..7aec5072a0 100644
+--- a/src/basic/cgroup-util.c
++++ b/src/basic/cgroup-util.c
+@@ -495,7 +495,7 @@ int cg_kill_kernel_sigkill(const char *path) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(killfile, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(killfile, "1", 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write to cgroup.kill for cgroup '%s': %m", path);
+ 
+@@ -1721,7 +1721,7 @@ int cg_set_attribute(const char *controller, const char *path, const char *attri
+         if (r < 0)
+                 return r;
+ 
+-        return write_string_file(p, value, WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(p, value, 0);
+ }
+ 
+ int cg_get_attribute(const char *controller, const char *path, const char *attribute, char **ret) {
+diff --git a/src/basic/namespace-util.c b/src/basic/namespace-util.c
+index 332e8cdfd5..804498127d 100644
+--- a/src/basic/namespace-util.c
++++ b/src/basic/namespace-util.c
+@@ -359,12 +359,12 @@ int userns_acquire(const char *uid_map, const char *gid_map) {
+                 freeze();
+ 
+         xsprintf(path, "/proc/" PID_FMT "/uid_map", pid);
+-        r = write_string_file(path, uid_map, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, uid_map, 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write UID map: %m");
+ 
+         xsprintf(path, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(path, gid_map, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, gid_map, 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write GID map: %m");
+ 
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index d7cfcd9105..58fb5918a3 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -63,13 +63,13 @@ int procfs_tasks_set_limit(uint64_t limit) {
+          * decrease it, as threads-max is the much more relevant sysctl. */
+         if (limit > pid_max-1) {
+                 sprintf(buffer, "%" PRIu64, limit+1); /* Add one, since PID 0 is not a valid PID */
+-                r = write_string_file("/proc/sys/kernel/pid_max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/kernel/pid_max", buffer, 0);
+                 if (r < 0)
+                         return r;
+         }
+ 
+         sprintf(buffer, "%" PRIu64, limit);
+-        r = write_string_file("/proc/sys/kernel/threads-max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/threads-max", buffer, 0);
+         if (r < 0) {
+                 uint64_t threads_max;
+ 
+diff --git a/src/basic/sysctl-util.c b/src/basic/sysctl-util.c
+index 2feb4917d7..4c74620a00 100644
+--- a/src/basic/sysctl-util.c
++++ b/src/basic/sysctl-util.c
+@@ -97,7 +97,7 @@ int sysctl_write_full(const char *property, const char *value, Hashmap **shadow)
+         if (r < 0)
+                 return r;
+ 
+-        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL);
++        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | 0 | WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL);
+ }
+ 
+ int sysctl_writef(const char *property, const char *format, ...) {
+diff --git a/src/binfmt/binfmt.c b/src/binfmt/binfmt.c
+index d21f3f79ff..258607cc7e 100644
+--- a/src/binfmt/binfmt.c
++++ b/src/binfmt/binfmt.c
+@@ -30,7 +30,7 @@ static bool arg_unregister = false;
+ 
+ static int delete_rule(const char *rulename) {
+         const char *fn = strjoina("/proc/sys/fs/binfmt_misc/", rulename);
+-        return write_string_file(fn, "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(fn, "-1", 0);
+ }
+ 
+ static int apply_rule(const char *filename, unsigned line, const char *rule) {
+@@ -58,7 +58,7 @@ static int apply_rule(const char *filename, unsigned line, const char *rule) {
+         if (r >= 0)
+                 log_debug("%s:%u: Rule '%s' deleted.", filename, line, rulename);
+ 
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, 0);
+         if (r < 0)
+                 return log_error_errno(r, "%s:%u: Failed to add binary format '%s': %m",
+                                        filename, line, rulename);
+@@ -248,7 +248,7 @@ static int run(int argc, char *argv[]) {
+                         return r;
+ 
+                 /* Flush out all rules */
+-                r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to flush binfmt_misc rules, ignoring: %m");
+                 else
+diff --git a/src/core/cgroup.c b/src/core/cgroup.c
+index 6933aae54d..ab6fccc0e4 100644
+--- a/src/core/cgroup.c
++++ b/src/core/cgroup.c
+@@ -5175,7 +5175,7 @@ int unit_cgroup_freezer_action(Unit *u, FreezerAction action) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(path, one_zero(objective == FREEZER_FROZEN), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, one_zero(objective == FREEZER_FROZEN), 0);
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/core/ipe-setup.c b/src/core/ipe-setup.c
+index 4648d43829..80d03d87d4 100644
+--- a/src/core/ipe-setup.c
++++ b/src/core/ipe-setup.c
+@@ -94,7 +94,7 @@ int ipe_setup(void) {
+                 if (!activate_path)
+                         return log_oom();
+ 
+-                r = write_string_file(activate_path, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(activate_path, "1", 0);
+                 if (r == -ESTALE) {
+                         log_debug_errno(r,
+                                         "IPE policy %s is already loaded with a version that is equal or higher, skipping.",
+diff --git a/src/core/main.c b/src/core/main.c
+index 172742c769..e68ce2a6d8 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -1826,7 +1826,7 @@ static void initialize_core_pattern(bool skip_setup) {
+         if (getpid_cached() != 1)
+                 return;
+ 
+-        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to write '%s' to /proc/sys/kernel/core_pattern, ignoring: %m",
+                                   arg_early_core_pattern);
+diff --git a/src/core/smack-setup.c b/src/core/smack-setup.c
+index 7ea902b6f9..ee4cd56023 100644
+--- a/src/core/smack-setup.c
++++ b/src/core/smack-setup.c
+@@ -321,17 +321,17 @@ int mac_smack_setup(bool *loaded_policy) {
+         }
+ 
+ #if HAVE_SMACK_RUN_LABEL
+-        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK label \"" SMACK_RUN_LABEL "\" on self: %m");
+-        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK ambient label \"" SMACK_RUN_LABEL "\": %m");
+         r = write_string_file("/sys/fs/smackfs/netlabel",
+                               "0.0.0.0/0 " SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"0.0.0.0/0 " SMACK_RUN_LABEL "\": %m");
+-        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"127.0.0.1 -CIPSO\": %m");
+ #endif
+diff --git a/src/home/homework.c b/src/home/homework.c
+index 00e74894b3..7457113efe 100644
+--- a/src/home/homework.c
++++ b/src/home/homework.c
+@@ -304,7 +304,7 @@ static void drop_caches_now(void) {
+          * for details. We write "3" into /proc/sys/vm/drop_caches to ensure dentries/inodes are flushed, but
+          * not more. */
+ 
+-        r = write_string_file("/proc/sys/vm/drop_caches", "3\n", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/vm/drop_caches", "3\n", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to drop caches, ignoring: %m");
+         else
+diff --git a/src/libsystemd/sd-device/sd-device.c b/src/libsystemd/sd-device/sd-device.c
+index 01fa90b1ff..83ab655bf4 100644
+--- a/src/libsystemd/sd-device/sd-device.c
++++ b/src/libsystemd/sd-device/sd-device.c
+@@ -2564,7 +2564,7 @@ _public_ int sd_device_set_sysattr_value(sd_device *device, const char *sysattr,
+         if (!value)
+                 return -ENOMEM;
+ 
+-        r = write_string_file(path, value, WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_NOFOLLOW);
++        r = write_string_file(path, value, 0 | WRITE_STRING_FILE_NOFOLLOW);
+         if (r < 0) {
+                 /* On failure, clear cache entry, as we do not know how it fails. */
+                 device_remove_cached_sysattr_value(device, sysattr);
+diff --git a/src/nspawn/nspawn-cgroup.c b/src/nspawn/nspawn-cgroup.c
+index 4f28b4a225..c899c218b2 100644
+--- a/src/nspawn/nspawn-cgroup.c
++++ b/src/nspawn/nspawn-cgroup.c
+@@ -93,7 +93,7 @@ int sync_cgroup(pid_t pid, CGroupUnified unified_requested, uid_t uid_shift) {
+         fn = strjoina(tree, cgroup, "/cgroup.procs");
+ 
+         sprintf(pid_string, PID_FMT, pid);
+-        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_DISABLE_BUFFER|WRITE_STRING_FILE_MKDIR_0755);
++        r = write_string_file(fn, pid_string, 0|WRITE_STRING_FILE_MKDIR_0755);
+         if (r < 0) {
+                 log_error_errno(r, "Failed to move process: %m");
+                 goto finish;
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 500725d35f..745b6815db 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -2857,7 +2857,7 @@ static int reset_audit_loginuid(void) {
+         if (streq(p, "4294967295"))
+                 return 0;
+ 
+-        r = write_string_file("/proc/self/loginuid", "4294967295", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/loginuid", "4294967295", 0);
+         if (r < 0) {
+                 log_error_errno(r,
+                                 "Failed to reset audit login UID. This probably means that your kernel is too\n"
+@@ -4588,7 +4588,7 @@ static int setup_uid_map(
+                 return log_oom();
+ 
+         xsprintf(uid_map, "/proc/" PID_FMT "/uid_map", pid);
+-        r = write_string_file(uid_map, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, s, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write UID map: %m");
+ 
+@@ -4598,7 +4598,7 @@ static int setup_uid_map(
+                 return log_oom();
+ 
+         xsprintf(uid_map, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(uid_map, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, s, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write GID map: %m");
+ 
+diff --git a/src/shared/binfmt-util.c b/src/shared/binfmt-util.c
+index a26175474b..1413a9c72c 100644
+--- a/src/shared/binfmt-util.c
++++ b/src/shared/binfmt-util.c
+@@ -46,7 +46,7 @@ int disable_binfmt(void) {
+                 return 0;
+         }
+ 
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to unregister binfmt_misc entries: %m");
+ 
+diff --git a/src/shared/cgroup-setup.c b/src/shared/cgroup-setup.c
+index 49d40f60d8..0f4aa8512a 100644
+--- a/src/shared/cgroup-setup.c
++++ b/src/shared/cgroup-setup.c
+@@ -369,7 +369,7 @@ int cg_attach(const char *controller, const char *path, pid_t pid) {
+ 
+         xsprintf(c, PID_FMT "\n", pid);
+ 
+-        r = write_string_file(fs, c, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, c, 0);
+         if (r == -EOPNOTSUPP && cg_is_threaded(path) > 0)
+                 /* When the threaded mode is used, we cannot read/write the file. Let's return recognizable error. */
+                 return -EUCLEAN;
+@@ -399,7 +399,7 @@ int cg_fd_attach(int fd, pid_t pid) {
+ 
+         xsprintf(c, PID_FMT "\n", pid);
+ 
+-        return write_string_file_at(fd, "cgroup.procs", c, WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file_at(fd, "cgroup.procs", c, 0);
+ }
+ 
+ int cg_attach_fallback(const char *controller, const char *path, pid_t pid) {
+@@ -1049,7 +1049,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+ 
+         sc = strstrip(contents);
+         if (isempty(sc)) {
+-                r = write_string_file(fs, agent, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, agent, 0);
+                 if (r < 0)
+                         return r;
+         } else if (!path_equal(sc, agent))
+@@ -1067,7 +1067,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+ 
+         sc = strstrip(contents);
+         if (streq(sc, "0")) {
+-                r = write_string_file(fs, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, "1", 0);
+                 if (r < 0)
+                         return r;
+ 
+@@ -1094,7 +1094,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(fs, "0", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "0", 0);
+         if (r < 0)
+                 return r;
+ 
+@@ -1104,7 +1104,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+ 
+-        r = write_string_file(fs, "", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "", 0);
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/shared/coredump-util.c b/src/shared/coredump-util.c
+index 805503f366..3234a1d76e 100644
+--- a/src/shared/coredump-util.c
++++ b/src/shared/coredump-util.c
+@@ -180,7 +180,7 @@ void disable_coredumps(void) {
+         if (detect_container() > 0)
+                 return;
+ 
+-        r = write_string_file("/proc/sys/kernel/core_pattern", "|/bin/false", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", "|/bin/false", 0);
+         if (r < 0)
+                 log_debug_errno(r, "Failed to turn off coredumps, ignoring: %m");
+ }
+diff --git a/src/shared/hibernate-util.c b/src/shared/hibernate-util.c
+index 1213fdc2c7..4c26e6a4ee 100644
+--- a/src/shared/hibernate-util.c
++++ b/src/shared/hibernate-util.c
+@@ -498,7 +498,7 @@ int write_resume_config(dev_t devno, uint64_t offset, const char *device) {
+ 
+         /* We write the offset first since it's safer. Note that this file is only available in 4.17+, so
+          * fail gracefully if it doesn't exist and we're only overwriting it with 0. */
+-        r = write_string_file("/sys/power/resume_offset", offset_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume_offset", offset_str, 0);
+         if (r == -ENOENT) {
+                 if (offset != 0)
+                         return log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
+@@ -514,7 +514,7 @@ int write_resume_config(dev_t devno, uint64_t offset, const char *device) {
+                 log_debug("Wrote resume_offset=%s for device '%s' to /sys/power/resume_offset.",
+                           offset_str, device);
+ 
+-        r = write_string_file("/sys/power/resume", devno_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume", devno_str, 0);
+         if (r < 0)
+                 return log_error_errno(r,
+                                        "Failed to write device '%s' (%s) to /sys/power/resume: %m",
+diff --git a/src/shared/smack-util.c b/src/shared/smack-util.c
+index d0a79b2635..0c82d9943a 100644
+--- a/src/shared/smack-util.c
++++ b/src/shared/smack-util.c
+@@ -113,7 +113,7 @@ int mac_smack_apply_pid(pid_t pid, const char *label) {
+                 return 0;
+ 
+         p = procfs_file_alloca(pid, "attr/current");
+-        r = write_string_file(p, label, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(p, label, 0);
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
+index 181bb4ccef..2dbb3f4bc6 100644
+--- a/src/sleep/sleep.c
++++ b/src/sleep/sleep.c
+@@ -158,7 +158,7 @@ static int write_mode(const char *path, char * const *modes) {
+         assert(path);
+ 
+         STRV_FOREACH(mode, modes) {
+-                r = write_string_file(path, *mode, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(path, *mode, 0);
+                 if (r >= 0) {
+                         log_debug("Using sleep mode '%s' for %s.", *mode, path);
+                         return 0;
+diff --git a/src/storagetm/storagetm.c b/src/storagetm/storagetm.c
+index ca8e886d37..5c27c54f09 100644
+--- a/src/storagetm/storagetm.c
++++ b/src/storagetm/storagetm.c
+@@ -197,7 +197,7 @@ static int nvme_subsystem_unlink(NvmeSubsystem *s) {
+                                         if (!enable_fn)
+                                                 return log_oom();
+ 
+-                                        r = write_string_file_at(namespaces_fd, enable_fn, "0", WRITE_STRING_FILE_DISABLE_BUFFER);
++                                        r = write_string_file_at(namespaces_fd, enable_fn, "0", 0);
+                                         if (r < 0)
+                                                 log_warning_errno(r, "Failed to disable namespace '%s' of NVME subsystem '%s', ignoring: %m", e->d_name, s->name);
+ 
+@@ -265,7 +265,7 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
+                 _cleanup_free_ char *truncated = strndup(w, 40); /* kernel refuses more than 40 chars (as per nvme spec) */
+ 
+                 /* The default string stored in 'attr_model' is "Linux" btw. */
+-                r = write_string_file_at(subsystem_fd, "attr_model", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file_at(subsystem_fd, "attr_model", truncated, 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to set model of subsystem to '%s', ignoring: %m", w);
+         }
+@@ -279,7 +279,7 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
+                         return log_oom();
+ 
+                  /* The default string stored in 'attr_firmware' is `uname -r` btw, but truncated to 8 chars. */
+-                r = write_string_file_at(subsystem_fd, "attr_firmware", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file_at(subsystem_fd, "attr_firmware", truncated, 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to set model of subsystem to '%s', ignoring: %m", truncated);
+         }
+@@ -306,7 +306,7 @@ static int nvme_subsystem_write_metadata(int subsystem_fd, sd_device *device) {
+                 if (!truncated)
+                         return log_oom();
+ 
+-                r = write_string_file_at(subsystem_fd, "attr_serial", truncated, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file_at(subsystem_fd, "attr_serial", truncated, 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to set serial of subsystem to '%s', ignoring: %m", truncated);
+         }
+@@ -356,7 +356,7 @@ static int nvme_namespace_write_metadata(int namespace_fd, sd_device *device, co
+                 id = id128_digest(j, l);
+         }
+ 
+-        r = write_string_file_at(namespace_fd, "device_uuid", SD_ID128_TO_UUID_STRING(id), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(namespace_fd, "device_uuid", SD_ID128_TO_UUID_STRING(id), 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set uuid of namespace to '%s', ignoring: %m", SD_ID128_TO_UUID_STRING(id));
+ 
+@@ -419,7 +419,7 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
+         if (subsystem_fd < 0)
+                 return log_error_errno(subsystem_fd, "Failed to create NVME subsystem '%s': %m", j);
+ 
+-        r = write_string_file_at(subsystem_fd, "attr_allow_any_host", "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(subsystem_fd, "attr_allow_any_host", "1", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set 'attr_allow_any_host' flag: %m");
+ 
+@@ -434,11 +434,11 @@ static int nvme_subsystem_add(const char *node, int consumed_fd, sd_device *devi
+ 
+         /* We use /proc/$PID/fd/$FD rather than /proc/self/fd/$FD, because this string is visible to others
+          * via configfs, and by including the PID it's clear to who the stuff belongs. */
+-        r = write_string_file_at(namespace_fd, "device_path", FORMAT_PROC_PID_FD_PATH(0, fd), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(namespace_fd, "device_path", FORMAT_PROC_PID_FD_PATH(0, fd), 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write 'device_path' attribute: %m");
+ 
+-        r = write_string_file_at(namespace_fd, "enable", "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(namespace_fd, "enable", "1", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write 'enable' attribute: %m");
+ 
+@@ -568,19 +568,19 @@ static int nvme_port_add_portnr(
+                 return 0;
+         }
+ 
+-        r = write_string_file_at(port_fd, "addr_adrfam", af_to_ipv4_ipv6(ip_family), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_adrfam", af_to_ipv4_ipv6(ip_family), 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set address family on NVME port %" PRIu16 ": %m", portnr);
+ 
+-        r = write_string_file_at(port_fd, "addr_trtype", "tcp", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_trtype", "tcp", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set transport type on NVME port %" PRIu16 ": %m", portnr);
+ 
+-        r = write_string_file_at(port_fd, "addr_trsvcid", fname, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_trsvcid", fname, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set IP port on NVME port %" PRIu16 ": %m", portnr);
+ 
+-        r = write_string_file_at(port_fd, "addr_traddr", ip_family == AF_INET6 ? "::" : "0.0.0.0", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file_at(port_fd, "addr_traddr", ip_family == AF_INET6 ? "::" : "0.0.0.0", 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to set IP address on NVME port %" PRIu16 ": %m", portnr);
+ 
+diff --git a/src/vconsole/vconsole-setup.c b/src/vconsole/vconsole-setup.c
+index ba742dda69..6f20e81615 100644
+--- a/src/vconsole/vconsole-setup.c
++++ b/src/vconsole/vconsole-setup.c
+@@ -277,7 +277,7 @@ static int toggle_utf8_vc(const char *name, int fd, bool utf8) {
+ static int toggle_utf8_sysfs(bool utf8) {
+         int r;
+ 
+-        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to %s sysfs UTF-8 flag: %m", enable_disable(utf8));
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0013-Handle-__cpu_mask-usage.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0013-Handle-__cpu_mask-usage.patch
@@ -1,0 +1,60 @@
+From ab4fda874b26542de96720db58cb0e8704a40108 Mon Sep 17 00:00:00 2001
+From: Scott Murray <scott.murray@konsulko.com>
+Date: Fri, 13 Sep 2019 19:26:27 -0400
+Subject: [PATCH 13/26] Handle __cpu_mask usage
+
+Fixes errors:
+
+src/test/test-cpu-set-util.c:18:54: error: '__cpu_mask' undeclared (first use in this function)
+src/test/test-sizeof.c:73:14: error: '__cpu_mask' undeclared (first use in this function)
+
+__cpu_mask is an internal type of glibc's cpu_set implementation, not
+part of the POSIX definition, which is problematic when building with
+musl, which does not define a matching type.  From inspection of musl's
+sched.h, however, it is clear that the corresponding type would be
+unsigned long, which does match glibc's actual __CPU_MASK_TYPE.  So,
+add a typedef to cpu-set-util.h defining __cpu_mask appropriately.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/shared/cpu-set-util.h | 2 ++
+ src/test/test-sizeof.c    | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/cpu-set-util.h b/src/shared/cpu-set-util.h
+index 2c477d8a01..c026ce77a6 100644
+--- a/src/shared/cpu-set-util.h
++++ b/src/shared/cpu-set-util.h
+@@ -6,6 +6,8 @@
+ #include "macro.h"
+ #include "missing_syscall.h"
+ 
++typedef unsigned long __cpu_mask;
++
+ /* This wraps the libc interface with a variable to keep the allocated size. */
+ typedef struct CPUSet {
+         cpu_set_t *set;
+diff --git a/src/test/test-sizeof.c b/src/test/test-sizeof.c
+index ea0c58770e..b65c0bd370 100644
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <sched.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/resource.h>
+@@ -12,6 +11,7 @@
+ #include <float.h>
+ 
+ #include "time-util.h"
++#include "cpu-set-util.h"
+ 
+ /* Print information about various types. Useful when diagnosing
+  * gcc diagnostics on an unfamiliar architecture. */
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0014-Handle-missing-gshadow.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0014-Handle-missing-gshadow.patch
@@ -1,0 +1,172 @@
+From c5165f6adf8a9cfe8c0784c598b87d7d7e8b7d1a Mon Sep 17 00:00:00 2001
+From: Alex Kiernan <alex.kiernan@gmail.com>
+Date: Tue, 10 Mar 2020 11:05:20 +0000
+Subject: [PATCH 14/26] Handle missing gshadow
+
+gshadow usage is now present in the userdb code. Mask all uses of it to
+allow compilation on musl
+
+Upstream-Status: Inappropriate [musl specific]
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[Rebased for v247]
+Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>
+---
+ src/shared/user-record-nss.c | 20 ++++++++++++++++++++
+ src/shared/user-record-nss.h |  4 ++++
+ src/shared/userdb.c          |  7 ++++++-
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/user-record-nss.c b/src/shared/user-record-nss.c
+index 9223a2e6ca..f9eb1a5b64 100644
+--- a/src/shared/user-record-nss.c
++++ b/src/shared/user-record-nss.c
+@@ -286,8 +286,10 @@ int nss_group_to_group_record(
+         if (isempty(grp->gr_name))
+                 return -EINVAL;
+ 
++#if ENABLE_GSHADOW
+         if (sgrp && !streq_ptr(sgrp->sg_namp, grp->gr_name))
+                 return -EINVAL;
++#endif
+ 
+         g = group_record_new();
+         if (!g)
+@@ -303,6 +305,7 @@ int nss_group_to_group_record(
+ 
+         g->gid = grp->gr_gid;
+ 
++#if ENABLE_GSHADOW
+         if (sgrp) {
+                 if (looks_like_hashed_password(utf8_only(sgrp->sg_passwd))) {
+                         g->hashed_password = strv_new(sgrp->sg_passwd);
+@@ -318,6 +321,7 @@ int nss_group_to_group_record(
+                 if (r < 0)
+                         return r;
+         }
++#endif
+ 
+         r = sd_json_buildo(
+                         &g->json,
+@@ -345,6 +349,7 @@ int nss_sgrp_for_group(const struct group *grp, struct sgrp *ret_sgrp, char **re
+         assert(ret_sgrp);
+         assert(ret_buffer);
+ 
++#if ENABLE_GSHADOW
+         for (;;) {
+                 _cleanup_free_ char *buf = NULL;
+                 struct sgrp sgrp, *result;
+@@ -373,6 +378,9 @@ int nss_sgrp_for_group(const struct group *grp, struct sgrp *ret_sgrp, char **re
+                 buflen *= 2;
+                 buf = mfree(buf);
+         }
++#else
++        return -ESRCH;
++#endif
+ }
+ 
+ int nss_group_record_by_name(
+@@ -383,7 +391,9 @@ int nss_group_record_by_name(
+         _cleanup_free_ char *sbuf = NULL;
+         _cleanup_free_ struct group *result = NULL;
+         bool incomplete = false;
++#if ENABLE_GSHADOW
+         struct sgrp sgrp, *sresult = NULL;
++#endif
+         int r;
+ 
+         assert(name);
+@@ -392,6 +402,7 @@ int nss_group_record_by_name(
+         if (r < 0)
+                 return r;
+ 
++#if ENABLE_GSHADOW
+         if (with_shadow) {
+                 r = nss_sgrp_for_group(result, &sgrp, &sbuf);
+                 if (r < 0) {
+@@ -403,6 +414,9 @@ int nss_group_record_by_name(
+                 incomplete = true;
+ 
+         r = nss_group_to_group_record(result, sresult, ret);
++#else
++        r = nss_group_to_group_record(result, NULL, ret);
++#endif
+         if (r < 0)
+                 return r;
+ 
+@@ -419,13 +433,16 @@ int nss_group_record_by_gid(
+         _cleanup_free_ char *sbuf = NULL;
+         _cleanup_free_ struct group *result = NULL;
+         bool incomplete = false;
++#if ENABLE_GSHADOW
+         struct sgrp sgrp, *sresult = NULL;
++#endif
+         int r;
+ 
+         r = getgrgid_malloc(gid, &result);
+         if (r < 0)
+                 return r;
+ 
++#if ENABLE_GSHADOW
+         if (with_shadow) {
+                 r = nss_sgrp_for_group(result, &sgrp, &sbuf);
+                 if (r < 0) {
+@@ -437,6 +454,9 @@ int nss_group_record_by_gid(
+                 incomplete = true;
+ 
+         r = nss_group_to_group_record(result, sresult, ret);
++#else
++        r = nss_group_to_group_record(result, NULL, ret);
++#endif
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/shared/user-record-nss.h b/src/shared/user-record-nss.h
+index 22ab04d6ee..4e52e7a911 100644
+--- a/src/shared/user-record-nss.h
++++ b/src/shared/user-record-nss.h
+@@ -2,7 +2,11 @@
+ #pragma once
+ 
+ #include <grp.h>
++#if ENABLE_GSHADOW
+ #include <gshadow.h>
++#else
++struct sgrp;
++#endif
+ #include <pwd.h>
+ #include <shadow.h>
+ 
+diff --git a/src/shared/userdb.c b/src/shared/userdb.c
+index ff83d4bf90..54d36cc706 100644
+--- a/src/shared/userdb.c
++++ b/src/shared/userdb.c
+@@ -1042,13 +1042,15 @@ int groupdb_iterator_get(UserDBIterator *iterator, GroupRecord **ret) {
+                 if (gr) {
+                         _cleanup_free_ char *buffer = NULL;
+                         bool incomplete = false;
++#if ENABLE_GSHADOW
+                         struct sgrp sgrp;
+-
++#endif
+                         if (streq_ptr(gr->gr_name, "root"))
+                                 iterator->synthesize_root = false;
+                         if (gr->gr_gid == GID_NOBODY)
+                                 iterator->synthesize_nobody = false;
+ 
++#if ENABLE_GSHADOW
+                         if (!FLAGS_SET(iterator->flags, USERDB_SUPPRESS_SHADOW)) {
+                                 r = nss_sgrp_for_group(gr, &sgrp, &buffer);
+                                 if (r < 0) {
+@@ -1061,6 +1063,9 @@ int groupdb_iterator_get(UserDBIterator *iterator, GroupRecord **ret) {
+                         }
+ 
+                         r = nss_group_to_group_record(gr, r >= 0 ? &sgrp : NULL, ret);
++#else
++                        r = nss_group_to_group_record(gr, NULL, ret);
++#endif
+                         if (r < 0)
+                                 return r;
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
@@ -1,0 +1,42 @@
+From ef9ad83759f78de983d2d7c4f95bc48b83bb8f66 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 12 Apr 2021 23:44:53 -0700
+Subject: [PATCH 15/26] missing_syscall.h: Define MIPS ABI defines for musl
+
+musl does not define _MIPS_SIM_ABI32, _MIPS_SIM_NABI32, _MIPS_SIM_ABI64
+unlike glibc where these are provided by libc headers, therefore define
+them here in case they are undefined
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/missing_syscall.h  | 6 ++++++
+ src/shared/base-filesystem.c | 1 +
+ 2 files changed, 7 insertions(+)
+
+--- a/src/basic/missing_syscall.h
++++ b/src/basic/missing_syscall.h
+@@ -20,6 +20,12 @@
+ #include <asm/sgidefs.h>
+ #endif
+ 
++#ifndef _MIPS_SIM_ABI32
++#define _MIPS_SIM_ABI32	1
++#define _MIPS_SIM_NABI32 2
++#define _MIPS_SIM_ABI64	3
++#endif
++
+ #include "macro.h"
+ #include "missing_keyctl.h"
+ #include "missing_sched.h"
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -20,6 +20,7 @@
+ #include "string-util.h"
+ #include "umask-util.h"
+ #include "user-util.h"
++#include "missing_syscall.h"
+ 
+ typedef enum BaseFilesystemFlags {
+         BASE_FILESYSTEM_IGNORE_ON_FAILURE = 1 << 0,

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0016-pass-correct-parameters-to-getdents64.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0016-pass-correct-parameters-to-getdents64.patch
@@ -1,0 +1,37 @@
+From 9079b158779a9c395c24f882f72a1c734795045d Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 15:15:11 -0800
+Subject: [PATCH 16/26] pass correct parameters to getdents64
+
+Fixes
+../git/src/basic/recurse-dir.c:57:40: error: incompatible pointer types passing 'uint8_t *' (aka 'unsigned char *') to parameter of type 'struct dirent *' [-Werror,-Wincompatible-pointer-types]
+                n = getdents64(dir_fd, (uint8_t*) de->buffer + de->buffer_size, bs - de->buffer_size);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+../git/src/basic/stat-util.c:102:28: error: incompatible pointer types passing 'union (unnamed union at ../git/src/basic/stat-util.c:78:9) *' to parameter of type 'struct dirent *' [-Werror,-Wincompatible-pointer-types]
+        n = getdents64(fd, &buffer, sizeof(buffer));
+                           ^~~~~~~
+
+Upstream-Status: Inappropriate [musl specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Jiaqing Zhao <jiaqing.zhao@linux.intel.com>
+---
+ src/basic/recurse-dir.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/recurse-dir.c b/src/basic/recurse-dir.c
+index 378fd92b06..5b567b457d 100644
+--- a/src/basic/recurse-dir.c
++++ b/src/basic/recurse-dir.c
+@@ -56,7 +56,7 @@ int readdir_all(int dir_fd,
+                 bs = MIN(MALLOC_SIZEOF_SAFE(de) - offsetof(DirectoryEntries, buffer), (size_t) SSIZE_MAX);
+                 assert(bs > de->buffer_size);
+ 
+-                n = getdents64(dir_fd, (uint8_t*) de->buffer + de->buffer_size, bs - de->buffer_size);
++                n = getdents64(dir_fd, (struct dirent*)((uint8_t*) de->buffer + de->buffer_size), bs - de->buffer_size);
+                 if (n < 0)
+                         return -errno;
+                 if (n == 0)
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0017-Adjust-for-musl-headers.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0017-Adjust-for-musl-headers.patch
@@ -1,0 +1,526 @@
+From be9d8f221ab9d31c0df8b2b3e66172bb9bc0f71f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 22:19:37 -0800
+Subject: [PATCH 17/26] Adjust for musl headers
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+[Rebased for v255.1]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/linux/ethtool.h                     | 3 ++-
+ src/libsystemd-network/sd-dhcp6-client.c      | 2 +-
+ src/network/netdev/bareudp.c                  | 2 +-
+ src/network/netdev/batadv.c                   | 2 +-
+ src/network/netdev/bond.c                     | 2 +-
+ src/network/netdev/bridge.c                   | 3 ++-
+ src/network/netdev/dummy.c                    | 2 +-
+ src/network/netdev/geneve.c                   | 2 +-
+ src/network/netdev/ifb.c                      | 2 +-
+ src/network/netdev/ipoib.c                    | 2 +-
+ src/network/netdev/ipvlan.c                   | 2 +-
+ src/network/netdev/macsec.c                   | 2 +-
+ src/network/netdev/macvlan.c                  | 2 +-
+ src/network/netdev/netdev.c                   | 2 +-
+ src/network/netdev/netdevsim.c                | 2 +-
+ src/network/netdev/nlmon.c                    | 2 +-
+ src/network/netdev/tunnel.c                   | 2 +-
+ src/network/netdev/vcan.c                     | 2 +-
+ src/network/netdev/veth.c                     | 2 +-
+ src/network/netdev/vlan.c                     | 2 +-
+ src/network/netdev/vrf.c                      | 2 +-
+ src/network/netdev/vxcan.c                    | 2 +-
+ src/network/netdev/vxlan.c                    | 2 +-
+ src/network/netdev/wireguard.c                | 2 +-
+ src/network/netdev/xfrm.c                     | 2 +-
+ src/network/networkd-dhcp-common.c            | 3 ++-
+ src/network/networkd-dhcp-prefix-delegation.c | 3 ++-
+ src/network/networkd-dhcp-server.c            | 2 +-
+ src/network/networkd-dhcp4.c                  | 2 +-
+ src/network/networkd-ipv6ll.c                 | 2 +-
+ src/network/networkd-link.c                   | 2 +-
+ src/network/networkd-ndisc.c                  | 2 +-
+ src/network/networkd-setlink.c                | 2 +-
+ src/network/networkd-sysctl.c                 | 2 +-
+ src/shared/netif-util.c                       | 2 +-
+ src/udev/udev-builtin-net_id.c                | 2 +-
+ 36 files changed, 40 insertions(+), 36 deletions(-)
+
+diff --git a/src/basic/linux/ethtool.h b/src/basic/linux/ethtool.h
+index a32293ba20..2aad67e9c0 100644
+--- a/src/basic/linux/ethtool.h
++++ b/src/basic/linux/ethtool.h
+@@ -16,7 +16,8 @@
+ 
+ #include <linux/const.h>
+ #include <linux/types.h>
+-#include <linux/if_ether.h>
++#include <netinet/if_ether.h>
++//#include <linux/if_ether.h>
+ 
+ #include <limits.h> /* for INT_MAX */
+ 
+diff --git a/src/libsystemd-network/sd-dhcp6-client.c b/src/libsystemd-network/sd-dhcp6-client.c
+index 3e992d7cad..c7e1ff4dbf 100644
+--- a/src/libsystemd-network/sd-dhcp6-client.c
++++ b/src/libsystemd-network/sd-dhcp6-client.c
+@@ -5,7 +5,7 @@
+ 
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_infiniband.h>
+ 
+ #include "sd-dhcp6-client.h"
+diff --git a/src/network/netdev/bareudp.c b/src/network/netdev/bareudp.c
+index e122abd97f..c120c2969b 100644
+--- a/src/network/netdev/bareudp.c
++++ b/src/network/netdev/bareudp.c
+@@ -2,7 +2,7 @@
+  * Copyright © 2020 VMware, Inc. */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "bareudp.h"
+ #include "netlink-util.h"
+diff --git a/src/network/netdev/batadv.c b/src/network/netdev/batadv.c
+index 9806d8eb7c..19c3d881c2 100644
+--- a/src/network/netdev/batadv.c
++++ b/src/network/netdev/batadv.c
+@@ -3,7 +3,7 @@
+ #include <inttypes.h>
+ #include <netinet/in.h>
+ #include <linux/genetlink.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "batadv.h"
+ #include "fileio.h"
+diff --git a/src/network/netdev/bond.c b/src/network/netdev/bond.c
+index b866940b7a..a0eaf0a866 100644
+--- a/src/network/netdev/bond.c
++++ b/src/network/netdev/bond.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "alloc-util.h"
+ #include "bond.h"
+diff --git a/src/network/netdev/bridge.c b/src/network/netdev/bridge.c
+index d3ba4989d9..4f7301c4f1 100644
+--- a/src/network/netdev/bridge.c
++++ b/src/network/netdev/bridge.c
+@@ -2,7 +2,8 @@
+ 
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+-#include <linux/if_arp.h>
++#include <netinet/in.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_bridge.h>
+ #include <netinet/in.h>
+ 
+diff --git a/src/network/netdev/dummy.c b/src/network/netdev/dummy.c
+index 8b2893d5b4..412123f036 100644
+--- a/src/network/netdev/dummy.c
++++ b/src/network/netdev/dummy.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "dummy.h"
+ 
+diff --git a/src/network/netdev/geneve.c b/src/network/netdev/geneve.c
+index 1d68be9bc8..539151c49e 100644
+--- a/src/network/netdev/geneve.c
++++ b/src/network/netdev/geneve.c
+@@ -2,7 +2,7 @@
+ 
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <netinet/in.h>
+ 
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/ifb.c b/src/network/netdev/ifb.c
+index d7ff44cb9e..e037629ae4 100644
+--- a/src/network/netdev/ifb.c
++++ b/src/network/netdev/ifb.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later
+  * Copyright © 2019 VMware, Inc. */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "ifb.h"
+ 
+diff --git a/src/network/netdev/ipoib.c b/src/network/netdev/ipoib.c
+index 6932c62e2a..fc458da9e8 100644
+--- a/src/network/netdev/ipoib.c
++++ b/src/network/netdev/ipoib.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_link.h>
+ 
+ #include "ipoib.h"
+diff --git a/src/network/netdev/ipvlan.c b/src/network/netdev/ipvlan.c
+index 6e50f72aaa..49acfee25e 100644
+--- a/src/network/netdev/ipvlan.c
++++ b/src/network/netdev/ipvlan.c
+@@ -3,7 +3,7 @@
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "conf-parser.h"
+ #include "ipvlan.h"
+diff --git a/src/network/netdev/macsec.c b/src/network/netdev/macsec.c
+index 6dd434f803..f9fbe9f51a 100644
+--- a/src/network/netdev/macsec.c
++++ b/src/network/netdev/macsec.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_ether.h>
+ #include <linux/if_macsec.h>
+ #include <linux/genetlink.h>
+diff --git a/src/network/netdev/macvlan.c b/src/network/netdev/macvlan.c
+index fd112b58e1..b038740bda 100644
+--- a/src/network/netdev/macvlan.c
++++ b/src/network/netdev/macvlan.c
+@@ -3,7 +3,7 @@
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "conf-parser.h"
+ #include "macvlan.h"
+diff --git a/src/network/netdev/netdev.c b/src/network/netdev/netdev.c
+index c2986aafb5..147f1c95d0 100644
+--- a/src/network/netdev/netdev.c
++++ b/src/network/netdev/netdev.c
+@@ -3,7 +3,7 @@
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <unistd.h>
+ 
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/netdevsim.c b/src/network/netdev/netdevsim.c
+index 59958c3bbe..61169016b0 100644
+--- a/src/network/netdev/netdevsim.c
++++ b/src/network/netdev/netdevsim.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "netdevsim.h"
+ 
+diff --git a/src/network/netdev/nlmon.c b/src/network/netdev/nlmon.c
+index ff372092e6..eef66811f4 100644
+--- a/src/network/netdev/nlmon.c
++++ b/src/network/netdev/nlmon.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "nlmon.h"
+ 
+diff --git a/src/network/netdev/tunnel.c b/src/network/netdev/tunnel.c
+index af05cfda81..f659bed3a6 100644
+--- a/src/network/netdev/tunnel.c
++++ b/src/network/netdev/tunnel.c
+@@ -2,7 +2,7 @@
+ 
+ #include <netinet/in.h>
+ #include <linux/fou.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_tunnel.h>
+ #include <linux/ip.h>
+ #include <linux/ip6_tunnel.h>
+diff --git a/src/network/netdev/vcan.c b/src/network/netdev/vcan.c
+index 380547ee1e..137c1adf8a 100644
+--- a/src/network/netdev/vcan.c
++++ b/src/network/netdev/vcan.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "vcan.h"
+ 
+diff --git a/src/network/netdev/veth.c b/src/network/netdev/veth.c
+index 54d3b59734..f3f75e22b5 100644
+--- a/src/network/netdev/veth.c
++++ b/src/network/netdev/veth.c
+@@ -3,7 +3,7 @@
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+ #include <errno.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/veth.h>
+ #include <netinet/in.h>
+ 
+diff --git a/src/network/netdev/vlan.c b/src/network/netdev/vlan.c
+index 60e49a5b8a..266fd58813 100644
+--- a/src/network/netdev/vlan.c
++++ b/src/network/netdev/vlan.c
+@@ -3,7 +3,7 @@
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+ #include <errno.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_vlan.h>
+ 
+ #include "parse-util.h"
+diff --git a/src/network/netdev/vrf.c b/src/network/netdev/vrf.c
+index c35419f859..4d1d3ef141 100644
+--- a/src/network/netdev/vrf.c
++++ b/src/network/netdev/vrf.c
+@@ -2,8 +2,8 @@
+ 
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+-#include <linux/if_arp.h>
+ #include <netinet/in.h>
++//#include <linux/if_arp.h>
+ 
+ #include "vrf.h"
+ 
+diff --git a/src/network/netdev/vxcan.c b/src/network/netdev/vxcan.c
+index 2de89b8e24..ce1b8f9b69 100644
+--- a/src/network/netdev/vxcan.c
++++ b/src/network/netdev/vxcan.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <linux/can/vxcan.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "vxcan.h"
+ 
+diff --git a/src/network/netdev/vxlan.c b/src/network/netdev/vxlan.c
+index d8a066370d..8f94eeb763 100644
+--- a/src/network/netdev/vxlan.c
++++ b/src/network/netdev/vxlan.c
+@@ -3,7 +3,7 @@
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "conf-parser.h"
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/wireguard.c b/src/network/netdev/wireguard.c
+index 8d1dddf828..5182783f45 100644
+--- a/src/network/netdev/wireguard.c
++++ b/src/network/netdev/wireguard.c
+@@ -5,7 +5,7 @@
+ 
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/ipv6_route.h>
+ #include <netinet/in.h>
+ #include <sys/ioctl.h>
+diff --git a/src/network/netdev/xfrm.c b/src/network/netdev/xfrm.c
+index 905bfc0bdf..39e34dbb3b 100644
+--- a/src/network/netdev/xfrm.c
++++ b/src/network/netdev/xfrm.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "missing_network.h"
+ #include "xfrm.h"
+diff --git a/src/network/networkd-dhcp-common.c b/src/network/networkd-dhcp-common.c
+index 8b64dfe8f0..caa2885728 100644
+--- a/src/network/networkd-dhcp-common.c
++++ b/src/network/networkd-dhcp-common.c
+@@ -1,7 +1,8 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
++#include <net/if.h>
+ 
+ #include "bus-error.h"
+ #include "bus-locator.h"
+diff --git a/src/network/networkd-dhcp-prefix-delegation.c b/src/network/networkd-dhcp-prefix-delegation.c
+index 16426de981..3d8efc05f1 100644
+--- a/src/network/networkd-dhcp-prefix-delegation.c
++++ b/src/network/networkd-dhcp-prefix-delegation.c
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/ipv6_route.h>
+ 
+ #include "dhcp6-lease-internal.h"
+ #include "hashmap.h"
+@@ -21,6 +20,8 @@
+ #include "strv.h"
+ #include "tunnel.h"
+ 
++#include <linux/ipv6_route.h>
++
+ bool link_dhcp_pd_is_enabled(Link *link) {
+         assert(link);
+ 
+diff --git a/src/network/networkd-dhcp-server.c b/src/network/networkd-dhcp-server.c
+index c35102af74..3be469ae16 100644
+--- a/src/network/networkd-dhcp-server.c
++++ b/src/network/networkd-dhcp-server.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if.h>
+ 
+ #include "sd-dhcp-server.h"
+diff --git a/src/network/networkd-dhcp4.c b/src/network/networkd-dhcp4.c
+index d94ac1a213..b8fe82cb6a 100644
+--- a/src/network/networkd-dhcp4.c
++++ b/src/network/networkd-dhcp4.c
+@@ -3,7 +3,7 @@
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "alloc-util.h"
+ #include "device-private.h"
+diff --git a/src/network/networkd-ipv6ll.c b/src/network/networkd-ipv6ll.c
+index 04f51ab530..c4580754f7 100644
+--- a/src/network/networkd-ipv6ll.c
++++ b/src/network/networkd-ipv6ll.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "in-addr-util.h"
+ #include "networkd-address.h"
+diff --git a/src/network/networkd-link.c b/src/network/networkd-link.c
+index 3c042e6c18..05fe2cb900 100644
+--- a/src/network/networkd-link.c
++++ b/src/network/networkd-link.c
+@@ -4,7 +4,7 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_link.h>
+ #include <linux/netdevice.h>
+ #include <sys/socket.h>
+diff --git a/src/network/networkd-ndisc.c b/src/network/networkd-ndisc.c
+index 33e86fb04e..51292871fc 100644
+--- a/src/network/networkd-ndisc.c
++++ b/src/network/networkd-ndisc.c
+@@ -6,7 +6,7 @@
+ #include <arpa/inet.h>
+ #include <netinet/icmp6.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "sd-ndisc.h"
+ 
+diff --git a/src/network/networkd-setlink.c b/src/network/networkd-setlink.c
+index 8519e6e7a0..7aca2bbecc 100644
+--- a/src/network/networkd-setlink.c
++++ b/src/network/networkd-setlink.c
+@@ -2,7 +2,7 @@
+ 
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_bridge.h>
+ #include <linux/ipv6.h>
+ 
+diff --git a/src/network/networkd-sysctl.c b/src/network/networkd-sysctl.c
+index 10a35bc44b..84c6b68ee4 100644
+--- a/src/network/networkd-sysctl.c
++++ b/src/network/networkd-sysctl.c
+@@ -2,7 +2,7 @@
+ 
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "sd-messages.h"
+ 
+diff --git a/src/shared/netif-util.c b/src/shared/netif-util.c
+index 978ce42341..899b5f613f 100644
+--- a/src/shared/netif-util.c
++++ b/src/shared/netif-util.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ 
+ #include "arphrd-util.h"
+ #include "device-util.h"
+diff --git a/src/udev/udev-builtin-net_id.c b/src/udev/udev-builtin-net_id.c
+index 09c04b9a7f..4686897dbf 100644
+--- a/src/udev/udev-builtin-net_id.c
++++ b/src/udev/udev-builtin-net_id.c
+@@ -19,7 +19,7 @@
+ #include <stdarg.h>
+ #include <unistd.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/netdevice.h>
+ #include <linux/pci_regs.h>
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
@@ -1,0 +1,52 @@
+From 349f9a0f9ecfc6575a3d9eeaffe89536e6a43914 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 8 Nov 2022 13:31:34 -0800
+Subject: [PATCH 18/26] test-bus-error: strerror() is assumed to be GNU
+ specific version mark it so
+
+Upstream-Status: Inappropriate [Upstream systemd only supports glibc]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/libsystemd/sd-bus/test-bus-error.c | 2 ++
+ src/test/test-errno-util.c             | 3 ++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-bus/test-bus-error.c b/src/libsystemd/sd-bus/test-bus-error.c
+index 91045c06c2..a06b9bac0c 100644
+--- a/src/libsystemd/sd-bus/test-bus-error.c
++++ b/src/libsystemd/sd-bus/test-bus-error.c
+@@ -99,7 +99,9 @@ TEST(error) {
+         assert_se(!sd_bus_error_is_set(&error));
+         assert_se(sd_bus_error_set_errno(&error, EBUSY) == -EBUSY);
+         assert_se(streq(error.name, "System.Error.EBUSY"));
++#ifdef __GLIBC__
+         assert_se(streq(error.message, STRERROR(EBUSY)));
++#endif
+         assert_se(sd_bus_error_has_name(&error, "System.Error.EBUSY"));
+         assert_se(sd_bus_error_get_errno(&error) == EBUSY);
+         assert_se(sd_bus_error_is_set(&error));
+diff --git a/src/test/test-errno-util.c b/src/test/test-errno-util.c
+index ab463bd1b3..e2ebcaaf33 100644
+--- a/src/test/test-errno-util.c
++++ b/src/test/test-errno-util.c
+@@ -4,7 +4,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tests.h"
+-
++#ifdef __GLIBC__
+ TEST(strerror_not_threadsafe) {
+         /* Just check that strerror really is not thread-safe. */
+         log_info("strerror(%d) → %s", 200, strerror(200));
+@@ -46,6 +46,7 @@ TEST(STRERROR_OR_ELSE) {
+         log_info("STRERROR_OR_ELSE(EPERM, \"EOF\") → %s", STRERROR_OR_EOF(EPERM));
+         log_info("STRERROR_OR_ELSE(-EPERM, \"EOF\") → %s", STRERROR_OR_EOF(-EPERM));
+ }
++#endif /* __GLIBC__ */
+ 
+ TEST(PROTECT_ERRNO) {
+         errno = 12;
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0019-errno-util-Make-STRERROR-portable-for-musl.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0019-errno-util-Make-STRERROR-portable-for-musl.patch
@@ -1,0 +1,41 @@
+From 28fa1d5f56c6ddee9e336e6f2051c55e9f2f98b4 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 23 Jan 2023 23:39:46 -0800
+Subject: [PATCH 19/26] errno-util: Make STRERROR portable for musl
+
+Sadly, systemd has decided to use yet another GNU extention in a macro
+lets make this such that we can use XSI compliant strerror_r() for
+non-glibc hosts
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/errno-util.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/basic/errno-util.h b/src/basic/errno-util.h
+index 48b76e4bf7..6e7653e2d9 100644
+--- a/src/basic/errno-util.h
++++ b/src/basic/errno-util.h
+@@ -15,8 +15,16 @@
+  * https://stackoverflow.com/questions/34880638/compound-literal-lifetime-and-if-blocks
+  *
+  * Note that we use the GNU variant of strerror_r() here. */
+-#define STRERROR(errnum) strerror_r(abs(errnum), (char[ERRNO_BUF_LEN]){}, ERRNO_BUF_LEN)
++static inline const char * STRERROR(int errnum);
+ 
++static inline const char * STRERROR(int errnum) {
++#ifdef __GLIBC__
++        return strerror_r(abs(errnum), (char[ERRNO_BUF_LEN]){}, ERRNO_BUF_LEN);
++#else
++        static __thread char buf[ERRNO_BUF_LEN];
++        return strerror_r(abs(errnum), buf, ERRNO_BUF_LEN) ? "unknown error" : buf;
++#endif
++}
+ /* A helper to print an error message or message for functions that return 0 on EOF.
+  * Note that we can't use ({ … }) to define a temporary variable, so errnum is
+  * evaluated twice. */
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch
@@ -1,0 +1,39 @@
+From 66de8a53849f76f5596327c38ae5f002b9f534cd Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 2 Aug 2023 12:06:27 -0700
+Subject: [PATCH 20/26] sd-event: Make malloc_trim() conditional on glibc
+
+musl does not have this API
+
+Upstream-Status: Inappropriate [musl-specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/libsystemd/sd-event/sd-event.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-event/sd-event.c b/src/libsystemd/sd-event/sd-event.c
+index 7aea7d2581..d3f4001f53 100644
+--- a/src/libsystemd/sd-event/sd-event.c
++++ b/src/libsystemd/sd-event/sd-event.c
+@@ -1881,7 +1881,7 @@ _public_ int sd_event_add_exit(
+ }
+ 
+ _public_ int sd_event_trim_memory(void) {
+-        int r;
++        int r = 0;
+ 
+         /* A default implementation of a memory pressure callback. Simply releases our own allocation caches
+          * and glibc's. This is automatically used when people call sd_event_add_memory_pressure() with a
+@@ -1895,7 +1895,9 @@ _public_ int sd_event_trim_memory(void) {
+ 
+         usec_t before_timestamp = now(CLOCK_MONOTONIC);
+         hashmap_trim_pools();
++#ifdef __GLIBC__
+         r = malloc_trim(0);
++#endif
+         usec_t after_timestamp = now(CLOCK_MONOTONIC);
+ 
+         if (r > 0)
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0021-shared-Do-not-use-malloc_info-on-musl.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0021-shared-Do-not-use-malloc_info-on-musl.patch
@@ -1,0 +1,57 @@
+From 93d13363c605fb2de484f38f3726f8fbad1c3540 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 2 Aug 2023 12:20:40 -0700
+Subject: [PATCH 21/26] shared: Do not use malloc_info on musl
+
+Upstream-Status: Inappropriate [musl-specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/shared/bus-util.c      | 5 +++--
+ src/shared/common-signal.c | 4 ++--
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/src/shared/bus-util.c b/src/shared/bus-util.c
+index ff80e580fc..a628a29d0c 100644
+--- a/src/shared/bus-util.c
++++ b/src/shared/bus-util.c
+@@ -787,15 +787,16 @@ static int method_dump_memory_state_by_fd(sd_bus_message *message, void *userdat
+         _cleanup_close_ int fd = -EBADF;
+         size_t dump_size;
+         FILE *f;
+-        int r;
++        int r = 0;
+ 
+         assert(message);
+ 
+         f = memstream_init(&m);
+         if (!f)
+                 return -ENOMEM;
+-
++#ifdef __GLIBC__
+         r = RET_NERRNO(malloc_info(/* options= */ 0, f));
++#endif
+         if (r < 0)
+                 return r;
+ 
+diff --git a/src/shared/common-signal.c b/src/shared/common-signal.c
+index 8e70e365dd..9e782caec9 100644
+--- a/src/shared/common-signal.c
++++ b/src/shared/common-signal.c
+@@ -65,12 +65,12 @@ int sigrtmin18_handler(sd_event_source *s, const struct signalfd_siginfo *si, vo
+                         log_oom();
+                         break;
+                 }
+-
++#ifdef __GLIBC__
+                 if (malloc_info(0, f) < 0) {
+                         log_error_errno(errno, "Failed to invoke malloc_info(): %m");
+                         break;
+                 }
+-
++#endif
+                 (void) memstream_dump(LOG_INFO, &m);
+                 break;
+         }
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0022-avoid-missing-LOCK_EX-declaration.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0022-avoid-missing-LOCK_EX-declaration.patch
@@ -1,0 +1,56 @@
+From 5b8df64993b68a5a4af0f214d8cae77f4e716593 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 2 Jan 2024 11:03:27 +0800
+Subject: [PATCH 22/26] avoid missing LOCK_EX declaration
+
+This only happens on MUSL. Include sys/file.h to avoid compilation
+error about missing LOCK_EX declaration.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/fd-util.h    | 1 +
+ src/core/exec-invoke.c | 1 +
+ src/shared/dev-setup.h | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/src/basic/fd-util.h b/src/basic/fd-util.h
+index 93b254c680..5f0b1a816d 100644
+--- a/src/basic/fd-util.h
++++ b/src/basic/fd-util.h
+@@ -6,6 +6,7 @@
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <sys/socket.h>
++#include <sys/file.h>
+ 
+ #include "macro.h"
+ #include "missing_fcntl.h"
+diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
+index 9d636f5529..6be43caa57 100644
+--- a/src/core/exec-invoke.c
++++ b/src/core/exec-invoke.c
+@@ -5,6 +5,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+ #include <sys/prctl.h>
++#include <sys/file.h>
+ 
+ #if HAVE_PAM
+ #include <security/pam_appl.h>
+diff --git a/src/shared/dev-setup.h b/src/shared/dev-setup.h
+index 92ba6cf764..ba01a0ae55 100644
+--- a/src/shared/dev-setup.h
++++ b/src/shared/dev-setup.h
+@@ -2,6 +2,7 @@
+ #pragma once
+ 
+ #include <sys/types.h>
++#include <sys/file.h>
+ 
+ int dev_setup(const char *prefix, uid_t uid, gid_t gid);
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0023-include-signal.h-to-avoid-the-undeclared-error.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0023-include-signal.h-to-avoid-the-undeclared-error.patch
@@ -1,0 +1,27 @@
+From e39afec7e5a2f3a9de7202affab4d0340ba879d7 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 2 Jul 2024 22:18:47 -0700
+Subject: [PATCH 23/26] include signal.h to avoid the 'undeclared' error
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/pidref.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/basic/pidref.h b/src/basic/pidref.h
+index 42ddf4e50b..b9cf53680f 100644
+--- a/src/basic/pidref.h
++++ b/src/basic/pidref.h
+@@ -3,6 +3,7 @@
+ 
+ typedef struct PidRef PidRef;
+ 
++#include <signal.h>
+ #include "macro.h"
+ #include "process-util.h"
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0024-undef-stdin-for-references-using-stdin-as-a-struct-m.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0024-undef-stdin-for-references-using-stdin-as-a-struct-m.patch
@@ -1,0 +1,48 @@
+From 5a4334fde21b896cd75b2d1a56e06a4f365e9c4d Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 2 Jul 2024 22:44:31 -0700
+Subject: [PATCH 24/26] undef stdin for references using stdin as a struct
+ member
+
+In musl stdio.h, we have:
+include/stdio.h:#define stdin  (stdin)
+
+This causes error when a struct member is also named stdin. undef it.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/shared/edit-util.c         | 2 ++
+ src/systemctl/systemctl-edit.c | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/src/shared/edit-util.c b/src/shared/edit-util.c
+index e37609c2e1..1b212ae7b4 100644
+--- a/src/shared/edit-util.c
++++ b/src/shared/edit-util.c
+@@ -3,6 +3,8 @@
+ #include <errno.h>
+ #include <stdio.h>
+ 
++#undef stdin
++
+ #include "alloc-util.h"
+ #include "copy.h"
+ #include "edit-util.h"
+diff --git a/src/systemctl/systemctl-edit.c b/src/systemctl/systemctl-edit.c
+index c42a31153d..7695ceeead 100644
+--- a/src/systemctl/systemctl-edit.c
++++ b/src/systemctl/systemctl-edit.c
+@@ -13,6 +13,8 @@
+ #include "systemctl.h"
+ #include "terminal-util.h"
+ 
++#undef stdin
++
+ int verb_cat(int argc, char *argv[], void *userdata) {
+         _cleanup_hashmap_free_ Hashmap *cached_id_map = NULL, *cached_name_map = NULL;
+         _cleanup_(lookup_paths_done) LookupPaths lp = {};
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0025-adjust-header-inclusion-order-to-avoid-redeclaration.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0025-adjust-header-inclusion-order-to-avoid-redeclaration.patch
@@ -1,0 +1,288 @@
+From a90044320eecda424ed678d283ef60806c70fcda Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 2 Jul 2024 23:23:57 -0700
+Subject: [PATCH 25/26] adjust header inclusion order to avoid redeclaration
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/parse-util.c                | 3 ++-
+ src/libsystemd-network/ndisc-option.c | 6 +++---
+ src/libsystemd-network/sd-radv.c      | 5 +++--
+ src/network/netdev/l2tp-tunnel.c      | 9 ++++-----
+ src/network/netdev/l2tp-tunnel.h      | 6 +++---
+ src/network/netdev/wireguard.c        | 2 +-
+ src/network/networkctl-link-info.c    | 4 ++--
+ src/network/networkd-bridge-mdb.c     | 3 ++-
+ src/network/networkd-route.c          | 8 ++++----
+ src/resolve/resolved-dns-stream.c     | 5 +++--
+ src/resolve/resolved-manager.c        | 5 +++--
+ src/shared/conf-parser.c              | 3 ++-
+ 12 files changed, 32 insertions(+), 27 deletions(-)
+
+diff --git a/src/basic/parse-util.c b/src/basic/parse-util.c
+index faa5344921..0fc9d12c89 100644
+--- a/src/basic/parse-util.c
++++ b/src/basic/parse-util.c
+@@ -2,7 +2,6 @@
+ 
+ #include <errno.h>
+ #include <inttypes.h>
+-#include <linux/ipv6.h>
+ #include <net/if.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -20,6 +19,8 @@
+ #include "string-util.h"
+ #include "strv.h"
+ 
++#include <linux/ipv6.h>
++
+ int parse_boolean(const char *v) {
+         if (!v)
+                 return -EINVAL;
+diff --git a/src/libsystemd-network/ndisc-option.c b/src/libsystemd-network/ndisc-option.c
+index 3aab51f51b..feeb4c78e5 100644
+--- a/src/libsystemd-network/ndisc-option.c
++++ b/src/libsystemd-network/ndisc-option.c
+@@ -1,8 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/ipv6.h>
+-#include <netinet/icmp6.h>
+-
+ #include "dns-resolver-internal.h"
+ #include "dns-domain.h"
+ #include "ether-addr-util.h"
+@@ -16,6 +13,9 @@
+ #include "strv.h"
+ #include "unaligned.h"
+ 
++#include <linux/ipv6.h>
++#include <netinet/icmp6.h>
++
+ /* RFC does not say anything about the maximum number of options, but let's limit the number of options for
+  * safety. Typically, the number of options in an ICMPv6 message should be only a few. */
+ #define MAX_OPTIONS 128
+diff --git a/src/libsystemd-network/sd-radv.c b/src/libsystemd-network/sd-radv.c
+index f241929ad5..7cef3c3f71 100644
+--- a/src/libsystemd-network/sd-radv.c
++++ b/src/libsystemd-network/sd-radv.c
+@@ -3,8 +3,6 @@
+   Copyright © 2017 Intel Corporation. All rights reserved.
+ ***/
+ 
+-#include <linux/ipv6.h>
+-#include <netinet/icmp6.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ 
+@@ -29,6 +27,9 @@
+ #include "strv.h"
+ #include "unaligned.h"
+ 
++#include <linux/ipv6.h>
++#include <netinet/icmp6.h>
++
+ int sd_radv_new(sd_radv **ret) {
+         _cleanup_(sd_radv_unrefp) sd_radv *ra = NULL;
+ 
+diff --git a/src/network/netdev/l2tp-tunnel.c b/src/network/netdev/l2tp-tunnel.c
+index c87e44797b..437b40c114 100644
+--- a/src/network/netdev/l2tp-tunnel.c
++++ b/src/network/netdev/l2tp-tunnel.c
+@@ -1,10 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <netinet/in.h>
+-#include <linux/if_arp.h>
+-#include <linux/l2tp.h>
+-#include <linux/genetlink.h>
+-
+ #include "conf-parser.h"
+ #include "hashmap.h"
+ #include "l2tp-tunnel.h"
+@@ -17,6 +12,10 @@
+ #include "string-table.h"
+ #include "string-util.h"
+ 
++#include <netinet/in.h>
++#include <linux/l2tp.h>
++#include <linux/genetlink.h>
++
+ static const char* const l2tp_l2spec_type_table[_NETDEV_L2TP_L2SPECTYPE_MAX] = {
+         [NETDEV_L2TP_L2SPECTYPE_NONE]    = "none",
+         [NETDEV_L2TP_L2SPECTYPE_DEFAULT] = "default",
+diff --git a/src/network/netdev/l2tp-tunnel.h b/src/network/netdev/l2tp-tunnel.h
+index c558ed49de..8419ef34c5 100644
+--- a/src/network/netdev/l2tp-tunnel.h
++++ b/src/network/netdev/l2tp-tunnel.h
+@@ -1,13 +1,13 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
+-#include <netinet/in.h>
+-#include <linux/l2tp.h>
+-
+ #include "in-addr-util.h"
+ #include "netdev.h"
+ #include "networkd-util.h"
+ 
++#include <netinet/in.h>
++#include <linux/l2tp.h>
++
+ typedef enum L2tpL2specType {
+         NETDEV_L2TP_L2SPECTYPE_NONE = L2TP_L2SPECTYPE_NONE,
+         NETDEV_L2TP_L2SPECTYPE_DEFAULT = L2TP_L2SPECTYPE_DEFAULT,
+diff --git a/src/network/netdev/wireguard.c b/src/network/netdev/wireguard.c
+index 5182783f45..79b21cb4ba 100644
+--- a/src/network/netdev/wireguard.c
++++ b/src/network/netdev/wireguard.c
+@@ -5,9 +5,9 @@
+ 
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
++#include <netinet/in.h>
+ //#include <linux/if_arp.h>
+ #include <linux/ipv6_route.h>
+-#include <netinet/in.h>
+ #include <sys/ioctl.h>
+ 
+ #include "sd-resolve.h"
+diff --git a/src/network/networkctl-link-info.c b/src/network/networkctl-link-info.c
+index f356d3c231..216c442de1 100644
+--- a/src/network/networkctl-link-info.c
++++ b/src/network/networkctl-link-info.c
+@@ -1,7 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_tunnel.h>
+-
+ #include "bus-common-errors.h"
+ #include "bus-error.h"
+ #include "bus-util.h"
+@@ -16,6 +14,8 @@
+ #include "strxcpyx.h"
+ #include "wifi-util.h"
+ 
++#include <linux/if_tunnel.h>
++
+ /* use 128 kB for receive socket kernel queue, we shouldn't need more here */
+ #define RCVBUF_SIZE    (128*1024)
+ 
+diff --git a/src/network/networkd-bridge-mdb.c b/src/network/networkd-bridge-mdb.c
+index 358ca4d294..fe87f7c093 100644
+--- a/src/network/networkd-bridge-mdb.c
++++ b/src/network/networkd-bridge-mdb.c
+@@ -2,7 +2,6 @@
+ 
+ /* Make sure the net/if.h header is included before any linux/ one */
+ #include <net/if.h>
+-#include <linux/if_bridge.h>
+ 
+ #include "netlink-util.h"
+ #include "networkd-bridge-mdb.h"
+@@ -13,6 +12,8 @@
+ #include "string-util.h"
+ #include "vlan-util.h"
+ 
++#include <linux/if_bridge.h>
++
+ #define STATIC_BRIDGE_MDB_ENTRIES_PER_NETWORK_MAX 1024U
+ 
+ /* remove MDB entry. */
+diff --git a/src/network/networkd-route.c b/src/network/networkd-route.c
+index 0f3f79ec4f..325743bebf 100644
+--- a/src/network/networkd-route.c
++++ b/src/network/networkd-route.c
+@@ -1,9 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if.h>
+-#include <linux/ipv6_route.h>
+-#include <linux/nexthop.h>
+-
+ #include "alloc-util.h"
+ #include "event-util.h"
+ #include "netlink-util.h"
+@@ -21,6 +17,10 @@
+ #include "vrf.h"
+ #include "wireguard.h"
+ 
++#include <linux/if.h>
++#include <linux/ipv6_route.h>
++#include <linux/nexthop.h>
++
+ static Route* route_detach_impl(Route *route) {
+         assert(route);
+         assert(!!route->network + !!route->manager + !!route->wireguard <= 1);
+diff --git a/src/resolve/resolved-dns-stream.c b/src/resolve/resolved-dns-stream.c
+index e57af66221..f66d8f0606 100644
+--- a/src/resolve/resolved-dns-stream.c
++++ b/src/resolve/resolved-dns-stream.c
+@@ -1,7 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <linux/if_arp.h>
+-#include <netinet/tcp.h>
+ #include <unistd.h>
+ 
+ #include "alloc-util.h"
+@@ -12,6 +10,9 @@
+ #include "resolved-dns-stream.h"
+ #include "resolved-manager.h"
+ 
++//#include <linux/if_arp.h>
++#include <netinet/tcp.h>
++
+ #define DNS_STREAMS_MAX 128
+ 
+ #define DNS_QUERIES_PER_STREAM 32
+diff --git a/src/resolve/resolved-manager.c b/src/resolve/resolved-manager.c
+index dbaad81734..b988e75851 100644
+--- a/src/resolve/resolved-manager.c
++++ b/src/resolve/resolved-manager.c
+@@ -1,8 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+ #include <fcntl.h>
+-#include <linux/ipv6.h>
+-#include <netinet/in.h>
+ #include <poll.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+@@ -46,6 +44,9 @@
+ #include "utf8.h"
+ #include "varlink-util.h"
+ 
++#include <linux/ipv6.h>
++#include <netinet/in.h>
++
+ #define SEND_TIMEOUT_USEC (200 * USEC_PER_MSEC)
+ 
+ static int manager_process_link(sd_netlink *rtnl, sd_netlink_message *mm, void *userdata) {
+diff --git a/src/shared/conf-parser.c b/src/shared/conf-parser.c
+index eaa8a5f11c..03379e7474 100644
+--- a/src/shared/conf-parser.c
++++ b/src/shared/conf-parser.c
+@@ -2,7 +2,6 @@
+ 
+ #include <errno.h>
+ #include <limits.h>
+-#include <linux/ipv6.h>
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -47,6 +46,8 @@
+ #include "time-util.h"
+ #include "utf8.h"
+ 
++#include <linux/ipv6.h>
++
+ DEFINE_PRIVATE_HASH_OPS_WITH_VALUE_DESTRUCTOR(config_file_hash_ops_fclose,
+                                               char, path_hash_func, path_compare,
+                                               FILE, safe_fclose);
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0026-build-path.c-avoid-boot-time-segfault-for-musl.patch
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/0026-build-path.c-avoid-boot-time-segfault-for-musl.patch
@@ -1,0 +1,31 @@
+From f2a7cf1d2a2bc2516a180809efd85c828cd9c7f4 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 3 Jul 2024 07:18:42 -0700
+Subject: [PATCH 26/26] build-path.c: avoid boot time segfault for musl
+
+This function, at runtime, should return -ENOEXEC. For musl, it
+somehow segfaults. I think it's related to getauxval, but it's
+really does not matter, just return -ENOEXEC.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/build-path.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/basic/build-path.c b/src/basic/build-path.c
+index b5972658df..4ef551034e 100644
+--- a/src/basic/build-path.c
++++ b/src/basic/build-path.c
+@@ -151,6 +151,7 @@ int get_build_exec_dir(char **ret) {
+          */
+ 
+         static int runpath_cached = -ERRNO_MAX-1;
++        return -ENOEXEC;
+         if (runpath_cached == -ERRNO_MAX-1) {
+                 const char *runpath = NULL;
+ 
+-- 
+2.34.1
+

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/99-default.preset
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/99-default.preset
@@ -1,0 +1,1 @@
+disable *

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/init
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/init
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          udev
+# Required-Start:    mountvirtfs
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+# Short-Description: Start udevd, populate /dev and load drivers.
+### END INIT INFO
+
+. /etc/init.d/functions
+
+export TZ=/etc/localtime
+
+[ -d /sys/class ] || exit 1
+[ -r /proc/mounts ] || exit 1
+[ -x @UDEVD@ ] || exit 1
+[ -f /etc/default/udev-cache ] && . /etc/default/udev-cache
+[ -f /etc/udev/udev.conf ] && . /etc/udev/udev.conf
+
+readfile () {
+   filename=$1
+   READDATA=""
+   if [ -r $filename ]; then
+       while read line; do
+           READDATA="$READDATA$line"
+       done < $filename
+   fi
+}
+
+case "$1" in
+  start)
+    export ACTION=add
+    # propagate /dev from /sys
+    echo "Starting udev"
+
+    # mount the devtmpfs on /dev, if not already done
+    LANG=C awk '$2 == "/dev" && ($3 == "devtmpfs") { exit 1 }' /proc/mounts && {
+            mount -n -o mode=0755 -t devtmpfs none "/dev"
+    }
+    [ -e /dev/pts ] || mkdir -m 0755 /dev/pts
+    [ -e /dev/shm ] || mkdir -m 1777 /dev/shm
+    mount -a -t tmpfs 2>/dev/null
+
+    # cache handling
+    if [ "$DEVCACHE" != "" ]; then
+            readfile /proc/version
+            VERSION="$READDATA"
+            readfile /proc/cmdline
+            CMDLINE="$READDATA"
+            readfile /proc/devices
+            DEVICES="$READDATA"
+            readfile /proc/atags
+            ATAGS="$READDATA"
+
+            if [ -e $DEVCACHE ]; then
+                    readfile /etc/udev/cache.data
+                    if [ "$READDATA" = "$VERSION$CMDLINE$DEVICES$ATAGS" ]; then
+                            (cd /; tar xf $DEVCACHE > /dev/null 2>&1)
+                            not_first_boot=1
+                            [ "$VERBOSE" != "no" ] && echo "udev: using cache file $DEVCACHE"
+                            [ -e /dev/shm/udev.cache ] && rm -f /dev/shm/udev.cache
+                    else
+                            echo "$VERSION$CMDLINE$DEVICES$ATAGS" > /dev/shm/udev.cache
+                    fi
+            else
+                    echo "$VERSION$CMDLINE$DEVICES$ATAGS" > /dev/shm/udev.cache
+            fi
+    fi
+
+    # make_extra_nodes
+    killproc systemd-udevd > "/dev/null" 2>&1
+
+    # trigger the sorted events
+    echo -e '\000\000\000\000' > /proc/sys/kernel/hotplug
+    @UDEVD@ -d
+
+    udevadm control --env=STARTUP=1
+    if [ "$not_first_boot" != "" ];then
+            udevadm trigger --action=add --subsystem-nomatch=tty --subsystem-nomatch=mem --subsystem-nomatch=vc --subsystem-nomatch=vtconsole --subsystem-nomatch=misc --subsystem-nomatch=dcon --subsystem-nomatch=pci_bus  --subsystem-nomatch=graphics	 --subsystem-nomatch=backlight --subsystem-nomatch=video4linux	--subsystem-nomatch=platform
+            (udevadm settle --timeout=3; udevadm control --env=STARTUP=)&
+    else
+            udevadm trigger --action=add
+            udevadm settle
+    fi
+    ;;
+  stop)
+    echo "Stopping udevd"
+    start-stop-daemon --stop --name systemd-udevd --quiet
+    ;;
+  restart)
+    $0 stop
+    sleep 1
+    $0 start
+    ;;
+  status)
+    status systemd-udevd
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|status|restart}"
+    exit 1
+esac
+exit 0

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/org.freedesktop.hostname1_no_polkit.conf
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/org.freedesktop.hostname1_no_polkit.conf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+        <policy group="systemd-hostname">
+                <allow own="org.freedesktop.hostname1"/>
+                <allow send_destination="org.freedesktop.hostname1"/>
+                <allow receive_sender="org.freedesktop.hostname1"/>
+        </policy>
+</busconfig>

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/systemd-pager.sh
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/systemd-pager.sh
@@ -1,0 +1,7 @@
+# Systemd expect a color capable pager, however the less provided
+# by busybox is not. This make many interaction with systemd pretty
+# annoying. As a workaround we disable the systemd pager if less
+# is not the GNU version.
+if ! less -V > /dev/null 2>&1 ; then
+	export SYSTEMD_PAGER=
+fi

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/touchscreen.rules
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd/touchscreen.rules
@@ -1,0 +1,18 @@
+# There are a number of modifiers that are allowed to be used in some
+# of the different fields. They provide the following subsitutions:
+#
+# %n the "kernel number" of the device.
+#    For example, 'sda3' has a "kernel number" of '3'
+# %e the smallest number for that name which does not matches an existing node
+# %k the kernel name for the device
+# %M the kernel major number for the device
+# %m the kernel minor number for the device
+# %b the bus id for the device
+# %c the string returned by the PROGRAM
+# %s{filename} the content of a sysfs attribute
+# %% the '%' char itself
+#
+
+# Create a symlink to any touchscreen input device
+SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{modalias}=="input:*-e0*,3,*a0,1,*18,*", SYMLINK+="input/touchscreen0"
+SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{modalias}=="ads7846", SYMLINK+="input/touchscreen0"

--- a/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd_257.8.bb
+++ b/meta-luneos-holdbacks-5.3/recipes-core/systemd/systemd_257.8.bb
@@ -1,0 +1,941 @@
+require systemd-257.inc
+
+PROVIDES = "udev"
+
+PE = "1"
+
+DEPENDS = "gperf-native libcap util-linux python3-jinja2-native"
+
+SECTION = "base/shell"
+
+inherit useradd pkgconfig meson perlnative update-rc.d update-alternatives systemd gettext bash-completion manpages features_check mime
+
+# unmerged-usr support is deprecated upstream, taints the system and will be
+# removed in the near future. Fail the build if it is not enabled.
+REQUIRED_DISTRO_FEATURES += "usrmerge"
+
+# As this recipe builds udev, respect systemd being in DISTRO_FEATURES so
+# that we don't build both udev and systemd in world builds.
+REQUIRED_DISTRO_FEATURES += "systemd"
+
+SRC_URI += " \
+           file://touchscreen.rules \
+           file://00-create-volatile.conf \
+           ${@bb.utils.contains('PACKAGECONFIG', 'polkit_hostnamed_fallback', 'file://org.freedesktop.hostname1_no_polkit.conf', '', d)} \
+           ${@bb.utils.contains('PACKAGECONFIG', 'polkit_hostnamed_fallback', 'file://00-hostnamed-network-user.conf', '', d)} \
+           file://init \
+           file://99-default.preset \
+           file://systemd-pager.sh \
+           file://0001-binfmt-Don-t-install-dependency-links-at-install-tim.patch \
+           file://0002-implment-systemd-sysv-install-for-OE.patch \
+           file://0001-Do-not-create-var-log-README.patch \
+           "
+
+# patches needed by musl
+SRC_URI:append:libc-musl = " ${SRC_URI_MUSL}"
+SRC_URI_MUSL = "\
+               file://0003-missing_type.h-add-comparison_fn_t.patch \
+               file://0004-add-fallback-parse_printf_format-implementation.patch \
+               file://0005-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch \
+               file://0006-add-missing-FTW_-macros-for-musl.patch \
+               file://0007-Use-uintmax_t-for-handling-rlim_t.patch \
+               file://0008-Define-glibc-compatible-basename-for-non-glibc-syste.patch \
+               file://0009-Do-not-disable-buffering-when-writing-to-oom_score_a.patch \
+               file://0010-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch \
+               file://0011-avoid-redefinition-of-prctl_mm_map-structure.patch \
+               file://0012-do-not-disable-buffer-in-writing-files.patch \
+               file://0013-Handle-__cpu_mask-usage.patch \
+               file://0014-Handle-missing-gshadow.patch \
+               file://0015-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch \
+               file://0016-pass-correct-parameters-to-getdents64.patch \
+               file://0017-Adjust-for-musl-headers.patch \
+               file://0018-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch \
+               file://0019-errno-util-Make-STRERROR-portable-for-musl.patch \
+               file://0020-sd-event-Make-malloc_trim-conditional-on-glibc.patch \
+               file://0021-shared-Do-not-use-malloc_info-on-musl.patch \
+               file://0022-avoid-missing-LOCK_EX-declaration.patch \
+               file://0023-include-signal.h-to-avoid-the-undeclared-error.patch \
+               file://0024-undef-stdin-for-references-using-stdin-as-a-struct-m.patch \
+               file://0025-adjust-header-inclusion-order-to-avoid-redeclaration.patch \
+               file://0026-build-path.c-avoid-boot-time-segfault-for-musl.patch \
+               "
+
+PAM_PLUGINS = " \
+    pam-plugin-unix \
+    pam-plugin-loginuid \
+    pam-plugin-keyinit \
+    pam-plugin-namespace \
+"
+
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'acl audit apparmor efi ldconfig pam pni-names selinux smack polkit seccomp', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'minidebuginfo', 'coredump elfutils', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'rfkill', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xkbcommon', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'sysvinit', 'link-udev-shared', d)} \
+    backlight \
+    binfmt \
+    gshadow \
+    hibernate \
+    hostnamed \
+    idn \
+    ima \
+    kmod \
+    localed \
+    logind \
+    machined \
+    myhostname \
+    networkd \
+    nss \
+    nss-mymachines \
+    nss-resolve \
+    quotacheck \
+    randomseed \
+    resolved \
+    serial-getty-generator \
+    set-time-epoch \
+    sysusers \
+    timedated \
+    timesyncd \
+    userdb \
+    utmp \
+    vconsole \
+    wheel-group \
+    zstd \
+"
+
+PACKAGECONFIG:remove:libc-musl = " \
+    gshadow \
+    idn \
+    localed \
+    myhostname \
+    nss \
+    nss-mymachines \
+    nss-resolve \
+    sysusers \
+    userdb \
+    utmp \
+"
+
+# https://github.com/seccomp/libseccomp/issues/347
+PACKAGECONFIG:remove:mipsarch = "seccomp"
+
+TARGET_CC_ARCH:append:libc-musl = " -D__UAPI_DEF_ETHHDR=0 -D_LARGEFILE64_SOURCE"
+
+# Some of the dependencies are weak-style recommends - if not available at runtime,
+# systemd won't fail but the library-related feature will be skipped with a warning.
+
+# Use the upstream systemd serial-getty@.service and rely on
+# systemd-getty-generator instead of using the OE-core specific
+# systemd-serialgetty.bb - not enabled by default.
+PACKAGECONFIG[serial-getty-generator] = ""
+
+PACKAGECONFIG[acl] = "-Dacl=enabled,-Dacl=disabled,acl"
+PACKAGECONFIG[audit] = "-Daudit=enabled,-Daudit=disabled,audit"
+PACKAGECONFIG[apparmor] = "-Dapparmor=enabled,-Dapparmor=disabled,apparmor"
+PACKAGECONFIG[backlight] = "-Dbacklight=true,-Dbacklight=false"
+PACKAGECONFIG[binfmt] = "-Dbinfmt=true,-Dbinfmt=false"
+PACKAGECONFIG[bpf-framework] = "-Dbpf-framework=enabled,-Dbpf-framework=disabled,clang-native bpftool-native libbpf,libbpf"
+PACKAGECONFIG[bzip2] = "-Dbzip2=enabled,-Dbzip2=disabled,bzip2"
+PACKAGECONFIG[coredump] = "-Dcoredump=true,-Dcoredump=false"
+PACKAGECONFIG[cryptsetup] = "-Dlibcryptsetup=enabled,-Dlibcryptsetup=disabled,cryptsetup,,cryptsetup"
+PACKAGECONFIG[cryptsetup-plugins] = "-Dlibcryptsetup-plugins=enabled,-Dlibcryptsetup-plugins=disabled,cryptsetup,,cryptsetup"
+PACKAGECONFIG[tpm2] = "-Dtpm2=enabled,-Dtpm2=disabled,tpm2-tss,tpm2-tss libtss2 libtss2-tcti-device"
+# If multiple compression libraries are enabled, the format to use for compression is chosen implicitly,
+# so if you want to compress with e.g. lz4 you cannot enable zstd, so you cannot read zstd-compressed journal files.
+# This option allows to enable all compression formats for reading, but choosing a specific one for writing.
+PACKAGECONFIG[default-compression-lz4] = "-Dlz4=true -Ddefault-compression=lz4,,lz4"
+PACKAGECONFIG[default-compression-xz] = "-Dxz=true -Ddefault-compression=xz,,xz"
+PACKAGECONFIG[default-compression-zstd] = "-Dzstd=true -Ddefault-compression=zstd,,zstd"
+PACKAGECONFIG[efi] = "-Defi=true -Dbootloader=enabled,-Defi=false -Dbootloader=disabled,python3-pyelftools-native"
+PACKAGECONFIG[elfutils] = "-Delfutils=enabled,-Delfutils=disabled,elfutils,,libelf libdw"
+PACKAGECONFIG[fido] = "-Dlibfido2=enabled,-Dlibfido2=disabled,libfido2"
+PACKAGECONFIG[firstboot] = "-Dfirstboot=true,-Dfirstboot=false"
+PACKAGECONFIG[repart] = "-Drepart=enabled,-Drepart=disabled"
+PACKAGECONFIG[homed] = "-Dhomed=enabled,-Dhomed=disabled"
+# Sign the journal for anti-tampering
+PACKAGECONFIG[gcrypt] = "-Dgcrypt=enabled,-Dgcrypt=disabled,libgcrypt"
+PACKAGECONFIG[gnutls] = "-Dgnutls=enabled,-Dgnutls=disabled,gnutls"
+PACKAGECONFIG[gshadow] = "-Dgshadow=true,-Dgshadow=false"
+PACKAGECONFIG[hibernate] = "-Dhibernate=true,-Dhibernate=false"
+PACKAGECONFIG[hostnamed] = "-Dhostnamed=true,-Dhostnamed=false"
+PACKAGECONFIG[idn] = "-Didn=true,-Didn=false"
+PACKAGECONFIG[ima] = "-Dima=true,-Dima=false"
+# importd requires journal-upload/xz/zlib/bzip2/gcrypt
+PACKAGECONFIG[importd] = "-Dimportd=enabled,-Dimportd=disabled,glib-2.0"
+# Update NAT firewall rules
+PACKAGECONFIG[iptc] = "-Dlibiptc=enabled,-Dlibiptc=disabled,iptables"
+PACKAGECONFIG[journal-color] = ",,,less"
+PACKAGECONFIG[journal-upload] = "-Dlibcurl=enabled,-Dlibcurl=disabled,curl"
+PACKAGECONFIG[kmod] = "-Dkmod=enabled,-Dkmod=disabled,kmod,libkmod"
+PACKAGECONFIG[ldconfig] = "-Dldconfig=true,-Dldconfig=false,,ldconfig"
+PACKAGECONFIG[libidn] = "-Dlibidn=enabled,-Dlibidn=disabled,libidn,,libidn"
+PACKAGECONFIG[libidn2] = "-Dlibidn2=enabled,-Dlibidn2=disabled,libidn2,,libidn2"
+# Link udev shared with systemd helper library.
+# If enabled the udev package depends on the systemd package (which has the needed shared library).
+PACKAGECONFIG[link-udev-shared] = "-Dlink-udev-shared=true,-Dlink-udev-shared=false"
+PACKAGECONFIG[localed] = "-Dlocaled=true,-Dlocaled=false"
+PACKAGECONFIG[logind] = "-Dlogind=true,-Dlogind=false"
+PACKAGECONFIG[lz4] = "-Dlz4=enabled,-Dlz4=disabled,lz4"
+PACKAGECONFIG[machined] = "-Dmachined=true,-Dmachined=false"
+PACKAGECONFIG[manpages] = "-Dman=enabled,-Dman=disabled,python3-lxml-native libxslt-native xmlto-native docbook-xml-dtd4-native docbook-xsl-stylesheets-native"
+PACKAGECONFIG[microhttpd] = "-Dmicrohttpd=enabled,-Dmicrohttpd=disabled,libmicrohttpd"
+PACKAGECONFIG[mountfsd] = "-Dmountfsd=true,-Dmountfsd=false"
+PACKAGECONFIG[myhostname] = "-Dnss-myhostname=true,-Dnss-myhostname=false,,libnss-myhostname"
+PACKAGECONFIG[nsresourced] = "-Dnsresourced=true,-Dnsresourced=false"
+PACKAGECONFIG[networkd] = "-Dnetworkd=true,-Dnetworkd=false"
+PACKAGECONFIG[no-dns-fallback] = "-Ddns-servers="
+PACKAGECONFIG[no-ntp-fallback] = "-Dntp-servers="
+PACKAGECONFIG[nss] = "-Dnss-systemd=true,-Dnss-systemd=false,,libnss-systemd"
+PACKAGECONFIG[nss-mymachines] = "-Dnss-mymachines=enabled,-Dnss-mymachines=disabled"
+PACKAGECONFIG[nss-resolve] = "-Dnss-resolve=enabled,-Dnss-resolve=disabled,,libnss-resolve"
+PACKAGECONFIG[oomd] = "-Doomd=true,-Doomd=false"
+PACKAGECONFIG[openssl] = "-Dopenssl=enabled,-Dopenssl=disabled,openssl"
+PACKAGECONFIG[p11kit] = "-Dp11kit=enabled,-Dp11kit=disabled,p11-kit"
+PACKAGECONFIG[pam] = "-Dpam=enabled,-Dpam=disabled,libpam,${PAM_PLUGINS}"
+PACKAGECONFIG[pcre2] = "-Dpcre2=enabled,-Dpcre2=disabled,libpcre2"
+PACKAGECONFIG[polkit] = "-Dpolkit=enabled,-Dpolkit=disabled"
+# If polkit is disabled and networkd+hostnamed are in use, enabling this option and
+# using dbus-broker will allow networkd to be authorized to change the
+# hostname without acquiring additional privileges
+PACKAGECONFIG[polkit_hostnamed_fallback] = ",,,,dbus-broker,polkit"
+PACKAGECONFIG[portabled] = "-Dportabled=true,-Dportabled=false"
+PACKAGECONFIG[pstore] = "-Dpstore=true,-Dpstore=false"
+PACKAGECONFIG[pni-names] = ",,,"
+PACKAGECONFIG[qrencode] = "-Dqrencode=enabled,-Dqrencode=disabled,qrencode,,qrencode"
+PACKAGECONFIG[quotacheck] = "-Dquotacheck=true,-Dquotacheck=false"
+PACKAGECONFIG[randomseed] = "-Drandomseed=true,-Drandomseed=false"
+PACKAGECONFIG[resolved] = "-Dresolve=true,-Dresolve=false"
+PACKAGECONFIG[rfkill] = "-Drfkill=true,-Drfkill=false"
+PACKAGECONFIG[seccomp] = "-Dseccomp=enabled,-Dseccomp=disabled,libseccomp"
+PACKAGECONFIG[selinux] = "-Dselinux=enabled,-Dselinux=disabled,libselinux,initscripts-sushell"
+PACKAGECONFIG[smack] = "-Dsmack=true,-Dsmack=false"
+PACKAGECONFIG[sysext] = "-Dsysext=true, -Dsysext=false"
+PACKAGECONFIG[sysusers] = "-Dsysusers=true,-Dsysusers=false"
+PACKAGECONFIG[sysvinit] = "-Dsysvinit-path=${sysconfdir}/init.d -Dsysvrcnd-path=${sysconfdir},-Dsysvinit-path= -Dsysvrcnd-path=,,systemd-compat-units update-rc.d"
+# When enabled use reproducible build timestamp if set as time epoch,
+# or build time if not. When disabled, time epoch is unset.
+def build_epoch(d):
+    epoch = d.getVar('SOURCE_DATE_EPOCH') or "-1"
+    return '-Dtime-epoch=%d' % int(epoch)
+PACKAGECONFIG[set-time-epoch] = "${@build_epoch(d)},-Dtime-epoch=0"
+PACKAGECONFIG[timedated] = "-Dtimedated=true,-Dtimedated=false"
+PACKAGECONFIG[timesyncd] = "-Dtimesyncd=true,-Dtimesyncd=false"
+PACKAGECONFIG[sbinmerge] = "-Dsplit-bin=false,-Dsplit-bin=true"
+PACKAGECONFIG[userdb] = "-Duserdb=true,-Duserdb=false"
+PACKAGECONFIG[utmp] = "-Dutmp=true,-Dutmp=false"
+PACKAGECONFIG[valgrind] = "-DVALGRIND=1,,valgrind"
+PACKAGECONFIG[vconsole] = "-Dvconsole=true,-Dvconsole=false,,${PN}-vconsole-setup"
+PACKAGECONFIG[wheel-group] = "-Dwheel-group=true, -Dwheel-group=false"
+PACKAGECONFIG[xdg-autostart] = "-Dxdg-autostart=true,-Dxdg-autostart=false"
+# Verify keymaps on locale change
+PACKAGECONFIG[xkbcommon] = "-Dxkbcommon=enabled,-Dxkbcommon=disabled,libxkbcommon"
+PACKAGECONFIG[xz] = "-Dxz=enabled,-Dxz=disabled,xz"
+PACKAGECONFIG[zlib] = "-Dzlib=enabled,-Dzlib=disabled,zlib"
+PACKAGECONFIG[zstd] = "-Dzstd=enabled,-Dzstd=disabled,zstd"
+
+RESOLV_CONF ??= ""
+
+# bpf-framework: pass the recipe-sysroot to the compiler used to build
+# the eBPFs, so that it can find needed system includes in there.
+CFLAGS:append = " --sysroot=${STAGING_DIR_TARGET}"
+LDFLAGS:append:aarch64 = " ${@bb.utils.contains('PACKAGECONFIG', 'openssl', '-Wl,-z,gcs-report-dynamic=none', '', d)}"
+
+EXTRA_OEMESON += "-Dnobody-user=nobody \
+                  -Dnobody-group=nogroup \
+                  -Ddefault-locale=C \
+                  -Dmode=release \
+                  -Dsystem-alloc-uid-min=101 \
+                  -Dsystem-uid-max=999 \
+                  -Dsystem-alloc-gid-min=101 \
+                  -Dsystem-gid-max=999 \
+                  -Dtranslations=${@'false' if d.getVar('USE_NLS') == 'no' else 'true'} \
+                  ${@bb.utils.contains('DISTRO_FEATURES', 'zeroconf', '-Ddefault-mdns=no -Ddefault-llmnr=no', '', d)} \
+                  -Ddbus=disabled \
+                  "
+
+# Hardcode target binary paths to avoid using paths from sysroot or worse
+# it pokes for these binaries on build host and encodes that distro assumption
+# into target
+EXTRA_OEMESON += "-Dkexec-path=${sbindir}/kexec \
+                  -Dkmod-path=${base_bindir}/kmod \
+                  -Dmount-path=${base_bindir}/mount \
+                  -Dquotacheck-path=${sbindir}/quotacheck \
+                  -Dquotaon-path=${sbindir}/quotaon \
+                  -Dsulogin-path=${base_sbindir}/sulogin \
+                  -Dnologin-path=${base_sbindir}/nologin \
+                  -Dumount-path=${base_bindir}/umount \
+                  -Dloadkeys-path=${bindir}/loadkeys \
+                  -Dsetfont-path=${bindir}/setfont"
+
+# The 60 seconds is watchdog's default vaule.
+WATCHDOG_TIMEOUT ??= "60"
+
+# To make use of the hardware watchdog it is sufficient to set WATCHDOG_RUNTIME_SEC
+# (RuntimeWatchdogSec= option in /etc/systemd/system.conf) to a value like 20s
+# and the watchdog is enabled. (defaults is no hardware watchdog use)
+WATCHDOG_RUNTIME_SEC ??= ""
+
+do_install() {
+	meson_do_install
+
+	if ${@bb.utils.contains('PACKAGECONFIG', 'sysusers', 'true', 'false', d)}; then
+		# Change the root user's home directory in /lib/sysusers.d/basic.conf.
+		# This is done merely for backward compatibility with previous systemd recipes.
+		# systemd hardcodes root user's HOME to be "/root". Changing to use other values
+		# may have unexpected runtime behaviors.
+		if [ "${ROOT_HOME}" != "/root" ]; then
+			bbwarn "Using ${ROOT_HOME} as root user's home directory is not fully supported by systemd"
+			sed -i -e 's#/root#${ROOT_HOME}#g' ${D}${exec_prefix}/lib/sysusers.d/basic.conf
+		fi
+	fi
+	install -d ${D}/${base_sbindir}
+
+	if ! ${@bb.utils.contains('PACKAGECONFIG', 'serial-getty-generator', 'true', 'false', d)}; then
+		# Remove the serial-getty generator and instead use explicit services
+		# created by the systemd-serialgetty recipe
+		find ${D} -name \*getty-generator\* -delete
+	fi
+
+	# Provide support for initramfs
+	[ ! -e ${D}/init ] && ln -s ${nonarch_libdir}/systemd/systemd ${D}/init
+	[ ! -e ${D}/${base_sbindir}/udevd ] && ln -s ${nonarch_libdir}/systemd/systemd-udevd ${D}/${base_sbindir}/udevd
+
+	install -d ${D}${sysconfdir}/udev/rules.d/
+	install -d ${D}${nonarch_libdir}/tmpfiles.d
+	for rule in $(find ${UNPACKDIR} -maxdepth 1 -type f -name "*.rules"); do
+		install -m 0644 $rule ${D}${sysconfdir}/udev/rules.d/
+	done
+
+	install -m 0644 ${UNPACKDIR}/00-create-volatile.conf ${D}${nonarch_libdir}/tmpfiles.d/
+
+	if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
+		install -d ${D}${sysconfdir}/init.d
+		install -m 0755 ${UNPACKDIR}/init ${D}${sysconfdir}/init.d/systemd-udevd
+		sed -i s%@UDEVD@%${nonarch_libdir}/systemd/systemd-udevd% ${D}${sysconfdir}/init.d/systemd-udevd
+		install -Dm 0755 ${S}/src/systemctl/systemd-sysv-install.SKELETON ${D}${systemd_unitdir}/systemd-sysv-install
+	fi
+
+	if ${@bb.utils.contains('FILESYSTEM_PERMS_TABLES', 'files/fs-perms-volatile-log.txt', 'true', 'false', d)}; then
+		# base-files recipe provides /var/log which is a symlink to /var/volatile/log
+		rm -rf ${D}${localstatedir}/log
+		printf 'L\t\t%s/log\t\t-\t-\t-\t-\t%s/volatile/log\n' "${localstatedir}" \
+			"${localstatedir}" >>${D}${nonarch_libdir}/tmpfiles.d/00-create-volatile.conf
+	elif [ -e ${D}${localstatedir}/log/journal ]; then
+		chown root:systemd-journal ${D}${localstatedir}/log/journal
+
+		# journal-remote creates this at start
+		rm -rf ${D}${localstatedir}/log/journal/remote
+	fi
+
+	# if the user requests /tmp be on persistent storage (i.e. not volatile)
+	# then don't use a tmpfs for /tmp
+	if ! ${@bb.utils.contains('FILESYSTEM_PERMS_TABLES', 'files/fs-perms-volatile-tmp.txt', 'true', 'false', d)}; then
+		rm -f ${D}${nonarch_libdir}/systemd/system/tmp.mount
+		rm -f ${D}${nonarch_libdir}/systemd/system/local-fs.target.wants/tmp.mount
+	fi
+
+	install -d ${D}${systemd_system_unitdir}/graphical.target.wants
+	install -d ${D}${systemd_system_unitdir}/multi-user.target.wants
+	install -d ${D}${systemd_system_unitdir}/poweroff.target.wants
+	install -d ${D}${systemd_system_unitdir}/reboot.target.wants
+	install -d ${D}${systemd_system_unitdir}/rescue.target.wants
+
+	# Create symlinks for systemd-update-utmp-runlevel.service
+	if ${@bb.utils.contains('PACKAGECONFIG', 'utmp', 'true', 'false', d)} && ${@bb.utils.contains('PACKAGECONFIG', 'sysvinit', 'true', 'false', d)}; then
+		ln -sf ../systemd-update-utmp-runlevel.service ${D}${systemd_system_unitdir}/graphical.target.wants/systemd-update-utmp-runlevel.service
+		ln -sf ../systemd-update-utmp-runlevel.service ${D}${systemd_system_unitdir}/multi-user.target.wants/systemd-update-utmp-runlevel.service
+		ln -sf ../systemd-update-utmp-runlevel.service ${D}${systemd_system_unitdir}/poweroff.target.wants/systemd-update-utmp-runlevel.service
+		ln -sf ../systemd-update-utmp-runlevel.service ${D}${systemd_system_unitdir}/reboot.target.wants/systemd-update-utmp-runlevel.service
+		ln -sf ../systemd-update-utmp-runlevel.service ${D}${systemd_system_unitdir}/rescue.target.wants/systemd-update-utmp-runlevel.service
+	fi
+
+	# this file is needed to exist if networkd is disabled but timesyncd is still in use since timesyncd checks it
+	# for existence else it fails
+	if [ -s ${D}${exec_prefix}/lib/tmpfiles.d/systemd.conf ] &&
+	   ! ${@bb.utils.contains('PACKAGECONFIG', 'networkd', 'true', 'false', d)}; then
+		echo 'd /run/systemd/netif/links 0755 root root -' >>${D}${exec_prefix}/lib/tmpfiles.d/systemd.conf
+	fi
+	if ! ${@bb.utils.contains('PACKAGECONFIG', 'resolved', 'true', 'false', d)}; then
+		echo 'L! ${sysconfdir}/resolv.conf - - - - ../run/systemd/resolve/resolv.conf' >>${D}${exec_prefix}/lib/tmpfiles.d/etc.conf
+		echo 'd /run/systemd/resolve 0755 root root -' >>${D}${exec_prefix}/lib/tmpfiles.d/systemd.conf
+		echo 'f /run/systemd/resolve/resolv.conf 0644 root root' >>${D}${exec_prefix}/lib/tmpfiles.d/systemd.conf
+		ln -s ../run/systemd/resolve/resolv.conf ${D}${sysconfdir}/resolv-conf.systemd
+	else
+		resolv_conf="${@bb.utils.contains('RESOLV_CONF', 'stub-resolv', 'run/systemd/resolve/stub-resolv.conf', 'run/systemd/resolve/resolv.conf', d)}"
+		sed -i -e "s%^L! /etc/resolv.conf.*$%L! /etc/resolv.conf - - - - ../${resolv_conf}%g" ${D}${exec_prefix}/lib/tmpfiles.d/systemd-resolve.conf
+		ln -s ../${resolv_conf} ${D}${sysconfdir}/resolv-conf.systemd
+	fi
+	if ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'false', 'true', d)}; then
+		rm ${D}${exec_prefix}/lib/tmpfiles.d/x11.conf
+		rm -r ${D}${sysconfdir}/X11
+	fi
+
+	# If polkit is not available and a fallback was requested, install a drop-in that allows networkd to
+	# request hostname changes via DBUS without elevating its privileges
+	if ${@bb.utils.contains('PACKAGECONFIG', 'polkit_hostnamed_fallback', 'true', 'false', d)}; then
+		install -d ${D}${systemd_system_unitdir}/systemd-hostnamed.service.d/
+		install -m 0644 ${UNPACKDIR}/00-hostnamed-network-user.conf ${D}${systemd_system_unitdir}/systemd-hostnamed.service.d/
+		install -d ${D}${datadir}/dbus-1/system.d/
+		install -m 0644 ${UNPACKDIR}/org.freedesktop.hostname1_no_polkit.conf ${D}${datadir}/dbus-1/system.d/
+	fi
+
+	# create link for existing udev rules
+	ln -s ${base_bindir}/udevadm ${D}${base_sbindir}/udevadm
+
+	# install default policy for presets
+	# https://www.freedesktop.org/wiki/Software/systemd/Preset/#howto
+	install -Dm 0644 ${UNPACKDIR}/99-default.preset ${D}${systemd_unitdir}/system-preset/99-default.preset
+
+	# add a profile fragment to disable systemd pager with busybox less
+	install -Dm 0644 ${UNPACKDIR}/systemd-pager.sh ${D}${sysconfdir}/profile.d/systemd-pager.sh
+
+	if [ -n "${WATCHDOG_TIMEOUT}" ]; then
+		sed -i -e 's/#RebootWatchdogSec=10min/RebootWatchdogSec=${WATCHDOG_TIMEOUT}/' \
+			${D}/${sysconfdir}/systemd/system.conf
+	fi
+
+	if [ -n "${WATCHDOG_RUNTIME_SEC}" ]; then
+		sed -i -e 's/#RuntimeWatchdogSec=off/RuntimeWatchdogSec=${WATCHDOG_RUNTIME_SEC}/' \
+			${D}/${sysconfdir}/systemd/system.conf
+	fi
+
+	# Actively disable Predictable Network Interface Names
+	if ! ${@bb.utils.contains('PACKAGECONFIG', 'pni-names', 'true', 'false', d)}; then
+		sed -i 's/^NamePolicy=.*/NamePolicy=/;s/^AlternativeNamesPolicy=.*/AlternativeNamesPolicy=/' ${D}${nonarch_libdir}/systemd/network/99-default.link
+	fi
+}
+
+python populate_packages:prepend (){
+    systemdlibdir = d.getVar("libdir")
+    do_split_packages(d, systemdlibdir, r'^lib(.*)\.so\.*', 'lib%s', 'Systemd %s library', extra_depends='', allow_links=True)
+}
+PACKAGES_DYNAMIC += "^lib(udev|systemd|nss).*"
+
+# wrynose changed bash-completion.bbclass from
+#   PACKAGES += "${PN}-bash-completion"
+# to
+#   PACKAGE_BEFORE_PN += "${PN}-bash-completion"
+# An absolute assignment here therefore wipes the package the class adds, and
+# the completions end up installed but unpackaged. oe-core's own 259.5 recipe
+# uses += for exactly this reason.
+PACKAGE_BEFORE_PN += "\
+    ${PN}-analyze \
+    ${PN}-binfmt \
+    ${PN}-container \
+    ${PN}-crypt \
+    ${PN}-extra-utils \
+    ${PN}-gui \
+    ${PN}-initramfs \
+    ${PN}-journal-gatewayd \
+    ${PN}-journal-upload \
+    ${PN}-journal-remote \
+    ${PN}-kernel-install \
+    ${PN}-mime \
+    ${PN}-networkd \
+    ${PN}-rpm-macros \
+    ${PN}-udev-rules \
+    ${PN}-vconsole-setup \
+    ${PN}-zsh-completion \
+    libsystemd-shared \
+    udev \
+    udev-bash-completion \
+    udev-hwdb \
+"
+
+SUMMARY:${PN}-container = "Tools for containers and VMs"
+DESCRIPTION:${PN}-container = "Systemd tools to spawn and manage containers and virtual machines."
+
+SUMMARY:${PN}-journal-gatewayd = "HTTP server for journal events"
+DESCRIPTION:${PN}-journal-gatewayd = "systemd-journal-gatewayd serves journal events over the network. Clients must connect using HTTP. The server listens on port 19531 by default."
+
+SUMMARY:${PN}-journal-upload = "Send journal messages over the network"
+DESCRIPTION:${PN}-journal-upload = "systemd-journal-upload uploads journal entries to a specified URL."
+
+SUMMARY:${PN}-journal-remote = "Receive journal messages over the network"
+DESCRIPTION:${PN}-journal-remote = "systemd-journal-remote is a command to receive serialized journal events and store them to journal files."
+
+SUMMARY:libsystemd-shared = "Systemd shared library"
+
+SYSTEMD_PACKAGES = "${@bb.utils.contains('PACKAGECONFIG', 'binfmt', '${PN}-binfmt', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'microhttpd', '${PN}-journal-gatewayd', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'microhttpd', '${PN}-journal-remote', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'journal-upload', '${PN}-journal-upload', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'networkd', '${PN}-networkd', '', d)} \
+"
+SYSTEMD_SERVICE:${PN}-binfmt = "systemd-binfmt.service"
+
+USERADD_PACKAGES = "${PN} \
+                    udev \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'microhttpd', '${PN}-journal-gatewayd', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'microhttpd', '${PN}-journal-remote', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'journal-upload', '${PN}-journal-upload', '', d)} \
+                    ${@bb.utils.contains('PACKAGECONFIG', 'networkd', '${PN}-networkd', '', d)} \
+"
+GROUPADD_PARAM:${PN} = "-r systemd-journal;"
+GROUPADD_PARAM:udev = "-r render"
+GROUPADD_PARAM:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'polkit_hostnamed_fallback', '-r systemd-hostname;', '', d)}"
+USERADD_PARAM:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'coredump', '--system -d / -M --shell /sbin/nologin systemd-coredump;', '', d)}"
+USERADD_PARAM:${PN}-networkd = "--system -d / -M --shell /sbin/nologin systemd-network"
+USERADD_PARAM:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'polkit', '--system --no-create-home --user-group --home-dir ${datadir}/polkit-1 polkitd;', '', d)}"
+USERADD_PARAM:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'resolved', '--system -d / -M --shell /sbin/nologin systemd-resolve;', '', d)}"
+USERADD_PARAM:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'timesyncd', '--system -d / -M --shell /sbin/nologin systemd-timesync;', '', d)}"
+USERADD_PARAM:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'oomd', '--system -d / -M --shell /sbin/nologin systemd-oom;', '', d)}"
+USERADD_PARAM:${PN}-journal-gatewayd = "--system -d / -M --shell /sbin/nologin systemd-journal-gateway"
+USERADD_PARAM:${PN}-journal-remote = "--system -d / -M --shell /sbin/nologin systemd-journal-remote"
+USERADD_PARAM:${PN}-journal-upload = "--system -d / -M --shell /sbin/nologin systemd-journal-upload"
+
+FILES:${PN}-analyze = "${bindir}/systemd-analyze"
+
+FILES:${PN}-crypt = "${bindir}/systemd-cryptenroll \
+                     ${libdir}/cryptsetup \
+                    "
+RRECOMMENDS:${PN} += "${PN}-crypt"
+
+FILES:${PN}-initramfs = "/init"
+RDEPENDS:${PN}-initramfs = "${PN}"
+
+FILES:${PN}-gui = "${bindir}/systemadm"
+
+FILES:${PN}-vconsole-setup = "${nonarch_libdir}/systemd/systemd-vconsole-setup \
+                              ${systemd_system_unitdir}/systemd-vconsole-setup.service \
+                              ${systemd_system_unitdir}/sysinit.target.wants/systemd-vconsole-setup.service"
+
+RDEPENDS:${PN}-kernel-install += "bash"
+FILES:${PN}-kernel-install = "${bindir}/kernel-install \
+                              ${sysconfdir}/kernel/ \
+                              ${exec_prefix}/lib/kernel \
+                             "
+FILES:${PN}-rpm-macros = "${exec_prefix}/lib/rpm \
+                         "
+
+FILES:${PN}-zsh-completion = "${datadir}/zsh/site-functions"
+
+FILES:${PN}-binfmt = "${sysconfdir}/binfmt.d/ \
+                      ${exec_prefix}/lib/binfmt.d \
+                      ${nonarch_libdir}/systemd/systemd-binfmt \
+                      ${systemd_system_unitdir}/proc-sys-fs-binfmt_misc.* \
+                      ${systemd_system_unitdir}/systemd-binfmt.service"
+RRECOMMENDS:${PN}-binfmt = "${@bb.utils.contains('PACKAGECONFIG', 'binfmt', 'kernel-module-binfmt-misc', '', d)}"
+
+RDEPENDS:${PN}-vconsole-setup = "${@bb.utils.contains('PACKAGECONFIG', 'vconsole', 'kbd kbd-consolefonts kbd-keymaps', '', d)}"
+
+FILES:${PN}-journal-gatewayd = "${nonarch_libdir}/systemd/systemd-journal-gatewayd \
+                                ${systemd_system_unitdir}/systemd-journal-gatewayd.service \
+                                ${systemd_system_unitdir}/systemd-journal-gatewayd.socket \
+                                ${systemd_system_unitdir}/sockets.target.wants/systemd-journal-gatewayd.socket \
+                                ${datadir}/systemd/gatewayd/browse.html \
+                               "
+SYSTEMD_SERVICE:${PN}-journal-gatewayd = "systemd-journal-gatewayd.socket"
+
+FILES:${PN}-journal-upload = "${nonarch_libdir}/systemd/systemd-journal-upload \
+                              ${systemd_system_unitdir}/systemd-journal-upload.service \
+                              ${sysconfdir}/systemd/journal-upload.conf \
+                             "
+SYSTEMD_SERVICE:${PN}-journal-upload = "systemd-journal-upload.service"
+
+FILES:${PN}-journal-remote = "${nonarch_libdir}/systemd/systemd-journal-remote \
+                              ${nonarch_libdir}/sysusers.d/systemd-remote.conf \
+                              ${sysconfdir}/systemd/journal-remote.conf \
+                              ${systemd_system_unitdir}/systemd-journal-remote.service \
+                              ${systemd_system_unitdir}/systemd-journal-remote.socket \
+                             "
+SYSTEMD_SERVICE:${PN}-journal-remote = "systemd-journal-remote.socket"
+
+FILES:${PN}-container = "${sysconfdir}/dbus-1/system.d/org.freedesktop.import1.conf \
+                         ${sysconfdir}/dbus-1/system.d/org.freedesktop.machine1.conf \
+                         ${sysconfdir}/systemd/system/multi-user.target.wants/machines.target \
+                         ${base_bindir}/machinectl \
+                         ${bindir}/systemd-nspawn \
+                         ${nonarch_libdir}/systemd/import-pubring.gpg \
+                         ${systemd_system_unitdir}/busnames.target.wants/org.freedesktop.import1.busname \
+                         ${systemd_system_unitdir}/busnames.target.wants/org.freedesktop.machine1.busname \
+                         ${systemd_system_unitdir}/local-fs.target.wants/var-lib-machines.mount \
+                         ${systemd_system_unitdir}/machines.target.wants/var-lib-machines.mount \
+                         ${systemd_system_unitdir}/remote-fs.target.wants/var-lib-machines.mount \
+                         ${systemd_system_unitdir}/machine.slice \
+                         ${systemd_system_unitdir}/machines.target \
+                         ${systemd_system_unitdir}/org.freedesktop.import1.busname \
+                         ${systemd_system_unitdir}/org.freedesktop.machine1.busname \
+                         ${systemd_system_unitdir}/systemd-importd.service \
+                         ${systemd_system_unitdir}/systemd-machined.service \
+                         ${systemd_system_unitdir}/dbus-org.freedesktop.machine1.service \
+                         ${systemd_system_unitdir}/var-lib-machines.mount \
+                         ${nonarch_libdir}/systemd/systemd-import \
+                         ${nonarch_libdir}/systemd/systemd-importd \
+                         ${nonarch_libdir}/systemd/systemd-machined \
+                         ${nonarch_libdir}/systemd/systemd-pull \
+                         ${exec_prefix}/lib/tmpfiles.d/systemd-nspawn.conf \
+                         ${exec_prefix}/lib/tmpfiles.d/README \
+                         ${systemd_system_unitdir}/systemd-nspawn@.service \
+                         ${datadir}/dbus-1/system-services/org.freedesktop.import1.service \
+                         ${datadir}/dbus-1/system-services/org.freedesktop.machine1.service \
+                         ${datadir}/dbus-1/system.d/org.freedesktop.import1.conf \
+                         ${datadir}/dbus-1/system.d/org.freedesktop.machine1.conf \
+                         ${datadir}/polkit-1/actions/org.freedesktop.import1.policy \
+                         ${datadir}/polkit-1/actions/org.freedesktop.machine1.policy \
+                        "
+
+RDEPENDS:${PN}-container = "${@bb.utils.contains('PACKAGECONFIG', 'nss-mymachines', 'libnss-mymachines', '', d)}"
+
+# "machinectl import-tar" uses "tar --numeric-owner", not supported by busybox.
+RRECOMMENDS:${PN}-container += "\
+                         ${PN}-journal-gatewayd \
+                         ${PN}-journal-remote \
+                         ${PN}-journal-upload \
+                         kernel-module-dm-mod \
+                         kernel-module-loop \
+                         kernel-module-tun \
+                         tar \
+                        "
+
+FILES:${PN}-extra-utils = "\
+                        ${base_bindir}/systemd-escape \
+                        ${base_bindir}/systemd-inhibit \
+                        ${bindir}/systemd-detect-virt \
+                        ${bindir}/systemd-dissect \
+                        ${bindir}/systemd-path \
+                        ${bindir}/systemd-run \
+                        ${bindir}/systemd-cat \
+                        ${bindir}/systemd-creds \
+                        ${bindir}/systemd-delta \
+                        ${bindir}/systemd-cgls \
+                        ${bindir}/systemd-cgtop \
+                        ${bindir}/systemd-stdio-bridge \
+                        ${base_sbindir}/mount.ddi \
+                        ${systemd_system_unitdir}/initrd.target.wants/systemd-pcrphase-initrd.path \
+                        ${systemd_system_unitdir}/sysinit.target.wants/systemd-pcrphase.path \
+                        ${systemd_system_unitdir}/sysinit.target.wants/systemd-pcrphase-sysinit.path \
+                        ${nonarch_libdir}/systemd/systemd-resolve-host \
+                        ${nonarch_libdir}/systemd/systemd-ac-power \
+                        ${nonarch_libdir}/systemd/systemd-activate \
+                        ${nonarch_libdir}/systemd/systemd-measure \
+                        ${nonarch_libdir}/systemd/systemd-pcrphase \
+                        ${nonarch_libdir}/systemd/systemd-socket-proxyd \
+                        ${nonarch_libdir}/systemd/systemd-sleep \
+                        ${nonarch_libdir}/systemd/system-sleep \
+                        ${systemd_system_unitdir}/systemd-hibernate.service \
+                        ${systemd_system_unitdir}/systemd-hybrid-sleep.service \
+                        ${systemd_system_unitdir}/systemd-pcrphase-initrd.service \
+                        ${systemd_system_unitdir}/systemd-pcrphase.service \
+                        ${systemd_system_unitdir}/systemd-pcrphase-sysinit.service \
+                        ${systemd_system_unitdir}/systemd-suspend.service \
+                        ${systemd_system_unitdir}/sleep.target \
+                        ${nonarch_libdir}/systemd/systemd-initctl \
+                        ${systemd_system_unitdir}/systemd-initctl.service \
+                        ${systemd_system_unitdir}/systemd-initctl.socket \
+                        ${systemd_system_unitdir}/sockets.target.wants/systemd-initctl.socket \
+                        ${nonarch_libdir}/systemd/system-generators/systemd-gpt-auto-generator \
+                        ${nonarch_libdir}/systemd/systemd-cgroups-agent \
+"
+
+FILES:${PN}-mime = "${MIMEDIR}"
+RRECOMMENDS:${PN} += "${PN}-mime"
+
+FILES:${PN}-networkd = "\
+    ${bindir}/networkctl \
+    ${datadir}/dbus-1/system-services/org.freedesktop.network1.service \
+    ${datadir}/dbus-1/system.d/org.freedesktop.network1.conf \
+    ${datadir}/polkit-1/actions/org.freedesktop.network1.policy \
+    ${nonarch_libdir}/sysusers.d/systemd-network.conf \
+    ${nonarch_libdir}/tmpfiles.d/systemd-network.conf \
+    ${sysconfdir}/systemd/networkd.conf \
+    ${systemd_system_unitdir}/systemd-networkd* \
+    ${systemd_unitdir}/network/*.network \
+    ${systemd_unitdir}/network/*.network.example \
+    ${systemd_unitdir}/networkd.conf \
+    ${systemd_unitdir}/systemd-networkd* \
+"
+# systemd-networkd-persistent-storage.service BindsTo=systemd-networkd.service
+# systemd-networkd.service has Also=systemd-networkd-wait-online.service
+SYSTEMD_SERVICE:${PN}-networkd = "systemd-networkd.service"
+CONFFILES:${PN}-networkd = "${sysconfdir}/systemd/networkd.conf"
+RDEPENDS:${PN}-networkd += "${PN}"
+RRECOMMENDS:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'networkd', '${PN}-networkd', '', d)}"
+
+FILES:${PN}-udev-rules = "\
+                        ${nonarch_libdir}/udev/rules.d/70-uaccess.rules \
+                        ${nonarch_libdir}/udev/rules.d/71-seat.rules \
+                        ${nonarch_libdir}/udev/rules.d/73-seat-late.rules \
+                        ${nonarch_libdir}/udev/rules.d/99-systemd.rules \
+"
+
+CONFFILES:${PN} = "${sysconfdir}/systemd/coredump.conf \
+	${sysconfdir}/systemd/journald.conf \
+	${sysconfdir}/systemd/logind.conf \
+	${sysconfdir}/systemd/pstore.conf \
+	${sysconfdir}/systemd/resolved.conf \
+	${sysconfdir}/systemd/sleep.conf \
+	${sysconfdir}/systemd/system.conf \
+	${sysconfdir}/systemd/timesyncd.conf \
+	${sysconfdir}/systemd/user.conf \
+"
+
+FILES:${PN} = " ${base_bindir}/* \
+                ${base_sbindir}/shutdown \
+                ${base_sbindir}/halt \
+                ${base_sbindir}/poweroff \
+                ${base_sbindir}/runlevel \
+                ${base_sbindir}/telinit \
+                ${base_sbindir}/resolvconf \
+                ${base_sbindir}/reboot \
+                ${base_sbindir}/init \
+                ${datadir}/dbus-1/services \
+                ${datadir}/dbus-1/system-services \
+                ${datadir}/polkit-1 \
+                ${datadir}/${BPN} \
+                ${datadir}/factory \
+                ${sysconfdir}/credstore/ \
+                ${sysconfdir}/credstore.encrypted/ \
+                ${sysconfdir}/dbus-1/ \
+                ${sysconfdir}/modules-load.d/ \
+                ${sysconfdir}/pam.d/ \
+                ${sysconfdir}/profile.d/ \
+                ${sysconfdir}/sysctl.d/ \
+                ${sysconfdir}/systemd/ \
+                ${sysconfdir}/tmpfiles.d/ \
+                ${sysconfdir}/xdg/ \
+                ${sysconfdir}/init.d/README \
+                ${sysconfdir}/resolv-conf.systemd \
+                ${sysconfdir}/X11/xinit/xinitrc.d/* \
+                ${sysconfdir}/ssh/ssh_config.d/20-systemd-ssh-proxy.conf \
+                ${sysconfdir}/ssh/sshd_config.d/20-systemd-userdb.conf \
+                ${nonarch_libdir}/systemd/* \
+                ${libdir}/systemd/libsystemd-core* \
+                ${libdir}/pam.d \
+                ${nonarch_libdir}/pam.d \
+                ${systemd_unitdir}/* \
+                ${base_libdir}/security/*.so \
+                /cgroup \
+                ${bindir}/systemd* \
+                ${bindir}/busctl \
+                ${bindir}/coredumpctl \
+                ${bindir}/localectl \
+                ${bindir}/hostnamectl \
+                ${bindir}/resolvectl \
+                ${bindir}/timedatectl \
+                ${bindir}/bootctl \
+                ${bindir}/oomctl \
+                ${bindir}/userdbctl \
+                ${exec_prefix}/lib/credstore \
+                ${exec_prefix}/lib/tmpfiles.d/*.conf \
+                ${exec_prefix}/lib/systemd \
+                ${exec_prefix}/lib/modules-load.d \
+                ${exec_prefix}/lib/sysctl.d \
+                ${exec_prefix}/lib/sysusers.d \
+                ${exec_prefix}/lib/environment.d \
+                ${exec_prefix}/lib/pcrlock.d \
+                ${localstatedir} \
+                ${nonarch_libdir}/modprobe.d/systemd.conf \
+                ${nonarch_libdir}/modprobe.d/README \
+                ${datadir}/dbus-1/system.d/org.freedesktop.timedate1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.locale1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf \
+                ${@bb.utils.contains('PACKAGECONFIG', 'polkit_hostnamed_fallback', '${datadir}/dbus-1/system.d/org.freedesktop.hostname1_no_polkit.conf', '', d)} \
+                ${datadir}/dbus-1/system.d/org.freedesktop.hostname1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.login1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.timesync1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.portable1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.oom1.conf \
+                ${datadir}/dbus-1/system.d/org.freedesktop.home1.conf \
+               "
+
+FILES:${PN}-dev += "${base_libdir}/security/*.la ${datadir}/dbus-1/interfaces/ ${sysconfdir}/rpm/macros.systemd"
+
+RDEPENDS:${PN} += "kmod ${VIRTUAL-RUNTIME_dbus} util-linux-mount util-linux-umount udev (= ${EXTENDPKGV}) systemd-udev-rules util-linux-agetty util-linux-fsck util-linux-swaponoff util-linux-mkswap"
+RDEPENDS:${PN} += "systemd-serialgetty"
+RDEPENDS:${PN} += "volatile-binds"
+
+RRECOMMENDS:${PN} += "${PN}-extra-utils \
+                      udev-hwdb \
+                      e2fsprogs-e2fsck \
+                      kernel-module-autofs4 kernel-module-unix kernel-module-ipv6 kernel-module-sch-fq-codel \
+                      os-release \
+                      systemd-conf \
+                      ${@bb.utils.contains('PACKAGECONFIG', 'logind', 'pam-plugin-umask', '', d)} \
+"
+
+INSANE_SKIP:${PN} += "dev-so libdir"
+INSANE_SKIP:${PN}-dbg += "libdir"
+INSANE_SKIP:${PN}-doc += " libdir"
+INSANE_SKIP:libsystemd-shared += "libdir"
+
+FILES:libsystemd-shared = "${libdir}/systemd/libsystemd-shared*.so"
+
+RPROVIDES:udev = "hotplug"
+
+RDEPENDS:udev-bash-completion += "bash-completion"
+RDEPENDS:udev-hwdb += "udev"
+
+FILES:udev += "${base_sbindir}/udevd \
+               ${nonarch_libdir}/systemd/network/99-default.link \
+               ${nonarch_libdir}/systemd/systemd-udevd \
+               ${nonarch_libdir}/udev/accelerometer \
+               ${nonarch_libdir}/udev/ata_id \
+               ${nonarch_libdir}/udev/cdrom_id \
+               ${nonarch_libdir}/udev/collect \
+               ${nonarch_libdir}/udev/dmi_memory_id \
+               ${nonarch_libdir}/udev/fido_id \
+               ${nonarch_libdir}/udev/findkeyboards \
+               ${nonarch_libdir}/udev/iocost \
+               ${nonarch_libdir}/udev/keyboard-force-release.sh \
+               ${nonarch_libdir}/udev/keymap \
+               ${nonarch_libdir}/udev/mtd_probe \
+               ${nonarch_libdir}/udev/scsi_id \
+               ${nonarch_libdir}/udev/v4l_id \
+               ${nonarch_libdir}/udev/keymaps \
+               ${nonarch_libdir}/udev/rules.d/50-udev-default.rules \
+               ${nonarch_libdir}/udev/rules.d/60-autosuspend.rules \
+               ${nonarch_libdir}/udev/rules.d/60-autosuspend-chromiumos.rules \
+               ${nonarch_libdir}/udev/rules.d/60-block.rules \
+               ${nonarch_libdir}/udev/rules.d/60-cdrom_id.rules \
+               ${nonarch_libdir}/udev/rules.d/60-dmi-id.rules \
+               ${nonarch_libdir}/udev/rules.d/60-drm.rules \
+               ${nonarch_libdir}/udev/rules.d/60-evdev.rules \
+               ${nonarch_libdir}/udev/rules.d/60-fido-id.rules \
+               ${nonarch_libdir}/udev/rules.d/60-infiniband.rules \
+               ${nonarch_libdir}/udev/rules.d/60-input-id.rules \
+               ${nonarch_libdir}/udev/rules.d/60-persistent-alsa.rules \
+               ${nonarch_libdir}/udev/rules.d/60-persistent-input.rules \
+               ${nonarch_libdir}/udev/rules.d/60-persistent-storage.rules \
+               ${nonarch_libdir}/udev/rules.d/60-persistent-storage-mtd.rules \
+               ${nonarch_libdir}/udev/rules.d/60-persistent-storage-tape.rules \
+               ${nonarch_libdir}/udev/rules.d/60-persistent-v4l.rules \
+               ${nonarch_libdir}/udev/rules.d/60-sensor.rules \
+               ${nonarch_libdir}/udev/rules.d/60-serial.rules \
+               ${nonarch_libdir}/udev/rules.d/61-autosuspend-manual.rules \
+               ${nonarch_libdir}/udev/rules.d/64-btrfs.rules \
+               ${nonarch_libdir}/udev/rules.d/70-camera.rules \
+               ${nonarch_libdir}/udev/rules.d/70-joystick.rules \
+               ${nonarch_libdir}/udev/rules.d/70-memory.rules \
+               ${nonarch_libdir}/udev/rules.d/70-mouse.rules \
+               ${nonarch_libdir}/udev/rules.d/70-power-switch.rules \
+               ${nonarch_libdir}/udev/rules.d/70-touchpad.rules \
+               ${nonarch_libdir}/udev/rules.d/75-net-description.rules \
+               ${nonarch_libdir}/udev/rules.d/75-probe_mtd.rules \
+               ${nonarch_libdir}/udev/rules.d/78-sound-card.rules \
+               ${nonarch_libdir}/udev/rules.d/80-drivers.rules \
+               ${nonarch_libdir}/udev/rules.d/80-net-setup-link.rules \
+               ${nonarch_libdir}/udev/rules.d/81-net-dhcp.rules \
+               ${nonarch_libdir}/udev/rules.d/90-vconsole.rules \
+               ${nonarch_libdir}/udev/rules.d/90-iocost.rules \
+               ${nonarch_libdir}/udev/rules.d/README \
+               ${sysconfdir}/udev \
+               ${sysconfdir}/init.d/systemd-udevd \
+               ${systemd_system_unitdir}/*udev* \
+               ${systemd_system_unitdir}/*.wants/*udev* \
+               ${base_bindir}/systemd-hwdb \
+               ${base_bindir}/udevadm \
+               ${base_sbindir}/udevadm \
+               ${systemd_system_unitdir}/systemd-hwdb-update.service \
+              "
+
+FILES:udev-bash-completion = "${datadir}/bash-completion/completions/udevadm"
+FILES:udev-hwdb = "${nonarch_libdir}/udev/hwdb.d \
+                   "
+
+RCONFLICTS:${PN} = "tiny-init ${@bb.utils.contains('PACKAGECONFIG', 'resolved', 'resolvconf', '', d)}"
+
+INITSCRIPT_PACKAGES = "udev"
+INITSCRIPT_NAME:udev = "systemd-udevd"
+INITSCRIPT_PARAMS:udev = "start 03 S ."
+
+python __anonymous() {
+    if not bb.utils.contains('DISTRO_FEATURES', 'sysvinit', True, False, d):
+        d.setVar("INHIBIT_UPDATERCD_BBCLASS", "1")
+
+    if bb.utils.contains('DISTRO_FEATURES', 'systemd-resolved', True, False, d) and not bb.utils.contains('PACKAGECONFIG', 'nss-resolve resolved', True, False, d):
+        bb.error("DISTRO_FEATURES[systemd-resolved] requires PACKAGECONFIG[nss-resolve, resolved]")
+
+    if bb.utils.contains('PACKAGECONFIG', 'repart', True, False, d) and not bb.utils.contains('PACKAGECONFIG', 'openssl', True, False, d):
+        bb.error("PACKAGECONFIG[repart] requires PACKAGECONFIG[openssl]")
+
+    if bb.utils.contains('PACKAGECONFIG', 'homed', True, False, d) and not bb.utils.contains('PACKAGECONFIG', 'userdb openssl cryptsetup', True, False, d):
+        bb.error("PACKAGECONFIG[homed] requires PACKAGECONFIG[userdb], PACKAGECONFIG[openssl] and PACKAGECONFIG[cryptsetup]")
+}
+
+python do_warn_musl() {
+    if d.getVar('TCLIBC') == "musl":
+        bb.warn("Using systemd with musl is not recommended since it is not supported upstream and some patches are known to be problematic.")
+}
+addtask warn_musl before do_configure
+
+ALTERNATIVE:${PN} = "halt reboot shutdown poweroff \
+                     ${@bb.utils.contains('PACKAGECONFIG', 'sysvinit', 'runlevel', '', d)} \
+                     ${@bb.utils.contains('PACKAGECONFIG', 'resolved', 'resolv-conf', '', d)}"
+
+ALTERNATIVE_TARGET[resolv-conf] = "${sysconfdir}/resolv-conf.systemd"
+ALTERNATIVE_LINK_NAME[resolv-conf] = "${sysconfdir}/resolv.conf"
+ALTERNATIVE_PRIORITY[resolv-conf] ?= "50"
+
+ALTERNATIVE_TARGET[halt] = "${base_bindir}/systemctl"
+ALTERNATIVE_LINK_NAME[halt] = "${base_sbindir}/halt"
+ALTERNATIVE_PRIORITY[halt] ?= "300"
+
+ALTERNATIVE_TARGET[reboot] = "${base_bindir}/systemctl"
+ALTERNATIVE_LINK_NAME[reboot] = "${base_sbindir}/reboot"
+ALTERNATIVE_PRIORITY[reboot] ?= "300"
+
+ALTERNATIVE_TARGET[shutdown] = "${base_bindir}/systemctl"
+ALTERNATIVE_LINK_NAME[shutdown] = "${base_sbindir}/shutdown"
+ALTERNATIVE_PRIORITY[shutdown] ?= "300"
+
+ALTERNATIVE_TARGET[poweroff] = "${base_bindir}/systemctl"
+ALTERNATIVE_LINK_NAME[poweroff] = "${base_sbindir}/poweroff"
+ALTERNATIVE_PRIORITY[poweroff] ?= "300"
+
+ALTERNATIVE_TARGET[runlevel] = "${base_bindir}/systemctl"
+ALTERNATIVE_LINK_NAME[runlevel] = "${base_sbindir}/runlevel"
+ALTERNATIVE_PRIORITY[runlevel] ?= "300"
+
+pkg_postinst:${PN}:append () {
+	if ${@bb.utils.contains('PACKAGECONFIG', 'set-time-epoch', 'true', 'false', d)}; then
+		touch $D${nonarch_libdir}/clock-epoch
+	fi
+}
+
+pkg_postinst:${PN}:libc-glibc () {
+	if ${@bb.utils.contains('PACKAGECONFIG', 'myhostname', 'true', 'false', d)}; then
+		sed -e '/^hosts:/s/\s*\<myhostname\>//' \
+			-e 's/\(^hosts:.*\)\(\<files\>\)\(.*\)\(\<dns\>\)\(.*\)/\1\2 myhostname \3\4\5/' \
+			-i $D${sysconfdir}/nsswitch.conf
+	fi
+	if ${@bb.utils.contains('PACKAGECONFIG', 'nss', 'true', 'false', d)}; then
+		sed -e 's#\(^passwd:.*\)#\1 systemd#' \
+			-e 's#\(^group:.*\)#\1 systemd#' \
+			-e 's#\(^shadow:.*\)#\1 systemd#' \
+			-i $D${sysconfdir}/nsswitch.conf
+	fi
+}
+
+pkg_prerm:${PN}:libc-glibc () {
+	if ${@bb.utils.contains('PACKAGECONFIG', 'myhostname', 'true', 'false', d)}; then
+		sed -e '/^hosts:/s/\s*\<myhostname\>//' \
+			-e '/^hosts:/s/\s*myhostname//' \
+			-i $D${sysconfdir}/nsswitch.conf
+	fi
+	if ${@bb.utils.contains('PACKAGECONFIG', 'nss', 'true', 'false', d)}; then
+		sed -e '/^passwd:/s#\s*systemd##' \
+			-e '/^group:/s#\s*systemd##' \
+			-e '/^shadow:/s#\s*systemd##' \
+			-i $D${sysconfdir}/nsswitch.conf
+	fi
+}
+
+PACKAGE_WRITE_DEPS += "qemuwrapper-cross"
+
+pkg_postinst:udev-hwdb () {
+	if test -n "$D"; then
+		$INTERCEPT_DIR/postinst_intercept update_udev_hwdb ${PKG} mlprefix=${MLPREFIX} binprefix=${MLPREFIX} \
+			rootlibexecdir="${nonarch_libdir}" PREFERRED_PROVIDER_udev="${PREFERRED_PROVIDER_udev}" base_bindir="${base_bindir}"
+	else
+		systemd-hwdb update
+	fi
+}
+
+pkg_prerm:udev-hwdb () {
+	rm -f $D${sysconfdir}/udev/hwdb.bin
+}
+
+require dlopen-deps-257.inc


### PR DESCRIPTION
Adds meta-luneos-holdbacks-5.3 (systemd 257.8 from oe-core whinlatter, verbatim, plus its musl/OE compatibility patch series) as a machines-that-need-cgroup-v1 escape hatch from wrynose's newer oe-core systemd.

This in order to stay with cgroup v1 for now