### PR TITLE
classes: build/rootfs fixes from the wrynose platform bring-up

### DIFF
--- a/meta-luneos/classes/luneos_image.bbclass
+++ b/meta-luneos/classes/luneos_image.bbclass
@@ -24,3 +24,8 @@ do_rootfs[prefuncs] += "${@bb.utils.contains('DISTRO_FEATURES', 'smack', 'do_fet
 ROOTFS_POSTPROCESS_COMMAND += "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'smack', ' do_smack_labeling ; ', '', d)} \
 "
+
+# Inherited after oe-core's rootfs-postcommands (which image.bbclass pulls in via
+# "inherit_defer ${IMGCLASSES}", resolved at the end of parsing) so that our
+# systemd_handle_machine_id override actually wins. See the class for why.
+IMGCLASSES += "luneos_rootfs_postcommands"

--- a/meta-luneos/classes/luneos_rootfs_postcommands.bbclass
+++ b/meta-luneos/classes/luneos_rootfs_postcommands.bbclass
@@ -1,0 +1,59 @@
+# Overrides for oe-core's rootfs-postcommands.bbclass.
+#
+# image.bbclass pulls rootfs-postcommands in through "inherit_defer ${IMGCLASSES}",
+# which is resolved at the very end of parsing, so a plain function override in
+# luneos_image.bbclass loses to it. luneos_image.bbclass appends this class to
+# IMGCLASSES instead, so it is inherited immediately after rootfs-postcommands and
+# its definitions win, while ROOTFS_POSTPROCESS_COMMAND keeps its original
+# contents and ordering.
+
+# LuneOS deliberately masks a number of systemd units: webos-initscripts ships
+# /etc/systemd/system/<unit> as a symlink to /dev/null for getty@tty1.service,
+# syslog.socket, sntp.service, run-postinsts.service and others, because LuneOS
+# owns the display and provides its own replacements for those services.
+#
+# systemd 259 reports "Unit <x> is masked" and exits 1 when the preset policy
+# wants to enable a unit we have masked, which fails do_rootfs. scarthgap never
+# hit this: OE shipped its own Python reimplementation of systemctl there, and it
+# did not run preset-all at all.
+#
+# preset-all still applies every other preset before returning non-zero -- that
+# was checked by re-running it with the masks moved aside, which exits 0 and
+# creates exactly one extra symlink, enabling the getty@tty1 we masked on
+# purpose. So the masked-unit failure is safe to ignore, but nothing else is.
+#
+# Keep the body in sync with rootfs-postcommands.bbclass; only the two
+# preset-all invocations are wrapped.
+systemd_handle_machine_id() {
+    if ${@bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs", "true", "false", d)}; then
+        # Create machine-id
+        # 20:12 < mezcalero> koen: you have three options: a) run systemd-machine-id-setup at install time, b) have / read-only and an empty file there (for stateless) and c) boot with / writable
+        touch ${IMAGE_ROOTFS}${sysconfdir}/machine-id
+    fi
+    # In order to be backward compatible with the previous OE-core specific (re)implementation of systemctl
+    # we need to touch machine-id when handling presets and when the rootfs is NOT stateless
+    if ${@ 'true' if not bb.utils.contains('IMAGE_FEATURES', 'stateless-rootfs', True, False, d) else 'false'}; then
+        touch ${IMAGE_ROOTFS}${sysconfdir}/machine-id
+        if [ -e ${IMAGE_ROOTFS}${root_prefix}/lib/systemd/systemd ]; then
+            luneos_preset_all
+            luneos_preset_all --global
+        fi
+    fi
+}
+
+# Run preset-all, tolerating a non-zero exit caused only by units we masked.
+luneos_preset_all() {
+    preset_log="${T}/luneos-preset-all.log"
+    if systemctl --root="${IMAGE_ROOTFS}" $@ --preset-mode=enable-only preset-all > "$preset_log" 2>&1; then
+        cat "$preset_log"
+        return 0
+    fi
+    cat "$preset_log"
+    if ! grep -qi "Failed" "$preset_log"; then
+        bbfatal "systemctl preset-all $@ failed without reporting a reason"
+    fi
+    if grep -i "Failed" "$preset_log" | grep -qv "is masked"; then
+        bbfatal "systemctl preset-all $@ failed for a reason other than a masked unit"
+    fi
+    bbnote "systemctl preset-all $@ only failed on units LuneOS masks on purpose"
+}

--- a/meta-luneos/classes/webos_enactjs_app.bbclass
+++ b/meta-luneos/classes/webos_enactjs_app.bbclass
@@ -268,9 +268,16 @@ do_install() {
         exit 1
     fi
 
-    if [ -f $appdir/snapshot_blob.bin ] ; then
-        chown root:root "$appdir/snapshot_blob.bin"
-    fi
+    # The Enact packer (and the mv out of ./dist above) leave the staged files
+    # owned by the build user instead of root, which do_package rejects as host
+    # contamination:
+    #   Path ... is owned by uid 1000, gid 1000, which doesn't match any
+    #   user/group on target. This may be due to host contamination.
+    #   KeyError: 'getpwuid(): uid not found: 1000'
+    # snapshot_blob.bin was already being corrected on its own; the whole app
+    # directory needs it, as luna-init, mojo-framework and the localization
+    # classes already do for the trees they install.
+    chown -R root:root "$appdir"
 
     cd ${working}
 }

--- a/meta-luneos/classes/webos_npm_env.bbclass
+++ b/meta-luneos/classes/webos_npm_env.bbclass
@@ -30,10 +30,28 @@ WEBOS_NPM_INSTALL_FLAGS ?= "--arch=${WEBOS_NPM_ARCH} --target_arch=${WEBOS_NPM_A
 WEBOS_NODE_BIN ??= "${STAGING_BINDIR_NATIVE}/node"
 
 # for node-gyp
-WEBOS_NODE_VERSION = "20.13.0"
+#
+# This MUST track the nodejs version that meta-oe builds for the image
+# (meta-openembedded/meta-oe/recipes-devtools/nodejs). node-gyp compiles the
+# native modules against these headers, and a native module built against one
+# major version of node cannot be loaded by another: the V8 ABI differs.
+#
+# wrynose moved meta-oe to nodejs 22 while this was still pinned to 20, so every
+# module under /usr/lib/nodejs was built against Node 20's V8 headers and then
+# failed to load in Node 22 with
+#
+#   /usr/lib/nodejs/webos.node: undefined symbol:
+#   _ZN2v812api_internal18GlobalizeReferenceEPNS_8internal7IsolateEPm
+#
+# That kills every JS service (run-js-service exits immediately), which is not
+# obvious from the outside: com.palm.service.accounts never registers, so no
+# local profile is created, /var/luna/preferences/first-use-profile-created is
+# never written, BootManager stays in BOOT_STATE_FIRSTUSE and the device
+# relaunches First Use on every boot with no gesture bar.
+WEBOS_NODE_VERSION = "22.23.1"
 WEBOS_NODE_SRC_URI = "https://nodejs.org/dist/v${WEBOS_NODE_VERSION}/node-v${WEBOS_NODE_VERSION}.tar.xz;name=node"
 WEBOS_NODE_GYP = "node-gyp --arch '${TARGET_ARCH}' --nodedir '${UNPACKDIR}/node-v${WEBOS_NODE_VERSION}'"
-SRC_URI[node.sha256sum] = "11d229fcad7e6e10f450301223c602043f021cda51259ffafc7e55e484b37dc7"
+SRC_URI[node.sha256sum] = "b27385d6845089bdb91285d94b06c2a5cf1c37f8173a3c4e10824cc1ffadeaba"
 
 do_compile:prepend() {
     # this is needed to use user's gitconfig even after changing the HOME directory bellow

--- a/meta-luneos/classes/webos_qmake6.bbclass
+++ b/meta-luneos/classes/webos_qmake6.bbclass
@@ -84,3 +84,15 @@ do_configure:prepend() {
 do_compile:prepend() {
   ${EXPORT_WEBOS_QMAKE_MACHINE}
 }
+
+# qt6-qmake.bbclass rewrites STAGING_DIR_NATIVE and STAGING_DIR_HOST out of the
+# generated .pri/.prl files, but QMAKE_PRL_BUILD_DIR records ${B} - the build
+# directory - which matches neither, so it survives into the -dev package:
+#   File /usr/lib/libWebOSCoreCompositor.prl in package luna-surfacemanager-dev
+#   contains reference to TMPDIR [buildpaths]
+# The value is build-time bookkeeping that means nothing on target, so drop the
+# line. Done here rather than in meta-qt6 so we are not carrying a change to
+# that layer, and it covers every recipe that inherits this class.
+do_install:append() {
+    find ${D} -name "*.prl" -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+}

--- a/meta-luneos/classes/webos_qmake6_paths.bbclass
+++ b/meta-luneos/classes/webos_qmake6_paths.bbclass
@@ -30,7 +30,15 @@ OE_QMAKE_PATH_EXAMPLES = "${datadir}/examples"
 OE_QMAKE_PATH_TESTS = "${datadir}/tests"
 OE_QMAKE_PATH_HOST_PREFIX = ""
 OE_QMAKE_PATH_HOST_PREFIX:class-target = "${STAGING_DIR_NATIVE}"
-OE_QMAKE_PATH_HOST_BINS = "${bindir}${QT_DIR_NAME}"
+# OE_QMAKE_PATH_HOST_BINS is deliberately NOT overridden here. It names the
+# directory holding the *host* qmake, and meta-qt6 computes it from
+# STAGING_BINDIR_NATIVE. Setting it to ${bindir} - as this class used to,
+# carried over from the qt5-era qmake5_paths.bbclass - makes qt6-qmake.bbclass
+# derive OE_QMAKE_QMAKE = /usr/bin/qmake, the build host's path:
+#   run.do_configure: /usr/bin/qmake: not found
+# Every other OE_QMAKE_PATH_* below is a target path, which is why this one
+# looked like it belonged; the neighbouring OE_QMAKE_PATH_EXTERNAL_HOST_BINS
+# already uses STAGING_BINDIR_NATIVE for the same reason.
 OE_QMAKE_PATH_HOST_DATA = "${QMAKE_MKSPEC_PATH_TARGET}"
 OE_QMAKE_PATH_HOST_LIBS = "${STAGING_LIBDIR}"
 OE_QMAKE_PATH_EXTERNAL_HOST_BINS = "${STAGING_BINDIR_NATIVE}${QT_DIR_NAME}"

--- a/meta-luneos/conf/distro/include/luneos-preferred-versions.inc
+++ b/meta-luneos/conf/distro/include/luneos-preferred-versions.inc
@@ -28,3 +28,16 @@ PREFERRED_VERSION_meson-native = "1.12.0"
 PREFERRED_VERSION_mesa = "26.2.0%"
 
 PREFERRED_VERSION_lttng-modules:tenderloin    = "2.13.12+git"
+
+# Per-app V8 snapshots stay off under M151.
+# ----------------------------------------
+# webos_enactjs_app.bbclass defaults WEBOS_ENACTJS_PACK_OPTS to include
+# --snapshot, which builds each app a snapshot_blob.bin with mksnapshot-cross.
+# A V8 snapshot is only loadable by the V8 that produced it, and blobs built by
+# the M120 mksnapshot made every Enact app that ships one fail to start under
+# M151 - deleting the 8 blobs on the target was what got those apps running.
+# mksnapshot-cross_151 exists and configures now, but it has not been proven per
+# target arch, so leave --snapshot off: the apps load without a custom snapshot,
+# which costs some startup time but is correct. Dropping it also drops the
+# conditional mksnapshot-cross dependency in the class.
+WEBOS_ENACTJS_PACK_OPTS = "--production --isomorphic --locales=webos"


### PR DESCRIPTION
- webos_enactjs_app: chown the whole staged app dir to root, not just snapshot_blob.bin - the Enact packer leaves files owned by the build user and do_package rejects them as host contamination. Drop the --snapshot pack option (and its conditional mksnapshot-cross dependency): M120-built V8 blobs made every Enact app fail to start under M151, and mksnapshot-cross_151 is unproven per arch, so apps load without a custom snapshot for now (set in luneos-preferred-versions.inc).
- webos_npm_env: build node modules against the node version the image actually ships.
- luneos_image + new luneos_rootfs_postcommands: override oe-core's systemd machine-id handling via IMGCLASSES ordering, and tolerate systemctl preset-all failing on units LuneOS masks.
- webos_qmake6 / webos_qmake6_paths: qmake host-path and paths fixes for Qt 6.12 on wrynose.


Claude-Session: https://claude.ai/code/session_01Q2YGhQSXxskPV3aKDwfswj