### PR TITLE
sam, luna-sysservice - Add cardshell permission patches for NFC/wallp…

### DIFF
--- a/meta-luneos/recipes-webos-ose/luna-sysservice/luna-sysservice.bb
+++ b/meta-luneos/recipes-webos-ose/luna-sysservice/luna-sysservice.bb
@@ -17,7 +17,7 @@ DEPENDS = "luna-service2 libpbnjson uriparser libxml2 sqlite3 pmloglib nyx-lib l
 RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_ntp} tzcode luna-init"
 
 WEBOS_VERSION = "4.4.0-31_b768ff291f1bed353c8652bd430cc43ee80c8c79"
-PR = "r14"
+PR = "r15"
 
 inherit webos_component
 inherit webos_public_repo
@@ -38,6 +38,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0005-luna-sysservice-TimePrefsHandler.cpp-Fix-typo.patch \
     file://0006-com.webos.service.systemservice-Add-image.management.patch \
     file://0007-Add-back-Image-and-Wallpaper-handling.patch \
+    file://0008-com.webos.service.systemservice-Allow-cardshell-to-query-settings.patch \
     file://0001-CMakeLists-consistent-target_link_libraries-signature.patch \
 "
 

--- a/meta-luneos/recipes-webos-ose/luna-sysservice/luna-sysservice/0008-com.webos.service.systemservice-Allow-cardshell-to-query-settings.patch
+++ b/meta-luneos/recipes-webos-ose/luna-sysservice/luna-sysservice/0008-com.webos.service.systemservice-Allow-cardshell-to-query-settings.patch
@@ -1,0 +1,48 @@
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Wed, 26 Aug 2026 10:16:00 +0200
+Subject: [PATCH] com.webos.service.systemservice - Allow cardshell to query settings
+
+surfacemanager-cardshell needs systemsettings.query (e.g. wallpaper)
+but the group alone isn't enough at oem trust: add dev too. Also add
+inbound:["*"] - without it, callers below oem trust get rejected
+before the group/client-permission grants are even checked.
+
+Upstream-Status: Pending
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+diff --git a/files/sysbus/com.webos.service.systemservice.groups.json b/files/sysbus/com.webos.service.systemservice.groups.json
+--- a/files/sysbus/com.webos.service.systemservice.groups.json
++++ b/files/sysbus/com.webos.service.systemservice.groups.json
+@@ -1,7 +1,7 @@
+ {
+     "allowedNames" : ["com.webos.service.systemservice"],
+     "systemsettings.management" : ["oem"],
+-    "systemsettings.query" : ["oem"],
++    "systemsettings.query" : ["oem", "dev"],
+     "software.query" : ["dev"],
+     "time.management" : ["oem"],
+     "time.query" : ["dev"],
+diff --git a/files/sysbus/com.webos.service.systemservice.perm.json b/files/sysbus/com.webos.service.systemservice.perm.json
+--- a/files/sysbus/com.webos.service.systemservice.perm.json
++++ b/files/sysbus/com.webos.service.systemservice.perm.json
+@@ -2,5 +2,8 @@
+ 	"com.webos.service.systemservice":[
+ 		 "settings.query", "application.launcher", "systemsettings.management",
+ 		 "networkconnection.query", "telephony.management", "telephony.query"
++	],
++	"com.webos.surfacemanager-cardshell":[
++		 "systemsettings.query"
+ 	]
+ }
+diff --git a/files/sysbus/com.webos.service.systemservice.service.role.json.in b/files/sysbus/com.webos.service.systemservice.service.role.json.in
+--- a/files/sysbus/com.webos.service.systemservice.service.role.json.in
++++ b/files/sysbus/com.webos.service.systemservice.service.role.json.in
+@@ -6,6 +6,7 @@
+ 	"permissions": [
+ 		{
+ 			"service":"com.webos.service.systemservice",
++			"inbound":["*"],
+ 			"outbound":[
+ 				"com.webos.service.connectionmanager",
+ 				"com.webos.service.settingsservice",

--- a/meta-luneos/recipes-webos-ose/sam/sam.bb
+++ b/meta-luneos/recipes-webos-ose/sam/sam.bb
@@ -17,7 +17,7 @@ RDEPENDS:${PN} += "${VIRTUAL-RUNTIME_webos-customization}"
 VIRTUAL-RUNTIME_webos-customization ?= ""
 
 WEBOS_VERSION = "2.0.0-77_7afc802ab0499a7f84e64f3f142b26682d996878"
-PR = "r31"
+PR = "r32"
 
 inherit webos_component
 inherit webos_cmake
@@ -37,6 +37,7 @@ SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
 	file://0007-Setup-QT_IM_MODULE-for-client-apps.patch \
 	file://0008-NativeContainer-configure-native-apps.patch \
 	file://0009-Setup-QT_WAYLAND_SHELL_INTEGRATION-for-webOS.patch \
+	file://0010-com.webos.sam-Allow-surfacemanager-cardshell-to-launch-apps.patch \
 	file://0001-CMakeLists.txt-replace-std-gnu-0x-with-std-c-17-for-.patch \
 "
 

--- a/meta-luneos/recipes-webos-ose/sam/sam/0010-com.webos.sam-Allow-surfacemanager-cardshell-to-launch-apps.patch
+++ b/meta-luneos/recipes-webos-ose/sam/sam/0010-com.webos.sam-Allow-surfacemanager-cardshell-to-launch-apps.patch
@@ -1,0 +1,44 @@
+From 8d6f077086c6a7dbbfc300abbaa9bb40a4acc648 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Wed, 26 Aug 2026 09:59:47 +0200
+Subject: [PATCH] com.webos.sam - Allow surfacemanager-cardshell to launch apps
+
+com.webos.surfacemanager-cardshell (the QML launcher/cards UI) needs
+application.launcher to let the user tap an app icon and have SAM
+actually launch it. Granting the group alone isn't enough: SAM's own
+groups.d entry for application.launcher only allowed oem trust, and
+cardshell's process trust level doesn't satisfy that alone - dev must
+be added too, or every launch request is rejected with
+LS_REQUIRES_TRUST despite the grant being present.
+
+Upstream-Status: Pending
+---
+ files/sysbus/com.webos.sam.groups.json | 2 +-
+ files/sysbus/com.webos.sam.perm.json   | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/files/sysbus/com.webos.sam.groups.json b/files/sysbus/com.webos.sam.groups.json
+index 2ea7207..18168d3 100644
+--- a/files/sysbus/com.webos.sam.groups.json
++++ b/files/sysbus/com.webos.sam.groups.json
+@@ -1,6 +1,6 @@
+ {
+         "allowedNames" : ["com.webos.service.applicationmanager","com.webos.applicationManager","com.webos.service.applicationManager"],
+         "application.operation": ["dev"],
+-	"application.launcher": ["oem"],
++	"application.launcher": ["oem", "dev"],
+         "application.devmode": ["dev"]
+ }
+diff --git a/files/sysbus/com.webos.sam.perm.json b/files/sysbus/com.webos.sam.perm.json
+index 744decc..35dd5bf 100644
+--- a/files/sysbus/com.webos.sam.perm.json
++++ b/files/sysbus/com.webos.sam.perm.json
+@@ -11,5 +11,8 @@
+         "settings.query",
+         "settings.management",
+         "webapplication.management"
++    ],
++    "com.webos.surfacemanager-cardshell" : [
++        "application.launcher"
+     ]
+ }


### PR DESCRIPTION
…aper

Two live-tested permission fixes packaged into recipes:

- sam: surfacemanager-cardshell needs application.launcher to launch apps from a tap, but the group grant alone isn't enough - the group's trust level (oem) doesn't cover cardshell's process trust, dev has to be added too.
- luna-sysservice: same pattern for systemsettings.query (wallpaper and other settings reads), plus inbound:["*"] on the service role - without it, sub-oem callers are rejected before the group/ client-permission grants are even checked.

Both were previously only live-patched on-device and would have reverted on the next reflash or package reinstall.