### PR TITLE
Add initial fingerprint support to LuneOS

### DIFF
--- a/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
+++ b/meta-luneos/recipes-core/packagegroups/packagegroup-luneos-extended.bb
@@ -136,6 +136,17 @@ LIBHYBRIS_RDEPENDS = " \
     ofono-binder-plugin \
 "
 
+# Fingerprint stack: droidian-fpd talks to the Android biometrics HAL through
+# libhybris, webos-fingerprint-adapter bridges its D-Bus API onto the
+# luna-service2 bus for the shell (lockscreen unlock) and the Settings app
+# (enrollment). Only added for machines that actually have a fingerprint
+# sensor. Note: the device's Halium system image must also ship
+# libbiometry_fp_api.so (built from droidian-fpd's android/hybris/ directory).
+FINGERPRINT_RDEPENDS = " \
+    droidian-fpd \
+    webos-fingerprint-adapter \
+"
+
 # (Optional?) work for Qt6:
 #     qtscenegraph-adaptation
 
@@ -158,6 +169,16 @@ RDEPENDS:${PN}:append:tenderloin3g = " alsa-utils-systemd rmtfs qrtr rpmsgexport
 RDEPENDS:${PN}:append:mido = " alsa-utils-systemd mesa-driver-swrast rmtfs qrtr rpmsgexport"
 RDEPENDS:${PN}:append:tissot = " alsa-utils-systemd mesa-driver-swrast rmtfs qrtr rpmsgexport"
 RDEPENDS:${PN}:append:rosy = " alsa-utils-systemd mesa-driver-swrast rmtfs qrtr rpmsgexport"
+
+# Fingerprint-sensor devices only. These machine names come from the LuneOS
+# Halium layer; on a tree without them the overrides are simply inert.
+RDEPENDS:${PN}:append:sargo = " ${FINGERPRINT_RDEPENDS}"
+RDEPENDS:${PN}:append:sagit = " ${FINGERPRINT_RDEPENDS}"
+RDEPENDS:${PN}:append:mido-halium = " ${FINGERPRINT_RDEPENDS}"
+RDEPENDS:${PN}:append:tissot-halium = " ${FINGERPRINT_RDEPENDS}"
+# The GSI machine can land on any device; the stack is harmless without a
+# sensor (the adapter just reports unavailable).
+RDEPENDS:${PN}:append:halium-arm64 = " ${FINGERPRINT_RDEPENDS}"
 
 RDEPENDS:${PN}:append:mido-halium = " waydroid"
 RDEPENDS:${PN}:append:pinephone = " waydroid"

--- a/meta-luneos/recipes-luneos/apps/org.webosports.app.settings-qml.bb
+++ b/meta-luneos/recipes-luneos/apps/org.webosports.app.settings-qml.bb
@@ -14,9 +14,9 @@ inherit webos_app
 inherit pkgconfig
 
 PV = "0.4.0-1+git"
-SRCREV = "9a5b5527ec4c6a153c4c07c099e07cdb3dcb01c8"
+SRCREV = "9b481a456292165f167eed31b43fbc011502648b"
 
-WEBOS_GIT_PARAM_BRANCH = "qml-based"
+WEBOS_GIT_PARAM_BRANCH = "fingerprint"
 WEBOS_REPO_NAME = "org.webosports.app.settings"
 
 SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
@@ -26,8 +26,15 @@ SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
 REMOVE_ANDROID_PROPERTY_SERVICE_CMD:halium = ""
 REMOVE_ANDROID_PROPERTY_SERVICE_CMD = "sed -i 's/\"android-property-service.operation\", //g' ${D}/${webos_applicationsdir}/org.webosports.app.settings.deviceinfo/appinfo.json"
 
+# The fingerprint panel only makes sense with the halium fingerprint stack
+# (droidian-fpd + webos-fingerprint-adapter); drop the whole sub-app elsewhere
+# so its requiredPermissions don't trip the LS2 ACG validation.
+REMOVE_FINGERPRINT_APP_CMD:halium = ""
+REMOVE_FINGERPRINT_APP_CMD = "rm -rf ${D}/${webos_applicationsdir}/org.webosports.app.settings.fingerprint"
+
 do_install:append() {
     ${REMOVE_ANDROID_PROPERTY_SERVICE_CMD}
+    ${REMOVE_FINGERPRINT_APP_CMD}
 }
 
 FILES:${PN} += "${webos_applicationsdir}/org.webosports.app.settings-common \
@@ -41,6 +48,7 @@ FILES:${PN} += "${webos_applicationsdir}/org.webosports.app.settings-common \
                 ${webos_applicationsdir}/org.webosports.app.settings.deviceinfo \
                 ${webos_applicationsdir}/org.webosports.app.settings.devmodeswitcher \
                 ${webos_applicationsdir}/org.webosports.app.settings.exhibitionpreferences \
+                ${webos_applicationsdir}/org.webosports.app.settings.fingerprint \
                 ${webos_applicationsdir}/org.webosports.app.settings.help \
                 ${webos_applicationsdir}/org.webosports.app.settings.languagepicker \
                 ${webos_applicationsdir}/org.webosports.app.settings.location \

--- a/meta-luneos/recipes-luneos/luna-next-cardshell/luna-next-cardshell.bb
+++ b/meta-luneos/recipes-luneos/luna-next-cardshell/luna-next-cardshell.bb
@@ -20,11 +20,12 @@ PV = "0.6-0+git"
 # org.webosports.service.audio, the audio-service LuneOS no longer ships.
 # audiod claims that bus name, so the calls were answered with "Couldn't find
 # method: volumeUp" and the keys, the on-screen indicator and the system-menu
-# slider all did nothing. Confirmed on sargo: the legacy name keeps its own
-# volume (46) which is wired to no sink, while master/* moves pcm_output.
-# Drop the branch once it lands on master.
-WEBOS_GIT_PARAM_BRANCH = "herrie/audiod"
-SRCREV = "2b65632ac0872f096395c094997d6efa4de0207f"
+# Points at the fingerprint PR branch (off master) for the lockscreen
+# fingerprint unlock. NOTE: this branch is off master and does NOT carry the
+# herrie/audiod volume fix; reconcile the two (or repoint to master) once the
+# luna-next-cardshell fingerprint PR merges.
+WEBOS_GIT_PARAM_BRANCH = "fingerprint"
+SRCREV = "f02e9e0fb8c0fbbab631d628f522d4346d0c0943"
 
 inherit webos_ports_repo
 inherit webos_cmake

--- a/meta-luneos/recipes-luneos/webos-fingerprint-adapter/webos-fingerprint-adapter.bb
+++ b/meta-luneos/recipes-luneos/webos-fingerprint-adapter/webos-fingerprint-adapter.bb
@@ -1,0 +1,33 @@
+SUMMARY = "LuneOS fingerprint service, bridges droidian-fpd onto the luna-service2 bus"
+SECTION = "webos/services"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+# glib-2.0-native provides gdbus-codegen, which generates the fpd D-Bus glue
+DEPENDS = "luna-service2 libpbnjson glib-2.0 glib-2.0-native"
+
+# The service is useful without droidian-fpd running (it reports the sensor as
+# unavailable), but there is no point shipping it on its own.
+RRECOMMENDS:${PN} += "droidian-fpd"
+
+PV = "0.1.0-1+git"
+SRCREV = "878d42a485c74aab46fe49121b9464b530809fbf"
+
+inherit webos_ports_repo
+inherit webos_filesystem_paths
+inherit webos_cmake
+inherit pkgconfig
+inherit webos_system_bus
+inherit webos_systemd
+
+WEBOS_GIT_PARAM_BRANCH = "master"
+WEBOS_REPO_NAME = "webos-fingerprint-adapter"
+
+LUNEOS_SYSTEMD_SERVICE = "${PN}.service"
+
+SRC_URI = "${WEBOS_PORTS_GIT_REPO_COMPLETE}"
+
+# gdbus-codegen writes an absolute #include for the header it generates, same
+# QA hit as webos-nfc-adapter/webos-telephonyd.
+ERROR_QA:remove = "buildpaths"
+WARN_QA:append = " buildpaths"

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd.bb
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd.bb
@@ -1,0 +1,58 @@
+SUMMARY = "Fingerprint daemon bridging the Android biometrics HAL to D-Bus"
+DESCRIPTION = "Fingerprint enrollment/identification daemon for Halium devices. \
+Talks to the vendor android.hardware.biometrics.fingerprint@2.1 HIDL HAL \
+through libhybris (android_dlopen of libbiometry_fp_api.so, which has to be \
+built inside the device's Halium tree) and exposes the SailfishOS-style \
+fingerprint D-Bus API as org.droidian.fingerprint on the system bus. \
+Fork lineage: UBports biometryd -> sailfish-fpd-community -> droidian-fpd."
+HOMEPAGE = "https://github.com/FuriLabs/droidian-fpd"
+SECTION = "webos/support"
+# Daemon is GPL-3.0; the biometryd-derived bridge/HAL glue it embeds
+# (src/bridge/, src/hardware/) is LGPL-3.0 Canonical/UBports code.
+LICENSE = "GPL-3.0-only & LGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+DEPENDS = "qtbase libhybris"
+
+# Needs libhybris and the Android container providing the fingerprint HAL.
+COMPATIBLE_MACHINE = "^halium$"
+# libhybris is MACHINE_ARCH
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit pkgconfig
+inherit qt6-cmake
+inherit systemd
+
+SRC_URI = " \
+    git://github.com/FuriLabs/droidian-fpd.git;protocol=https;branch=trixie \
+    file://0001-Use-uid-0-for-the-single-LuneOS-user.patch \
+    file://0002-Treat-fingerId-0-as-a-failed-match.patch \
+    file://0003-Add-a-Rename-method.patch \
+    file://droidian-fpd.service \
+    file://fpd-hal-setup.sh \
+    file://90-uinput-fpc-ignore.rules \
+    file://50-no-reboot-key.conf \
+"
+
+PV = "2.0+git"
+SRCREV = "5296a7d9537b1cdf616ca2f601c54148440acf6e"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "droidian-fpd.service"
+
+# The daemon shells out to /usr/bin/getprop (util/property_store.cpp) to read
+# ro.build.version.sdk for the template-store path selection; android-tools is
+# already part of the halium stack via packagegroup-luneos-extended.
+RDEPENDS:${PN} += "android-tools"
+
+# Upstream's CMakeLists.txt has no install rules (Debian packaging installs by
+# hand), and its unit is written for Droidian's lxc@android + binder-wait
+# setup, so we ship our own unit from ${UNPACKDIR}.
+do_install() {
+    install -D -m 0755 ${B}/droidian-fpd ${D}${sbindir}/droidian-fpd
+    install -D -m 0644 ${S}/org.droidian.fingerprint.conf ${D}${sysconfdir}/dbus-1/system.d/org.droidian.fingerprint.conf
+    install -D -m 0644 ${UNPACKDIR}/droidian-fpd.service ${D}${systemd_system_unitdir}/droidian-fpd.service
+    install -D -m 0755 ${UNPACKDIR}/fpd-hal-setup.sh ${D}${bindir}/fpd-hal-setup.sh
+    install -D -m 0644 ${UNPACKDIR}/90-uinput-fpc-ignore.rules ${D}${sysconfdir}/udev/rules.d/90-uinput-fpc-ignore.rules
+    install -D -m 0644 ${UNPACKDIR}/50-no-reboot-key.conf ${D}${sysconfdir}/systemd/logind.conf.d/50-no-reboot-key.conf
+}

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/0001-Use-uid-0-for-the-single-LuneOS-user.patch
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/0001-Use-uid-0-for-the-single-LuneOS-user.patch
@@ -1,0 +1,52 @@
+From 4f61397434a6eb788679d7a080aa2b474ae287ed Mon Sep 17 00:00:00 2001
+From: Herrie <herrie@webos-ports.org>
+Date: Tue, 25 Aug 2026 18:31:22 +0200
+Subject: [PATCH] Use uid 0 for the single LuneOS user
+Upstream-Status: Inappropriate [LuneOS-specific configuration]
+
+LuneOS is single-user and runs as root. uid 0 selects
+/data/vendor_de/0/fpdata (API > 27) as the vendor HAL template store,
+the same convention Ubuntu Touch biometryd uses, and keeps the local
+finger-name map under /var/lib/droidian-fpd/0/.
+---
+ src/fpdcommunity.cpp | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/fpdcommunity.cpp b/src/fpdcommunity.cpp
+index 2bec2b9..535925c 100644
+--- a/src/fpdcommunity.cpp
++++ b/src/fpdcommunity.cpp
+@@ -33,8 +33,10 @@ FPDCommunity::FPDCommunity()
+     m_cancelTimer.setInterval(30000);
+     connect(&m_cancelTimer, &QTimer::timeout, this, &FPDCommunity::slot_cancelIdentify);
+ 
+-    // set current user - hybris for now
+-    setUser(32011);
++    // set current user - LuneOS is single-user and runs as root; matches the
++    // /data/vendor_de/0/fpdata (API>27) template store convention that
++    // Ubuntu Touch biometryd also uses.
++    setUser(0);
+     registerDBus();
+ }
+ 
+@@ -230,7 +232,7 @@ int FPDCommunity::Enroll(const QString &finger, const QDBusMessage &message)
+     if (m_state == FPSTATE_IDLE) {
+         setState(FPSTATE_ENROLLING);
+         m_addingFinger = finger;
+-        m_androidFP.enroll(32011); // hybris userID
++        m_androidFP.enroll(0);
+         emit EnrollProgressChanged(0);
+         return FPREPLY_STARTED;
+     }
+@@ -303,7 +305,7 @@ int FPDCommunity::Verify(const QDBusMessage &message)
+ 
+     if (m_state == FPSTATE_IDLE) {
+         setState(FPSTATE_VERIFYING);
+-        m_androidFP.enroll(32011); // hybris userID
++        m_androidFP.enroll(0);
+         emit EnrollProgressChanged(0);
+         return FPREPLY_STARTED;
+     }
+-- 
+2.53.0
+

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/0002-Treat-fingerId-0-as-a-failed-match.patch
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/0002-Treat-fingerId-0-as-a-failed-match.patch
@@ -1,0 +1,39 @@
+From d56717e4d38f51ad1286cf96d1fba61c54dd5d55 Mon Sep 17 00:00:00 2001
+From: Herrie <herrie@webos-ports.org>
+Date: Wed, 26 Aug 2026 05:23:21 +0200
+Subject: [PATCH] Treat fingerId 0 as a failed match, not an identification
+
+fingerprint@2.1 reports a failed authenticate as onAuthenticated with
+fingerId 0. slot_authenticated treated any id it couldn't find in the
+finger map - including 0 - as a successful identification of an
+"Unknown" finger, so a wrong finger emitted Identified() and whatever
+listens for it (device unlock) accepted it. Emit
+ErrorInfo(FINGER_NOT_RECOGNIZED) + Failed() instead.
+Upstream-Status: Pending [should go to FuriLabs/droidian-fpd and
+sailfishos-open/sailfish-fpd-community]
+---
+ src/fpdcommunity.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/fpdcommunity.cpp b/src/fpdcommunity.cpp
+index 535925c..98a6f6f 100644
+--- a/src/fpdcommunity.cpp
++++ b/src/fpdcommunity.cpp
+@@ -453,7 +453,13 @@ void FPDCommunity::slot_authenticated(uint32_t finger)
+ {
+     qDebug() << Q_FUNC_INFO << finger;
+     m_cancelTimer.stop();
+-    if (m_fingerMap.contains(finger)){
++    if (finger == 0) {
++        // fingerprint@2.1 reports a failed match as fingerId 0: that is a
++        // rejection, not an identification of an unknown finger. Treating it
++        // as Identified() would let any finger pass.
++        emit ErrorInfo(QStringLiteral("FINGER_NOT_RECOGNIZED"));
++        emit Failed();
++    } else if (m_fingerMap.contains(finger)){
+         emit Identified(m_fingerMap[finger]);
+     } else {
+         qWarning() << "Authenticated finger was not found in the map.  Assuming name";
+-- 
+2.53.0
+

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/0003-Add-a-Rename-method.patch
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/0003-Add-a-Rename-method.patch
@@ -1,0 +1,75 @@
+From 287ca517c348cec426d72a9b7ae725b6a542e3e7 Mon Sep 17 00:00:00 2001
+From: Herrie <herrie@webos-ports.org>
+Date: Wed, 26 Aug 2026 05:47:19 +0200
+Subject: [PATCH] Add a Rename method
+
+Renaming a fingerprint only changes the local name<->template-id map,
+which the daemon already owns and persists; no HAL call is involved.
+Rejects empty names and collisions with an existing name, and emits
+ListChanged so subscribers refresh.
+Upstream-Status: Pending [should go to FuriLabs/droidian-fpd and
+sailfishos-open/sailfish-fpd-community]
+---
+ src/fpdcommunity.cpp | 33 +++++++++++++++++++++++++++++++++
+ src/fpdcommunity.h   |  1 +
+ 2 files changed, 34 insertions(+)
+
+diff --git a/src/fpdcommunity.cpp b/src/fpdcommunity.cpp
+index 98a6f6f..1436992 100644
+--- a/src/fpdcommunity.cpp
++++ b/src/fpdcommunity.cpp
+@@ -339,6 +339,39 @@ int FPDCommunity::Remove(const QString &finger, const QDBusMessage &message)
+     return FPREPLY_STARTED;
+ }
+ 
++int FPDCommunity::Rename(const QString &finger, const QString &newName, const QDBusMessage &message)
++{
++    const QString caller = message.service();
++    qDebug() << Q_FUNC_INFO << finger << "->" << newName << caller;
++
++    if (newName.isEmpty()) {
++        return FPREPLY_KEY_IS_INVALID;
++    }
++
++    // New name must not collide with an existing one (a no-op rename to the
++    // same name is allowed).
++    if (newName != finger && m_fingerMap.values().contains(newName)) {
++        return FPREPLY_KEY_ALREADY_EXISTS;
++    }
++
++    uint32_t key = 0;
++    for (auto i = m_fingerMap.constBegin(); i != m_fingerMap.constEnd(); ++i) {
++        if (i.value() == finger) {
++            key = i.key();
++            break;
++        }
++    }
++
++    if (!key) {
++        return FPREPLY_KEY_DOES_NOT_EXIST;
++    }
++
++    m_fingerMap[key] = newName;
++    saveFingers();
++    emit ListChanged();
++    return FPREPLY_STARTED;
++}
++
+ void FPDCommunity::abort()
+ {
+     m_androidFP.cancel();
+diff --git a/src/fpdcommunity.h b/src/fpdcommunity.h
+index dd188ed..5c7f7ea 100644
+--- a/src/fpdcommunity.h
++++ b/src/fpdcommunity.h
+@@ -106,6 +106,7 @@ public:
+     Q_INVOKABLE int Abort(const QDBusMessage &message);
+     Q_INVOKABLE int Verify(const QDBusMessage &message);
+     Q_INVOKABLE int Remove(const QString &finger, const QDBusMessage &message);
++    Q_INVOKABLE int Rename(const QString &finger, const QString &newName, const QDBusMessage &message);
+ 
+     Q_SIGNAL void Added(const QString &finger);
+     Q_SIGNAL void Removed(const QString &finger);
+-- 
+2.53.0
+

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/50-no-reboot-key.conf
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/50-no-reboot-key.conf
@@ -1,0 +1,6 @@
+[Login]
+# The FPC fingerprint uinput device is tagged power-switch and can emit the
+# key logind maps to HandleRebootKey; a phone has no legitimate reboot key,
+# so ignore it entirely rather than reboot on a sensor touch.
+HandleRebootKey=ignore
+HandleRebootKeyLongPress=ignore

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/90-uinput-fpc-ignore.rules
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/90-uinput-fpc-ignore.rules
@@ -1,0 +1,9 @@
+# The FPC fingerprint HAL creates a uinput device (uinput-fpc) that injects
+# Android-style navigation key events while the sensor is active. The LuneOS
+# compositor auto-discovers it as a keyboard (surface-manager.env passes
+# "-plugin evdevkeyboard" with no device list) and the event flood can stall
+# input handling on the compositor main thread - hide it from input discovery.
+# It is also tagged "power-switch" by 70-power-switch.rules, which makes
+# systemd-logind watch it: a sensor touch emitting the mapped key then
+# reboots the device (HandleRebootKey=reboot). Strip that tag too.
+SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="uinput-fpc", ENV{ID_INPUT}="", ENV{ID_INPUT_KEY}="", ENV{ID_INPUT_KEYBOARD}="", TAG-="power-switch"

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/droidian-fpd.service
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/droidian-fpd.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Droidian fingerprint daemon
+# The vendor fingerprint HAL (fps_hal) runs inside the Android container, so
+# only start once android-system is up. Upstream additionally gates on
+# binder-wait from Droidian's libgbinder fork; mer-hybris libgbinder does not
+# ship that tool, so we rely on the HAL wrapper's own getService() retry loop
+# plus Restart=always to cover the window until hwservicemanager has
+# registered android.hardware.biometrics.fingerprint@2.1.
+After=android-system.service dbus.service
+Requires=dbus.service
+
+[Service]
+Type=dbus
+BusName=org.droidian.fingerprint
+# Bring the vendor fingerprint HAL up before the daemon: run the keymaster HMAC
+# shim (fake_crypt) needed by keymaster-4 devices, start the (usually
+# late_start) fps_hal service, and wait for it to be running. The helper is
+# bounded and always exits 0, so it can never block or fail the daemon start;
+# the "-" prefix is belt-and-braces. Without this the HAL never comes up on a
+# clean boot and the daemon below hangs until its start timeout.
+ExecStartPre=-/usr/bin/fpd-hal-setup.sh
+ExecStart=/usr/sbin/droidian-fpd
+# If the HAL is slow the daemon can sit in its getService() retry; give the
+# start more room than the default 90s so a transient delay triggers a clean
+# Restart rather than a hard start-timeout kill.
+TimeoutStartSec=150
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/fpd-hal-setup.sh
+++ b/meta-luneos/recipes-support/droidian-fpd/droidian-fpd/fpd-hal-setup.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Bring up the vendor fingerprint HAL for droidian-fpd.
+#
+# Two device-side prerequisites have to be met before the daemon can talk to
+# the sensor, and neither happens on its own inside the Halium container:
+#
+#  1. Keymaster-4 devices (e.g. sargo) need the gatekeeper/keymaster HMAC key
+#     agreement that Android's keystored normally performs at boot. Without it
+#     the fingerprint TA refuses to mint auth tokens and fps_hal dies with
+#     "KEYMASTER_GET_AUTH_TOKEN_KEY returned status=-24 / fpc_hal_open failed".
+#     fake_crypt performs that agreement; it is built into the Android image
+#     (PRODUCT_PACKAGES) and run inside the container.
+#
+#  2. The vendor fingerprint HAL is usually an init "class late_start" service,
+#     which the stripped-down container init never triggers, so it must be
+#     asked to start explicitly.
+#
+# Everything here is best-effort and bounded. On a device that needs no
+# fake_crypt, or where any step times out, we still exit 0: this runs as the
+# daemon's ExecStartPre and must never block or fail the daemon start. If the
+# HAL still is not up, droidian-fpd's own getService() retry and Restart=always
+# remain the backstop.
+
+log() { echo "fpd-hal-setup: $*"; }
+
+# Locate fake_crypt inside the container: the GSI ships it in /system/bin; a
+# hand-placed copy under /data/local is the fallback used before a rebuilt
+# image is flashed.
+FAKE_CRYPT=
+for p in /system/bin/fake_crypt /data/local/fake_crypt; do
+    if lxc-attach -n android -- test -x "$p" 2>/dev/null; then
+        FAKE_CRYPT=$p
+        break
+    fi
+done
+
+# Wait (bounded, ~10s) for a keymaster HAL so the HMAC agreement can succeed.
+i=0
+while [ $i -lt 50 ]; do
+    if getprop | grep -E '^\[init\.svc\.(vendor\.)?keymaster' | grep -q '\[running\]'; then
+        break
+    fi
+    i=$((i + 1))
+    sleep 0.2
+done
+
+if [ -n "$FAKE_CRYPT" ]; then
+    # keymaster can need a moment after it reports running before it will
+    # answer the agreement, so retry until it reports success (bounded ~30s).
+    i=0
+    while [ $i -lt 30 ]; do
+        out=$(lxc-attach -n android -- "$FAKE_CRYPT" 2>&1)
+        log "$out"
+        if echo "$out" | grep -q "HMAC sharing agreement complete"; then
+            break
+        fi
+        i=$((i + 1))
+        sleep 1
+    done
+else
+    log "fake_crypt not found in container; assuming device needs no keymaster shim"
+fi
+
+# Ask init to start the vendor fingerprint HAL.
+setprop ctl.start vendor.fps_hal
+
+# Wait (bounded, ~10s) until it is actually running, so the daemon connects
+# straight away instead of sitting in its getService() retry until systemd's
+# start timeout fires.
+i=0
+while [ $i -lt 50 ]; do
+    if [ "$(getprop init.svc.vendor.fps_hal)" = "running" ]; then
+        log "vendor.fps_hal running"
+        break
+    fi
+    i=$((i + 1))
+    sleep 0.2
+done
+
+exit 0


### PR DESCRIPTION
Initial work for fingerprint support on LuneOS :)

-Add a webos-fingerprint-adapter for LS2 calls. 
-Wire up some of the Mer/Droidian bits for usage of fingerprint.
-Add Settings Fingerprint app to add/remove/rename fingerprints
-Add fingerprint to lockscreen (green glow on acceptance, red glow on rejection), text after 5 failures.