### PR TITLE
umediaserver: order it after sam, whose subscription it depends on

### DIFF
--- a/meta-luneos/recipes-webos-ose/umediaserver/umediaserver.inc
+++ b/meta-luneos/recipes-webos-ose/umediaserver/umediaserver.inc
@@ -15,7 +15,7 @@ DEPENDS += "gstreamer1.0 gstreamer1.0-plugins-base"
 DEPENDS += "${@'' if '${WEBOS_DISTRO_PRERELEASE}' == '' else 'pmtrace'}"
 RDEPENDS:${PN} = "umediaserver-configs"
 
-INC_PR = "r29"
+INC_PR = "r30"
 
 inherit webos_component
 inherit webos_enhanced_submissions

--- a/meta-luneos/recipes-webos-ose/umediaserver/umediaserver/umediaserver.service
+++ b/meta-luneos/recipes-webos-ose/umediaserver/umediaserver/umediaserver.service
@@ -17,7 +17,8 @@
 [Unit]
 Description=meta-webos - "%n"
 Requires=ls-hubd.service
-After=ls-hubd.service
+Wants=sam.service
+After=ls-hubd.service sam.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
umediaserver's AppObserver subscribes to
com.webos.applicationManager/getAppLifeStatus at startup. When it comes up before sam has registered that name (as happens on a full stack restart, where sam additionally waits for surface-manager), ls-hubd's legacy service-name redirection resolves the call to LunaAppManager's com.palm.applicationManager instead, which has no such method. The LS2 client caches the name resolution for the life of the connection and AppObserver retries every 100ms without ever re-resolving, flooding the journal with LS_NO_METH/FG_RESUBSCRIBE_ERR at 10Hz (~17k lines per session) until umediaserver is restarted by hand.

Order umediaserver after sam so the name is registered before the subscription is made, the same way sam itself orders after surface-manager.