### PR TITLE
luna-surfacemanager-conf: order the compositor after android-system

### DIFF
--- a/meta-luneos/recipes-webos-ose/luna-surfacemanager/luna-surfacemanager-conf.bb
+++ b/meta-luneos/recipes-webos-ose/luna-surfacemanager/luna-surfacemanager-conf.bb
@@ -10,6 +10,7 @@ SRC_URI = " \
     file://surface-manager.env \
 "
 SRC_URI:append:qemuall = "file://99-virtualbox-mouse.rules"
+SRC_URI:append:halium = " file://surface-manager-daemon-after-android.conf"
 
 do_install() {
     install -d ${D}${sysconfdir}/surface-manager.d
@@ -21,8 +22,15 @@ do_install:append:qemuall() {
     install -v -m 0644 ${UNPACKDIR}/99-virtualbox-mouse.rules ${D}${sysconfdir}/udev/rules.d/99-virtualbox-mouse.rules
 }
 
+do_install:append:halium() {
+    install -d ${D}${systemd_unitdir}/system/surface-manager-daemon.service.d
+    install -v -m 0644 ${UNPACKDIR}/surface-manager-daemon-after-android.conf \
+        ${D}${systemd_unitdir}/system/surface-manager-daemon.service.d/
+}
+
 FILES:${PN} += " \
     ${sysconfdir}/surface-manager.d \
 "
 
 FILES:${PN}:append:qemuall = "${sysconfdir}/udev/rules.d"
+FILES:${PN}:append:halium = " ${systemd_unitdir}/system/surface-manager-daemon.service.d"

--- a/meta-luneos/recipes-webos-ose/luna-surfacemanager/luna-surfacemanager-conf/halium/surface-manager-daemon-after-android.conf
+++ b/meta-luneos/recipes-webos-ose/luna-surfacemanager/luna-surfacemanager-conf/halium/surface-manager-daemon-after-android.conf
@@ -1,0 +1,14 @@
+# Do not start the compositor before the Android container is up.
+#
+# On Halium the graphics stack lives on the Android side: libhybris reaches the
+# composer HAL over hwbinder, and the vendor GPU driver comes out of /vendor,
+# which mount-android.sh mounts. Starting the compositor first means it either
+# fails outright or silently takes libhybris' in-process fallback, dlopen'ing
+# the hwcomposer module itself instead of talking to the composer service.
+#
+# This lives here rather than as a Before= in android-system.service because
+# that unit is in meta-android, the generic Halium layer, and has no business
+# naming a LuneOS unit from meta-luneos. Installed only under the halium
+# MACHINEOVERRIDE, so non-Halium machines are untouched.
+[Unit]
+After=android-system.service


### PR DESCRIPTION
The counterpart to the meta-smartphone change for review feedback on shr-distribution/meta-smartphone#188. android-system.service used to carry Before=surface-manager-daemon.service, which made the generic Halium layer name a LuneOS unit; the ordering belongs on this side instead.

Ship a halium-only drop-in with After=android-system.service. On Halium the whole graphics stack is on the Android side - libhybris reaches the composer HAL over hwbinder, and the vendor GPU driver comes out of /vendor, which mount-android.sh mounts - so starting the compositor first either fails or silently takes libhybris' in-process fallback.

Scoped to the halium MACHINEOVERRIDE, so pinetab2, qemux86-64 and the rest are untouched. Verified on sargo: systemctl show surface-manager-daemon -p After lists android-system.service.