### PR TITLE
qml-webos-framework: register with appId, not just a bare name

### DIFF
--- a/meta-luneos/recipes-webos-ose/qml-webos-framework/qml-webos-framework.bb
+++ b/meta-luneos/recipes-webos-ose/qml-webos-framework/qml-webos-framework.bb
@@ -19,7 +19,7 @@ RPROVIDES:${PN}-examples = " \
 "
 
 WEBOS_VERSION = "1.0.0-171_f8586fc0655de188c38d12b911d68a589d28496f"
-PR = "r38"
+PR = "r39"
 
 inherit webos_qmake6
 inherit pkgconfig
@@ -38,6 +38,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0007-WebOSQuickWindow-make-setWindowPropery-Q_INVOKABLE.patch \
     file://0008-runner-debug-use-WEBOS_INSTALL_BINS-as-other-binarie.patch \
     file://0009-WebOSQuickWindow-use-APP_ID-env-variable-for-appId.patch \
+    file://0010-runner-register-with-appId-so-ls-hubd-can-resolve-i.patch \
 "
 
 OE_QMAKE_PATH_HEADERS = "${OE_QMAKE_PATH_QT_HEADERS}"

--- a/meta-luneos/recipes-webos-ose/qml-webos-framework/qml-webos-framework/0010-runner-register-with-appId-so-ls-hubd-can-resolve-i.patch
+++ b/meta-luneos/recipes-webos-ose/qml-webos-framework/qml-webos-framework/0010-runner-register-with-appId-so-ls-hubd-can-resolve-i.patch
@@ -1,0 +1,39 @@
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Thu, 27 Aug 2026 00:00:00 +0200
+Subject: [PATCH] runner: register with appId so ls-hubd can resolve its role
+
+qml-runner hosts many different per-appId QML apps (each Settings
+category page, among others) behind one shared executable. Without
+passing appId, ls-hubd can't resolve the connection's role by name
+and falls back to resolving it by executable path instead - which
+for a shared launcher like this means every app it hosts gets the
+same narrow, generic com.webos.app.qmlrunner role instead of its
+own, regardless of what that app's own role file actually grants.
+In practice this silently drops any luna.call() to a method group
+that isn't in that generic role's fallback allowlist, while
+luna.subscribe() and other allowlisted methods keep working -
+making it look like an app-specific permissions bug when it's
+actually this shared launcher never announcing which app it's
+running.
+
+LSRegisterApplicationService() exists for exactly this - register
+under a service name while also telling ls-hubd which appId's role
+should apply to the connection.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+Upstream-Status: Pending
+---
+ tools/runner/lunaservicewrapper.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/tools/runner/lunaservicewrapper.cpp
++++ b/tools/runner/lunaservicewrapper.cpp
+@@ -92,7 +92,7 @@
+         ls2ServiceName = ls2Name;
+ 
+     qInfo() << "LS2_NAME:" << ls2ServiceName << ", ls2ServiceName:" << ls2ServiceName;
+-    if (!LSRegister(ls2ServiceName.toLatin1(), &lunaHandle, &lsError))
++    if (!LSRegisterApplicationService(ls2ServiceName.toLatin1(), m_appId.toLatin1(), &lunaHandle, &lsError))
+         qWarning() << "LSRegister error:" << lsError.error_code << lsError.message;
+ }
+ 


### PR DESCRIPTION
Fixes a real bug found while debugging why a Settings sub-page's luna.call() to its own service was silently denied while an identical luna.subscribe() worked fine, and an unrelated luna-send call using the same-looking name succeeded - see the patch itself for the root cause (ls-hubd role resolution falling back to exe-path-based lookup, shared by every app qml-runner hosts).

Verified via a temporary debug build: with the fix, the affected Settings page's own connection now reaches its service's method groups correctly, confirmed against real hardware.