### PR TITLE
sensorfw: fix the doubled quote in tissot's transformation matrix

### DIFF
--- a/meta-luneos/recipes-support/sensorfw/sensorfw/sensord-tissot.conf
+++ b/meta-luneos/recipes-support/sensorfw/sensorfw/sensord-tissot.conf
@@ -9,7 +9,7 @@ gyroscopeadaptor = iiosensorsadaptor
 input_match=bmi120
 intervals = "200=>2000"
 default_interval=500
-transformation_matrix = ""0,1,0,1,0,0,0,0,1"
+transformation_matrix = "0,1,0,1,0,0,0,0,1"
 
 [als]
 input_match=ltr579


### PR DESCRIPTION
  transformation_matrix = ""0,1,0,1,0,0,0,0,1"

Every other sensord-*.conf uses a single quote. Whether sensorfw rejects the malformed value or misparses it, tissot's accelerometer orientation cannot be what was intended.