### PR TITLE
webos-connman-adapter: finish the port onto the connman 2.0 APIs

### DIFF
--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/wca-support-api.bb
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/wca-support-api.bb
@@ -24,3 +24,7 @@ inherit webos_public_repo
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Revert-Removing-support-for-com.webos.service.wan-se.patch \
 "
+
+# CMake 4: @VAR@ is no longer expanded in unquoted arguments (CMP0053),
+# which broke the install() DESTINATIONs in this component.
+SRC_URI += "file://0001-CMakeLists-use-CMake-variable-syntax-instead-of-VAR.patch"

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/wca-support-api/0001-CMakeLists-use-CMake-variable-syntax-instead-of-VAR.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/wca-support-api/0001-CMakeLists-use-CMake-variable-syntax-instead-of-VAR.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LuneOS / webOS Ports <team@webos-ports.org>
+Date: Thu, 13 Aug 2026 00:00:00 +0000
+Subject: [PATCH] CMakeLists: use ${{VAR}} instead of @VAR@ for variable references
+
+CMake's CMP0053, introduced in 3.1, stopped expanding @VAR@ in unquoted
+arguments. Until now this worked only because webOS.cmake declared
+cmake_minimum_required(VERSION 2.8.7), which left the policy at OLD. Raising
+that to 3.5 for CMake 4 - and CMake 4 removes the OLD behaviour of every policy
+older than 3.5, so it cannot be set back - makes @VAR@ a literal string:
+
+  Files/directories were installed but not shipped in any package:
+    /usr/@WEBOS_INSTALL_INCLUDEDIR@
+    /usr/@WEBOS_INSTALL_INCLUDEDIR@/...
+
+Upstream-Status: Pending
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d209918..d1a0202 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,7 @@ webos_component(1 0 0)
+ include(FindPkgConfig)
+ include_directories(include/public)
+ 
+-install(DIRECTORY "include/public/" DESTINATION @WEBOS_INSTALL_INCLUDEDIR@ FILES_MATCHING PATTERN "*.h" PATTERN ".*" EXCLUDE)
++install(DIRECTORY "include/public/" DESTINATION ${WEBOS_INSTALL_INCLUDEDIR} FILES_MATCHING PATTERN "*.h" PATTERN ".*" EXCLUDE)
+ webos_build_pkgconfig(files/pkgconfig/wca-support-api)
+ 
+ webos_config_build_doxygen(doc Doxyfile)

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter.bb
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter.bb
@@ -35,6 +35,11 @@ PACKAGECONFIG = "enable-multiple-routing-table"
 SRC_URI = "${WEBOSOSE_GIT_REPO_COMPLETE} \
     file://0001-Add-back-com.palm.wan-for-cellular-support.patch \
     file://0002-Update-webos-connman-adapter.role.json.in-Add-permis.patch \
+    file://0003-tethering-get-the-station-list-from-connman-instead-.patch \
+    file://0004-agent-implement-Cancel-and-Release-map-connman-2.0-s.patch \
+    file://0005-connectionmanager-implement-setDefaultInterface-with.patch \
+    file://0006-expose-DNS-search-domains-and-cellular-roaming-state.patch \
+    file://0007-connectionmanager-expose-per-service-timeservers-mDN.patch \
 "
 
 inherit webos_systemd

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0003-tethering-get-the-station-list-from-connman-instead-.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0003-tethering-get-the-station-list-from-connman-instead-.patch
@@ -1,0 +1,265 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LuneOS <dev@luneos.org>
+Date: Mon, 17 Aug 2026 17:54:08 +0200
+Subject: [PATCH] tethering: get the station list from connman instead of
+ GetStaCount
+
+GetStaCount and the wifi technology's StationMac property are webOS OSE
+connman fork additions that do not exist upstream, so
+/tethering/getStationCount reported nothing on connman 2.0.
+
+Upstream tracks the same thing: plugins/wifi.c feeds the supplicant's
+StaAuthorized/StaDeauthorized events into connman's tethering client
+table, which is published as Manager.GetTetheringClients (a list of
+station MAC addresses) and the TetheringClientsChanged signal.  That is
+both the count and the connectedStations array, from one call, and the
+signal replaces the fork's per-technology TetheringStaAuthorized.
+
+Upstream-Status: Inappropriate [LuneOS specific]
+---
+ files/xml/connman.xml        |  8 ++++--
+ src/connman_manager.c        | 51 +++++++++++++++++++++++++++++++++---
+ src/connman_manager.h        | 10 +++++++
+ src/connman_technology.c     |  2 --
+ src/connman_technology.h     |  1 -
+ src/logging.h                |  1 +
+ src/wifi_service.c           | 14 +++++-----
+ src/wifi_tethering_service.c | 17 ++++++++----
+ 8 files changed, 82 insertions(+), 22 deletions(-)
+
+diff --git a/files/xml/connman.xml b/files/xml/connman.xml
+index 392e73a..af967f5 100644
+--- a/files/xml/connman.xml
++++ b/files/xml/connman.xml
+@@ -71,8 +71,8 @@ limitations under the License.
+ 			<arg type="s" direction="in"/>
+ 			<arg type="o" direction="out"/>
+ 		</method>
+-		<method name="GetStaCount">
+-			<arg type="i" direction="out"/>
++		<method name="GetTetheringClients">
++			<arg type="as" direction="out"/>
+ 		</method>
+ 		<method name="RegisterPeerService">
+ 			<arg name="specification" type="a{sv}" direction="in"/>
+@@ -111,6 +111,10 @@ limitations under the License.
+ 		<signal name="GroupRemoved">
+ 			<arg type="o"/>
+ 		</signal>
++		<signal name="TetheringClientsChanged">
++			<arg type="as"/>
++			<arg type="as"/>
++		</signal>
+ 	</interface>
+ 	<interface name="net.connman.Technology">
+ 		<method name="GetProperties">
+diff --git a/src/connman_manager.c b/src/connman_manager.c
+index 1c28946..a73bf87 100644
+--- a/src/connman_manager.c
++++ b/src/connman_manager.c
+@@ -24,6 +24,7 @@
+ #include "connman_manager.h"
+ #include "logging.h"
+ #include "connectionmanager_service.h"
++#include "wifi_tethering_service.h"
+ #include "utils.h"
+ #include "wfdsie/wfdinfoelemwrapper.h"
+ 
+@@ -1200,18 +1201,41 @@ guint connman_manager_get_sta_count(connman_manager_t *manager)
+ 	if (NULL == manager)
+ 		return FALSE;
+ 
++	gchar **clients = connman_manager_get_tethering_clients(manager);
++	guint sta_count = clients ? g_strv_length(clients) : 0;
++
++	g_strfreev(clients);
++
++	return sta_count;
++}
++
++/**
++ * Retrieve the MAC addresses of the stations currently associated with our
++ * tethering AP (see header for API details)
++ */
++
++GStrv connman_manager_get_tethering_clients(connman_manager_t *manager)
++{
+ 	GError *error = NULL;
+-	guint sta_count = 0;
++	gchar **clients = NULL;
++
++	if (NULL == manager)
++	{
++		return NULL;
++	}
+ 
+-	connman_interface_manager_call_get_sta_count_sync(manager->remote, &sta_count, NULL, &error);
++	connman_interface_manager_call_get_tethering_clients_sync(manager->remote,
++	        &clients, NULL, &error);
+ 
+ 	if (error)
+ 	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_MANAGER_GET_TETHERING_CLIENTS_ERROR,
++		                      error->message);
+ 		g_error_free(error);
+-		return 0;
++		return NULL;
+ 	}
+ 
+-	return sta_count;
++	return clients;
+ }
+ 
+ /**
+@@ -2067,6 +2091,22 @@ saved_services_changed_cb(ConnmanInterfaceManager *proxy,
+ 	remove_services_from_list(&manager->saved_services, saved_services_removed);
+ }
+ 
++/**
++ * Callback for manager's "tethering_clients_changed" signal
++ *
++ * Connman emits this whenever a station associates with or leaves our
++ * tethering AP, which is what /tethering/getStationCount reports.
++ */
++static void
++tethering_clients_changed_cb(ConnmanInterfaceManager *proxy,
++                             gchar **clients_added, gchar **clients_removed,
++                             connman_manager_t *manager)
++{
++	WCALOG_DEBUG("Tethering clients changed");
++
++	send_sta_count_to_subscribers();
++}
++
+ /**
+  * Register for manager's "properties_changed" signal, calling the provided function whenever the callback function
+  * for the signal is called (see header for API details)
+@@ -2295,6 +2335,9 @@ connman_manager_t *connman_manager_new(void)
+ 	g_signal_connect(G_OBJECT(manager->remote), "saved-services-changed",
+ 	                 G_CALLBACK(saved_services_changed_cb), manager);
+ 
++	g_signal_connect(G_OBJECT(manager->remote), "tethering-clients-changed",
++	                 G_CALLBACK(tethering_clients_changed_cb), manager);
++
+ 	g_signal_connect(G_OBJECT(manager->remote), "group-added",
+ 	                 G_CALLBACK(group_added_cb), manager);
+ 
+diff --git a/src/connman_manager.h b/src/connman_manager.h
+index 0bdeaa5..6ba9ece 100644
+--- a/src/connman_manager.h
++++ b/src/connman_manager.h
+@@ -315,6 +315,16 @@ extern connman_group_t *connman_manager_create_group(connman_manager_t *manager,
+  */
+ extern guint connman_manager_get_sta_count(connman_manager_t *manager);
+ 
++/**
++ * @brief Retrieve the MAC addresses of the stations currently associated with
++ *        the tethering AP. Caller owns the result and must g_strfreev() it.
++ *
++ * @param[IN] manager A manager instance
++ *
++ * @return A NULL terminated array of MAC addresses, NULL on failure
++ */
++extern GStrv connman_manager_get_tethering_clients(connman_manager_t *manager);
++
+ /**
+  * Populate the group's peer_list field with all of the group's peers
+  *
+diff --git a/src/connman_technology.c b/src/connman_technology.c
+index ac98fb4..c6b9a18 100644
+--- a/src/connman_technology.c
++++ b/src/connman_technology.c
+@@ -1243,8 +1243,6 @@ void connman_technology_free(connman_technology_t *technology)
+ 	g_object_unref(technology->remote);
+ 	technology->remote = NULL;
+ 
+-	g_strfreev(technology->station_mac);
+-
+ 	g_strfreev(technology->interfaces);
+ 	technology->interfaces = NULL;
+ 
+diff --git a/src/connman_technology.h b/src/connman_technology.h
+index f16d367..f73c3ac 100644
+--- a/src/connman_technology.h
++++ b/src/connman_technology.h
+@@ -76,7 +76,6 @@ typedef struct connman_technology
+ 
+ 	gboolean removed; /* If true, the technology has been removed and should be deleted when callbacks complete*/
+ 	gint32 calls_pending; /* Number of connman DBUS calls pending. */
+-	GStrv station_mac;
+ } connman_technology_t;
+ 
+ 
+diff --git a/src/logging.h b/src/logging.h
+index 13f9c41..a208e83 100644
+--- a/src/logging.h
++++ b/src/logging.h
+@@ -88,6 +88,7 @@ extern PmLogContext gLogContext;
+ 
+ /** connman_manager.c */
+ #define MSGID_MANAGER_GET_PROPERTIES_ERROR              "MGR_GET_PROPERTIES_ERR"
++#define MSGID_MANAGER_GET_TETHERING_CLIENTS_ERROR       "MGR_GET_TETHERING_CLIENTS_ERR"
+ #define MSGID_MANAGER_GET_SERVICES_ERROR                "MGR_GET_SERVICES_ERR"
+ #define MSGID_MANAGER_GET_SAVED_SERVICES_ERROR          "MGR_GET_SAVED_SERVICES_ERR"
+ #define MSGID_MANAGER_GET_TECHNOLOGIES_ERROR            "MGR_GET_TECHNOLOGIES_ERR"
+diff --git a/src/wifi_service.c b/src/wifi_service.c
+index 541e14f..f7bc24d 100644
+--- a/src/wifi_service.c
++++ b/src/wifi_service.c
+@@ -2044,14 +2044,12 @@ static void technology_property_changed_callback(gpointer data,
+ 			send_tethering_state_to_subscribers();
+ 		}
+ 
+-		if(g_strcmp0(property, "StationMac") == 0) {
+-			GVariant *va = g_variant_get_child_value(value, 0);
+-			g_strfreev(technology->station_mac);
+-			technology->station_mac = g_variant_dup_strv(va, NULL);
+-
+-			g_variant_unref(va);
+-			send_sta_count_to_subscribers();
+-		}
++		/*
++		 * The station list used to arrive as a "StationMac" property on the
++		 * wifi technology; upstream connman reports it through the manager's
++		 * TetheringClientsChanged signal instead, which connman_manager.c
++		 * hooks up.
++		 */
+ 	}
+ 	else if (technology == connman_manager_find_ethernet_technology(manager))
+ 	{
+diff --git a/src/wifi_tethering_service.c b/src/wifi_tethering_service.c
+index 51810d4..c39208a 100644
+--- a/src/wifi_tethering_service.c
++++ b/src/wifi_tethering_service.c
+@@ -358,19 +358,26 @@ static void send_sta_count(jvalue_ref *reply)
+ 	if(NULL == reply)
+ 		return;
+ 
+-	unsigned int sta_count = connman_manager_get_sta_count(manager);
++	/*
++	 * Connman's tethering client list is fed from the supplicant's
++	 * StaAuthorized/StaDeauthorized events, so it is both the station count
++	 * and the list of station MACs.
++	 */
++	GStrv stations = connman_manager_get_tethering_clients(manager);
++	guint sta_count = stations ? g_strv_length(stations) : 0;
++
+ 	jobject_put(*reply, J_CSTR_TO_JVAL("stationCount"), jnumber_create_i32(sta_count));
+ 
+ 	jvalue_ref connected_stations_obj = jarray_create(NULL);
+ 
+-	connman_technology_t *wifi_tech = connman_manager_find_wifi_technology(manager);
+-
+-	for (int i = 0; i < g_strv_length(wifi_tech->station_mac); i++)
++	for (guint i = 0; i < sta_count; i++)
+ 	{
+-		jarray_append(connected_stations_obj, jstring_create(wifi_tech->station_mac[i]));
++		jarray_append(connected_stations_obj, jstring_create(stations[i]));
+ 	}
+ 
+ 	jobject_put(*reply, J_CSTR_TO_JVAL("connectedStations"), connected_stations_obj);
++
++	g_strfreev(stations);
+ }
+ 
+ void send_sta_count_to_subscribers(void)

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0004-agent-implement-Cancel-and-Release-map-connman-2.0-s.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0004-agent-implement-Cancel-and-Release-map-connman-2.0-s.patch
@@ -1,0 +1,132 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LuneOS <dev@luneos.org>
+Date: Mon, 17 Aug 2026 17:56:25 +0200
+Subject: [PATCH] agent: implement Cancel and Release, map connman 2.0's new
+ service errors
+
+net.connman.Agent.Cancel is part of connman's agent API and it calls it
+whenever a pending RequestInput or RequestPeerAuthorization is abandoned,
+so every cancellation was answered with UnknownMethod.  Release had the
+same problem.  Both are now acknowledged; our request handlers reply
+synchronously so there is no in-flight state to unwind.
+
+connman 2.0 added two service Error values.  "blocked" is reported when
+the AP refuses the association, and "online-check-failed" when a service
+connected fine but repeatedly failed the internet reachability check,
+which is reachable now that OnlineCheckMode is set to continuous.
+Neither was mapped, so /connect answered with a null error message.
+
+Upstream-Status: Inappropriate [LuneOS specific]
+---
+ files/xml/connman.xml |  2 ++
+ src/connman_agent.c   | 41 +++++++++++++++++++++++++++++++++++++++++
+ src/errors.h          |  2 ++
+ src/wifi_service.c    | 10 ++++++++++
+ 4 files changed, 55 insertions(+)
+
+diff --git a/files/xml/connman.xml b/files/xml/connman.xml
+index af967f5..7b2e3e6 100644
+--- a/files/xml/connman.xml
++++ b/files/xml/connman.xml
+@@ -187,6 +187,8 @@ limitations under the License.
+ 	<interface name="net.connman.Agent">
+ 		<method name="Release">
+ 		</method>
++		<method name="Cancel">
++		</method>
+ 		<method name="ReportError">
+ 			<arg type="o" direction="in"/>
+ 			<arg type="s" direction="in"/>
+diff --git a/src/connman_agent.c b/src/connman_agent.c
+index faf709e..48383ec 100644
+--- a/src/connman_agent.c
++++ b/src/connman_agent.c
+@@ -113,6 +113,43 @@ static gboolean request_peer_authorization_cb(
+ 	return TRUE;
+ }
+ 
++/*
++ * Connman calls Cancel when a request it made through RequestInput or
++ * RequestPeerAuthorization is no longer needed, for instance because the
++ * service was disconnected or the input timed out. Our request handlers reply
++ * synchronously so there is nothing in flight to abort, but the method still
++ * has to exist or every cancellation answers with UnknownMethod.
++ */
++static gboolean cancel_cb(ConnmanInterfaceAgent *interface,
++                          GDBusMethodInvocation *invocation,
++                          gpointer user_data)
++{
++	connman_agent_t *agent = user_data;
++
++	WCALOG_DEBUG("Agent request cancelled by connman");
++
++	connman_interface_agent_complete_cancel(agent->interface, invocation);
++
++	return TRUE;
++}
++
++/*
++ * Release is called when connman drops the agent registration, e.g. when it
++ * is shutting down.
++ */
++static gboolean release_cb(ConnmanInterfaceAgent *interface,
++                           GDBusMethodInvocation *invocation,
++                           gpointer user_data)
++{
++	connman_agent_t *agent = user_data;
++
++	WCALOG_DEBUG("Agent released by connman");
++
++	connman_interface_agent_complete_release(agent->interface, invocation);
++
++	return TRUE;
++}
++
+ static void bus_acquired_cb(GDBusConnection *connection, const gchar *name,
+                             gpointer user_data)
+ {
+@@ -130,6 +167,10 @@ static void bus_acquired_cb(GDBusConnection *connection, const gchar *name,
+ 	                 G_CALLBACK(request_peer_authorization_cb), agent);
+ 	g_signal_connect(agent->interface, "handle-report-peer-error",
+ 	                 G_CALLBACK(report_error_cb), agent);
++	g_signal_connect(agent->interface, "handle-cancel",
++	                 G_CALLBACK(cancel_cb), agent);
++	g_signal_connect(agent->interface, "handle-release",
++	                 G_CALLBACK(release_cb), agent);
+ 
+ 	error = NULL;
+ 
+diff --git a/src/errors.h b/src/errors.h
+index 0261938..22e59b7 100644
+--- a/src/errors.h
++++ b/src/errors.h
+@@ -117,6 +117,8 @@
+ #define WCA_API_ERROR_TETHERING_IP_ADDRESS_FAILED         148
+ #define WCA_API_ERROR_TETHERING_NOT_ALLOWED_TO_CHANGE_MAX_STATION_COUNT 210
+ #define WCA_API_ERROR_TETHERING_SET_MAX_STATION_COUNT_FAILED 211
++#define WCA_API_ERROR_BLOCKED                    212
++#define WCA_API_ERROR_ONLINE_CHECK_FAILED        213
+ 
+ #define WCA_API_ERROR_INTERFACE_NOT_CONNECTED    301
+ #define WCA_API_ERROR_INTERFACE_ALREADY_DEFAULT  302
+diff --git a/src/wifi_service.c b/src/wifi_service.c
+index f7bc24d..addbf83 100644
+--- a/src/wifi_service.c
++++ b/src/wifi_service.c
+@@ -655,6 +655,16 @@ static gboolean handle_failed_connection_request(gpointer user_data)
+ 		error_message = "Out of range";
+ 		error_code = WCA_API_ERROR_OUT_OF_RANGE;
+ 	}
++	else if (g_strcmp0(service->error, "blocked") == 0)
++	{
++		error_message = "Access point refused the connection";
++		error_code = WCA_API_ERROR_BLOCKED;
++	}
++	else if (g_strcmp0(service->error, "online-check-failed") == 0)
++	{
++		error_message = "Connected but the network has no internet access";
++		error_code = WCA_API_ERROR_ONLINE_CHECK_FAILED;
++	}
+ 
+ 	LSMessageReplyCustomError(current_connect_req->handle,
+ 	                          current_connect_req->message,

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0005-connectionmanager-implement-setDefaultInterface-with.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0005-connectionmanager-implement-setDefaultInterface-with.patch
@@ -1,0 +1,152 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LuneOS <dev@luneos.org>
+Date: Mon, 17 Aug 2026 17:59:38 +0200
+Subject: [PATCH] connectionmanager: implement setDefaultInterface with
+ MoveBefore
+
+Service.SetDefault is a webOS OSE connman fork addition.  Upstream hands
+the default route to the first connected favorite in its own service
+ordering and exposes MoveBefore/MoveAfter to reorder it, so promoting the
+requested wired service past the current default wired service is the
+equivalent operation.
+
+Also declares ClearProperty and ResetCounters on net.connman.Service
+while the interface is being brought in line with upstream.
+
+Upstream-Status: Inappropriate [LuneOS specific]
+---
+ files/xml/connman.xml           | 11 ++++++++++-
+ src/connectionmanager_service.c | 17 ++++++++++++++++-
+ src/connman_service.c           | 31 ++++++++++++++++++++++++++++---
+ src/connman_service.h           | 19 ++++++++++++++++++-
+ 4 files changed, 72 insertions(+), 6 deletions(-)
+
+diff --git a/files/xml/connman.xml b/files/xml/connman.xml
+index 7b2e3e6..d175b75 100644
+--- a/files/xml/connman.xml
++++ b/files/xml/connman.xml
+@@ -162,7 +162,16 @@ limitations under the License.
+ 		</method>
+ 		<method name="Remove">
+ 		</method>
+-		<method name="SetDefault">
++		<method name="ClearProperty">
++			<arg type="s" direction="in"/>
++		</method>
++		<method name="MoveBefore">
++			<arg type="o" direction="in"/>
++		</method>
++		<method name="MoveAfter">
++			<arg type="o" direction="in"/>
++		</method>
++		<method name="ResetCounters">
+ 		</method>
+ 		<signal name="PropertyChanged">
+ 			<arg type="s"/>
+diff --git a/src/connectionmanager_service.c b/src/connectionmanager_service.c
+index d356044..3c62a61 100644
+--- a/src/connectionmanager_service.c
++++ b/src/connectionmanager_service.c
+@@ -2868,7 +2868,22 @@ static bool handle_set_default_interface(LSHandle *sh, LSMessage *message,
+ 		else if(service_state == CONNMAN_SERVICE_STATE_READY
+ 			|| service_state == CONNMAN_SERVICE_STATE_CONFIGURATION)
+ 		{
+-			if (connman_service_set_default(service))
++			/*
++			 * Connman hands the default route to the first connected
++			 * favorite in its service ordering, so promoting this service
++			 * past the current default is what makes it default. The webOS
++			 * OSE connman fork had a SetDefault method for this; upstream
++			 * expects MoveBefore.
++			 */
++			connman_service_t *current_default =
++			        connman_manager_get_default_service(manager->wired_services);
++
++			if (NULL == current_default || current_default == service)
++			{
++				/* Nothing ranked ahead of it, so it already is the default */
++				LSMessageReplySuccess(sh, message);
++			}
++			else if (connman_service_move_before(service, current_default))
+ 			{
+ 				LSMessageReplySuccess(sh, message);
+ 			}
+diff --git a/src/connman_service.c b/src/connman_service.c
+index f28f6dd..3c4e4a4 100644
+--- a/src/connman_service.c
++++ b/src/connman_service.c
+@@ -1473,16 +1473,41 @@ gboolean connman_service_reject_peer(connman_service_t *service)
+  * Set the given service as default interface(see header for API details)
+  */
+ 
+-gboolean connman_service_set_default(connman_service_t *service)
++gboolean connman_service_move_before(connman_service_t *service,
++                                     connman_service_t *target)
+ {
+-	if (NULL == service)
++	GError *error = NULL;
++
++	if (NULL == service || NULL == target || service == target)
+ 	{
+ 		return FALSE;
+ 	}
+ 
++	connman_interface_service_call_move_before_sync(service->remote,
++	        target->path, NULL, &error);
++
++	if (error)
++	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_SERVICE_SET_DEFAULT_ERROR, error->message);
++		g_error_free(error);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++gboolean connman_service_move_after(connman_service_t *service,
++                                    connman_service_t *target)
++{
+ 	GError *error = NULL;
+ 
+-	connman_interface_service_call_set_default_sync(service->remote, NULL, &error);
++	if (NULL == service || NULL == target || service == target)
++	{
++		return FALSE;
++	}
++
++	connman_interface_service_call_move_after_sync(service->remote,
++	        target->path, NULL, &error);
+ 
+ 	if (error)
+ 	{
+diff --git a/src/connman_service.h b/src/connman_service.h
+index 38aa7d0..e0b8839 100644
+--- a/src/connman_service.h
++++ b/src/connman_service.h
+@@ -304,7 +304,24 @@ extern gboolean connman_service_reject_peer(connman_service_t *service);
+  *
+  * @return FALSE if the call failed, TRUE otherwise
+  */
+-extern gboolean connman_service_set_default(connman_service_t *service);
++/**
++ * @brief Move service ahead of target in connman's service ordering, which is
++ *        how the default route is chosen. Both services must be favorites and
++ *        in a connected state or connman rejects the call.
++ *
++ * @param[IN] service The service to promote
++ * @param[IN] target  The service to promote it past
++ *
++ * @return TRUE if the move succeeded
++ */
++extern gboolean connman_service_move_before(connman_service_t *service,
++        connman_service_t *target);
++
++/**
++ * @brief Move service behind target in connman's service ordering.
++ */
++extern gboolean connman_service_move_after(connman_service_t *service,
++        connman_service_t *target);
+ 
+ /**
+  * remove a remote connman service

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0006-expose-DNS-search-domains-and-cellular-roaming-state.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0006-expose-DNS-search-domains-and-cellular-roaming-state.patch
@@ -1,0 +1,265 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LuneOS <dev@luneos.org>
+Date: Mon, 17 Aug 2026 18:05:20 +0200
+Subject: [PATCH] expose DNS search domains and cellular roaming state
+
+Domains.Configuration is the connman property for DNS search suffixes.
+The adapter only ever set Nameservers.Configuration, so /setdns could
+configure resolvers but not search domains.  setdns now takes an optional
+domains array, and the resolved Domains are reported back in
+/getstatus alongside dns1..dnsN.
+
+Roaming was likewise never parsed, so com.webos.service.wan could not
+tell a roaming context from a home one; it is now reported per context
+in wan/getStatus and in connectionmanager/getstatus for cellular.
+
+Upstream-Status: Inappropriate [LuneOS specific]
+---
+ src/connectionmanager_service.c | 54 +++++++++++++++++++++++++++++++--
+ src/connman_service.c           | 45 +++++++++++++++++++++++++++
+ src/connman_service.h           | 13 ++++++++
+ src/logging.h                   |  1 +
+ src/wan_service.c               |  2 ++
+ 5 files changed, 112 insertions(+), 3 deletions(-)
+
+diff --git a/src/connectionmanager_service.c b/src/connectionmanager_service.c
+index 3c62a61..b65df78 100644
+--- a/src/connectionmanager_service.c
++++ b/src/connectionmanager_service.c
+@@ -193,8 +193,28 @@ static void update_connection_status(connman_service_t *connected_service,
+ 			            jstring_create(connected_service->ipinfo.dns[i]));
+ 		}
+ 
++		if (connected_service->ipinfo.domains &&
++		        g_strv_length(connected_service->ipinfo.domains) > 0)
++		{
++			jvalue_ref domains_obj = jarray_create(NULL);
++
++			for (i = 0; i < g_strv_length(connected_service->ipinfo.domains); i++)
++			{
++				jarray_append(domains_obj,
++				              jstring_create(connected_service->ipinfo.domains[i]));
++			}
++
++			jobject_put(*status, J_CSTR_TO_JVAL("domains"), domains_obj);
++		}
++
+ 		update_string_value(status, J_CSTR_TO_JVAL("method"),connected_service->ipinfo.ipv4.method);
+ 
++		if (connected_service->type == CONNMAN_SERVICE_TYPE_CELLULAR)
++		{
++			jobject_put(*status, J_CSTR_TO_JVAL("roaming"),
++			            jboolean_create(connected_service->roaming));
++		}
++
+ 		if (connman_service_type_wifi(connected_service))
+ 		{
+ 			update_string_value(status, J_CSTR_TO_JVAL("ssid"),connected_service->name);
+@@ -1504,14 +1524,16 @@ static bool handle_set_dns_command(LSHandle *sh, LSMessage *message,
+ 	// To prevent memory leaks, schema should be checked before the variables will be initialized.
+ 	jvalue_ref parsedObj = {0};
+ 	if (!LSMessageValidateSchema(sh, message,
+-	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_3(ARRAY(dns, string), PROP(ssid,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_4(ARRAY(dns, string),
++	                                     ARRAY(domains, string), PROP(ssid,
+ 	                                     string), PROP(interfaceName, string)) REQUIRED_1(dns))), &parsedObj))
+ 	{
+ 		return true;
+ 	}
+ 
+-	jvalue_ref dnsObj = {0};
++	jvalue_ref dnsObj = {0}, domainsObj = {0};
+ 	GStrv dns = NULL;
++	GStrv domains = NULL;
+ 	gchar *ssid = NULL;
+ 	connman_service_t *service = NULL;
+ 	gchar *interface_name = NULL;
+@@ -1536,6 +1558,30 @@ static bool handle_set_dns_command(LSHandle *sh, LSMessage *message,
+ 		dns[dns_arrsize] = NULL;
+ 	}
+ 
++	/*
++	 * Optional DNS search domains. Connman keeps these separate from the
++	 * nameserver list, in Domains.Configuration.
++	 */
++	if (jobject_get_exists(parsedObj, J_CSTR_TO_BUF("domains"), &domainsObj))
++	{
++		int i, domains_arrsize = jarray_size(domainsObj);
++		domains = (GStrv) g_new0(GStrv, domains_arrsize + 1);
++
++		for (i = 0; i < domains_arrsize; i++)
++		{
++			raw_buffer domain_buf = jstring_get(jarray_get(domainsObj, i));
++			domains[i] = g_strdup(domain_buf.m_str);
++			jstring_free_buffer(domain_buf);
++
++			if (0 == strlen(domains[i]))
++			{
++				goto invalid_params;
++			}
++		}
++
++		domains[domains_arrsize] = NULL;
++	}
++
+ 	get_string_value(parsedObj,J_CSTR_TO_BUF("ssid"),&ssid);
+ 	get_string_value(parsedObj,J_CSTR_TO_BUF("interfaceName"),&interface_name);
+ 
+@@ -1544,7 +1590,8 @@ static bool handle_set_dns_command(LSHandle *sh, LSMessage *message,
+ 
+ 	if (NULL != service)
+ 	{
+-		if (connman_service_set_nameservers(service, dns))
++		if (connman_service_set_nameservers(service, dns) &&
++		        (NULL == domains || connman_service_set_domains(service, domains)))
+ 		{
+ 			LSMessageReplySuccess(sh, message);
+ 		}
+@@ -1589,6 +1636,7 @@ invalid_params:
+ 	LSMessageReplyErrorInvalidParams(sh, message);
+ exit:
+ 	g_strfreev(dns);
++	g_strfreev(domains);
+ 	g_free(ssid);
+ 	g_free(interface_name);
+ 	j_release(&parsedObj);
+diff --git a/src/connman_service.c b/src/connman_service.c
+index 3c4e4a4..e8e3160 100644
+--- a/src/connman_service.c
++++ b/src/connman_service.c
+@@ -669,6 +669,34 @@ gboolean connman_service_set_nameservers(connman_service_t *service, GStrv dns)
+ 	return TRUE;
+ }
+ 
++/**
++ * Set the DNS search domains for the given service (see header for API details)
++ */
++
++gboolean connman_service_set_domains(connman_service_t *service, GStrv domains)
++{
++	GError *error = NULL;
++
++	if (NULL == service || NULL == domains)
++	{
++		return FALSE;
++	}
++
++	connman_interface_service_call_set_property_sync(service->remote,
++	        "Domains.Configuration",
++	        g_variant_new_variant(g_variant_new_strv((const gchar * const *)domains,
++	                              g_strv_length(domains))), NULL, &error);
++
++	if (error)
++	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_SERVICE_SET_DOMAINS_ERROR, error->message);
++		g_error_free(error);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
+ /**
+  * Set auto-connect property for the given service (see header for API details)
+  */
+@@ -938,6 +966,18 @@ gboolean connman_service_get_ipinfo(connman_service_t *service)
+ 			g_variant_unref(va);
+ 		}
+ 
++		if (!g_strcmp0(key, "Domains"))
++		{
++			GVariant *v = g_variant_get_child_value(property, 1);
++			GVariant *va = g_variant_get_child_value(v, 0);
++
++			g_strfreev(service->ipinfo.domains);
++			service->ipinfo.domains = g_variant_dup_strv(va, NULL);
++
++			g_variant_unref(v);
++			g_variant_unref(va);
++		}
++
+ 		if (!g_strcmp0(key, "HostRoutes"))
+ 		{
+ 			GVariant *v = g_variant_get_child_value(property, 1);
+@@ -1743,6 +1783,10 @@ void connman_service_update_properties(connman_service_t *service,
+ 		{
+ 			service->favorite = g_variant_get_boolean(val);
+ 		}
++		else if (!g_strcmp0(key, "Roaming"))
++		{
++			service->roaming = g_variant_get_boolean(val);
++		}
+ 		else if (!g_strcmp0(key, "Online"))
+ 		{
+ 			connman_service_advance_online_state(service, val);
+@@ -2124,6 +2168,7 @@ void connman_service_free(gpointer data, gpointer user_data)
+ 	g_free(service->ipinfo.ipv6.address);
+ 	g_free(service->ipinfo.ipv6.gateway);
+ 	g_strfreev(service->ipinfo.dns);
++	g_strfreev(service->ipinfo.domains);
+ 
+ 	g_free(service->proxyinfo.method);
+ 	g_free(service->proxyinfo.url);
+diff --git a/src/connman_service.h b/src/connman_service.h
+index e0b8839..2b6bf75 100644
+--- a/src/connman_service.h
++++ b/src/connman_service.h
+@@ -66,6 +66,7 @@ typedef struct ipinfo
+ 	gchar *iface;
+ 	ipv4info_t ipv4;
+ 	GStrv dns;
++	GStrv domains; /* DNS search domains */
+ 	ipv6info_t ipv6;
+ } ipinfo_t;
+ 
+@@ -140,6 +141,7 @@ typedef struct connman_service
+ 	gboolean disconnecting;
+ 	gboolean immutable;
+ 	gboolean favorite;
++	gboolean roaming; /* Cellular service is on a roaming network */
+ 	gboolean hidden;
+ 	gboolean online;
+ 	gboolean online_checking;
+@@ -376,6 +378,17 @@ extern gboolean connman_service_set_proxy(connman_service_t *service,
+ extern gboolean connman_service_set_nameservers(connman_service_t *service,
+         GStrv dns);
+ 
++/**
++ * Set the DNS search domains for a service
++ *
++ * @param[IN]  service A service instance
++ * @param[IN]  domains A NULL terminated array of search domains
++ *
++ * @return FALSE if the call to set "Domains.Configuration" property failed, TRUE otherwise
++ */
++extern gboolean connman_service_set_domains(connman_service_t *service,
++        GStrv domains);
++
+ /**
+  * Set the "autoconnect" flag for a service
+  *
+diff --git a/src/logging.h b/src/logging.h
+index a208e83..31ee1da 100644
+--- a/src/logging.h
++++ b/src/logging.h
+@@ -119,6 +119,7 @@ extern PmLogContext gLogContext;
+ #define MSGID_SERVICE_SET_IPV4_ERROR                    "SRVC_SET_IPV4_ERR"
+ #define MSGID_SERVICE_SET_IPV6_ERROR                    "SRVC_SET_IPV6_ERR"
+ #define MSGID_SERVICE_SET_NAMESERVER_ERROR              "SRVC_SET_NAMESERVER_ERR"
++#define MSGID_SERVICE_SET_DOMAINS_ERROR                 "SRVC_SET_DOMAINS_ERR"
+ #define MSGID_SERVICE_AUTOCONNECT_ERROR                 "SRVC_AUTOCONNECT_ERR"
+ #define MSGID_SERVICE_GET_IPINFO_ERROR                  "SRVC_GET_IPINFO_ERR"
+ #define MSGID_SERVICE_FETCH_PROPERTIES_ERROR            "SRVC_FETCH_PROPERTIES_ERR"
+diff --git a/src/wan_service.c b/src/wan_service.c
+index b22aa7b..d028c53 100644
+--- a/src/wan_service.c
++++ b/src/wan_service.c
+@@ -60,6 +60,8 @@ static void retrieve_wan_context(jvalue_ref context_obj,
+ 	            jboolean_create(connman_service_is_connected(service)));
+ 	jobject_put(context_obj, J_CSTR_TO_JVAL("onInternet"),
+ 	            jboolean_create(connman_service_is_online(service)));
++	jobject_put(context_obj, J_CSTR_TO_JVAL("roaming"),
++	            jboolean_create(service->roaming));
+ 
+ 	if (service->ipinfo.iface)
+ 	{

--- a/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0007-connectionmanager-expose-per-service-timeservers-mDN.patch
+++ b/meta-luneos/recipes-webos-ose/webos-connman-adapter/webos-connman-adapter/0007-connectionmanager-expose-per-service-timeservers-mDN.patch
@@ -1,0 +1,710 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LuneOS <dev@luneos.org>
+Date: Mon, 17 Aug 2026 18:12:05 +0200
+Subject: [PATCH] connectionmanager: expose per-service timeservers, mDNS and
+ traffic counters
+
+Three connman service capabilities that had no Luna API in front of them:
+
+  setTimeservers        Timeservers.Configuration, the NTP servers to use
+                        while a service is the default one
+  setmDNS               mDNS.Configuration, per-service multicast DNS
+  getServiceCounters    the RX/TX byte, packet, error and drop counters
+  resetServiceCounters  plus Service.ResetCounters to zero them
+
+The counters are lifetime totals per service, which is different from
+what monitorActivity already reports: that uses connman's Counter API and
+delivers periodic deltas.
+
+All four are registered in the existing networkconnection.query and
+networkconnection.management ACGs, so groups.json and perm.json are
+unchanged.
+
+Upstream-Status: Inappropriate [LuneOS specific]
+---
+ files/sysbus/webos-connman-adapter.api.json |  11 +-
+ src/connectionmanager_service.c             | 342 ++++++++++++++++++++
+ src/connectionmanager_service.h             |   4 +
+ src/connman_service.c                       | 137 ++++++++
+ src/connman_service.h                       |  51 +++
+ src/logging.h                               |   3 +
+ 6 files changed, 545 insertions(+), 3 deletions(-)
+
+diff --git a/files/sysbus/webos-connman-adapter.api.json b/files/sysbus/webos-connman-adapter.api.json
+index 8209bd7..0221532 100644
+--- a/files/sysbus/webos-connman-adapter.api.json
++++ b/files/sysbus/webos-connman-adapter.api.json
+@@ -3,7 +3,8 @@
+         "com.webos.service.connectionmanager/findProxyForURL",
+         "com.webos.service.connectionmanager/getinfo",
+         "com.webos.service.connectionmanager/getStatus",
+-        "com.webos.service.connectionmanager/getstatus"
++        "com.webos.service.connectionmanager/getstatus",
++        "com.webos.service.connectionmanager/getServiceCounters"
+     ],
+     "networkconnection.management": [
+         "com.webos.service.connectionmanager/setdns",
+@@ -13,7 +14,10 @@
+         "com.webos.service.connectionmanager/setstate",
+         "com.webos.service.connectionmanager/setTechnologyState",
+         "com.webos.service.connectionmanager/monitorActivity",
+-        "com.webos.service.connectionmanager/setDefaultInterface"
++        "com.webos.service.connectionmanager/setDefaultInterface",
++        "com.webos.service.connectionmanager/setTimeservers",
++        "com.webos.service.connectionmanager/setmDNS",
++        "com.webos.service.connectionmanager/resetServiceCounters"
+     ],
+     "wifi.query": [
+         "com.webos.service.wifi/findnetworks",
+@@ -84,6 +88,7 @@
+         "com.webos.service.wan/getContext",
+         "com.webos.service.wan/setHostRoutes",
+         "com.webos.service.wifi/getstatus",
+-        "com.webos.service.wifi/getwifidiagnostics"
++        "com.webos.service.wifi/getwifidiagnostics",
++        "com.webos.service.connectionmanager/getServiceCounters"
+     ]
+ }
+diff --git a/src/connectionmanager_service.c b/src/connectionmanager_service.c
+index b65df78..1e306d3 100644
+--- a/src/connectionmanager_service.c
++++ b/src/connectionmanager_service.c
+@@ -207,6 +207,20 @@ static void update_connection_status(connman_service_t *connected_service,
+ 			jobject_put(*status, J_CSTR_TO_JVAL("domains"), domains_obj);
+ 		}
+ 
++		if (connected_service->timeservers &&
++		        g_strv_length(connected_service->timeservers) > 0)
++		{
++			jvalue_ref timeservers_obj = jarray_create(NULL);
++
++			for (i = 0; i < g_strv_length(connected_service->timeservers); i++)
++			{
++				jarray_append(timeservers_obj,
++				              jstring_create(connected_service->timeservers[i]));
++			}
++
++			jobject_put(*status, J_CSTR_TO_JVAL("timeservers"), timeservers_obj);
++		}
++
+ 		update_string_value(status, J_CSTR_TO_JVAL("method"),connected_service->ipinfo.ipv4.method);
+ 
+ 		if (connected_service->type == CONNMAN_SERVICE_TYPE_CELLULAR)
+@@ -2882,6 +2896,330 @@ cleanup:
+ 	return true;
+ }
+ 
++/**
++ *  @brief Handler for "setTimeservers" command.
++ *
++ *  Sets the NTP servers connman should use while the selected service is the
++ *  default one (Timeservers.Configuration). An empty array clears the override
++ *  and falls back to whatever the network or FallbackTimeservers provides.
++ *
++ *  JSON format:
++ *  luna://com.webos.service.connectionmanager/setTimeservers
++ *      {"timeservers":["0.pool.ntp.org"], "ssid":"<ssid>", "interfaceName":"<iface>"}
++ */
++
++static bool handle_set_timeservers_command(LSHandle *sh, LSMessage *message,
++        void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	jvalue_ref parsedObj = {0};
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_3(ARRAY(timeservers, string),
++	                                     PROP(ssid, string), PROP(interfaceName, string))
++	                                     REQUIRED_1(timeservers))), &parsedObj))
++	{
++		return true;
++	}
++
++	jvalue_ref timeserversObj = {0};
++	GStrv timeservers = NULL;
++	gchar *ssid = NULL;
++	gchar *interface_name = NULL;
++	connman_service_t *service = NULL;
++
++	if (jobject_get_exists(parsedObj, J_CSTR_TO_BUF("timeservers"),
++	                       &timeserversObj))
++	{
++		int i, arrsize = jarray_size(timeserversObj);
++		timeservers = (GStrv) g_new0(GStrv, arrsize + 1);
++
++		for (i = 0; i < arrsize; i++)
++		{
++			raw_buffer buf = jstring_get(jarray_get(timeserversObj, i));
++			timeservers[i] = g_strdup(buf.m_str);
++			jstring_free_buffer(buf);
++
++			if (0 == strlen(timeservers[i]))
++			{
++				LSMessageReplyErrorInvalidParams(sh, message);
++				goto exit;
++			}
++		}
++
++		timeservers[arrsize] = NULL;
++	}
++
++	get_string_value(parsedObj, J_CSTR_TO_BUF("ssid"), &ssid);
++	get_string_value(parsedObj, J_CSTR_TO_BUF("interfaceName"), &interface_name);
++
++	service = retrieve_service_by_ssid(ssid, interface_name);
++
++	if (NULL == service)
++	{
++		LSMessageReplyCustomError(sh, message, "No connected network",
++		                          WCA_API_ERROR_NO_CONNECTED_NW);
++		goto exit;
++	}
++
++	if (connman_service_set_timeservers(service, timeservers))
++	{
++		LSMessageReplySuccess(sh, message);
++	}
++	else
++	{
++		LSMessageReplyErrorUnknown(sh, message);
++	}
++
++exit:
++	g_strfreev(timeservers);
++	g_free(ssid);
++	g_free(interface_name);
++	j_release(&parsedObj);
++	return true;
++}
++
++/**
++ *  @brief Handler for "setmDNS" command.
++ *
++ *  Enables or disables multicast DNS resolution on a service
++ *  (mDNS.Configuration).
++ *
++ *  JSON format:
++ *  luna://com.webos.service.connectionmanager/setmDNS
++ *      {"enabled":true, "ssid":"<ssid>", "interfaceName":"<iface>"}
++ */
++
++static bool handle_set_mdns_command(LSHandle *sh, LSMessage *message,
++                                    void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	jvalue_ref parsedObj = {0};
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_3(PROP(enabled, boolean),
++	                                     PROP(ssid, string), PROP(interfaceName, string))
++	                                     REQUIRED_1(enabled))), &parsedObj))
++	{
++		return true;
++	}
++
++	jvalue_ref enabledObj = {0};
++	bool enabled = false;
++	gchar *ssid = NULL;
++	gchar *interface_name = NULL;
++	connman_service_t *service = NULL;
++
++	if (jobject_get_exists(parsedObj, J_CSTR_TO_BUF("enabled"), &enabledObj))
++	{
++		jboolean_get(enabledObj, &enabled);
++	}
++
++	get_string_value(parsedObj, J_CSTR_TO_BUF("ssid"), &ssid);
++	get_string_value(parsedObj, J_CSTR_TO_BUF("interfaceName"), &interface_name);
++
++	service = retrieve_service_by_ssid(ssid, interface_name);
++
++	if (NULL == service)
++	{
++		LSMessageReplyCustomError(sh, message, "No connected network",
++		                          WCA_API_ERROR_NO_CONNECTED_NW);
++		goto exit;
++	}
++
++	if (connman_service_set_mdns(service, enabled))
++	{
++		LSMessageReplySuccess(sh, message);
++	}
++	else
++	{
++		LSMessageReplyErrorUnknown(sh, message);
++	}
++
++exit:
++	g_free(ssid);
++	g_free(interface_name);
++	j_release(&parsedObj);
++	return true;
++}
++
++static void append_service_counters(jvalue_ref *reply,
++                                    connman_service_t *service)
++{
++	jvalue_ref counters = jobject_create();
++
++	jobject_put(counters, J_CSTR_TO_JVAL("rxBytes"),
++	            jnumber_create_i64(service->stats.rx_bytes));
++	jobject_put(counters, J_CSTR_TO_JVAL("txBytes"),
++	            jnumber_create_i64(service->stats.tx_bytes));
++	jobject_put(counters, J_CSTR_TO_JVAL("rxPackets"),
++	            jnumber_create_i64(service->stats.rx_packets));
++	jobject_put(counters, J_CSTR_TO_JVAL("txPackets"),
++	            jnumber_create_i64(service->stats.tx_packets));
++	jobject_put(counters, J_CSTR_TO_JVAL("rxErrors"),
++	            jnumber_create_i64(service->stats.rx_errors));
++	jobject_put(counters, J_CSTR_TO_JVAL("txErrors"),
++	            jnumber_create_i64(service->stats.tx_errors));
++	jobject_put(counters, J_CSTR_TO_JVAL("rxDropped"),
++	            jnumber_create_i64(service->stats.rx_dropped));
++	jobject_put(counters, J_CSTR_TO_JVAL("txDropped"),
++	            jnumber_create_i64(service->stats.tx_dropped));
++	jobject_put(counters, J_CSTR_TO_JVAL("connectedTime"),
++	            jnumber_create_i64(service->stats.time));
++
++	if (service->ipinfo.iface)
++	{
++		jobject_put(counters, J_CSTR_TO_JVAL("interfaceName"),
++		            jstring_create(service->ipinfo.iface));
++	}
++
++	jobject_put(*reply, J_CSTR_TO_JVAL("counters"), counters);
++}
++
++/**
++ *  @brief Handler for "getServiceCounters" command.
++ *
++ *  Reports the cumulative traffic counters connman keeps for a service. These
++ *  are lifetime totals for the service, unlike monitorActivity which reports
++ *  periodic deltas through the connman counter API.
++ *
++ *  JSON format:
++ *  luna://com.webos.service.connectionmanager/getServiceCounters
++ *      {"ssid":"<ssid>", "interfaceName":"<iface>"}
++ */
++
++static bool handle_get_service_counters_command(LSHandle *sh,
++        LSMessage *message, void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	jvalue_ref parsedObj = {0};
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_2(PROP(ssid, string),
++	                                     PROP(interfaceName, string)))), &parsedObj))
++	{
++		return true;
++	}
++
++	gchar *ssid = NULL;
++	gchar *interface_name = NULL;
++	connman_service_t *service = NULL;
++	jvalue_ref reply = NULL;
++
++	get_string_value(parsedObj, J_CSTR_TO_BUF("ssid"), &ssid);
++	get_string_value(parsedObj, J_CSTR_TO_BUF("interfaceName"), &interface_name);
++
++	service = retrieve_service_by_ssid(ssid, interface_name);
++
++	if (NULL == service)
++	{
++		LSMessageReplyCustomError(sh, message, "No connected network",
++		                          WCA_API_ERROR_NO_CONNECTED_NW);
++		goto exit;
++	}
++
++	/* Refresh so the counters are current rather than whatever was cached */
++	GVariant *properties = connman_service_fetch_properties(service);
++
++	if (NULL != properties)
++	{
++		connman_service_update_properties(service, properties);
++		g_variant_unref(properties);
++	}
++
++	reply = jobject_create();
++	jobject_put(reply, J_CSTR_TO_JVAL("returnValue"), jboolean_create(true));
++	append_service_counters(&reply, service);
++
++	LSError lserror;
++	LSErrorInit(&lserror);
++
++	if (!LSMessageReply(sh, message, jvalue_tostring(reply, jschema_all()),
++	                    &lserror))
++	{
++		LSErrorPrint(&lserror, stderr);
++		LSErrorFree(&lserror);
++	}
++
++exit:
++	if (reply)
++	{
++		j_release(&reply);
++	}
++
++	g_free(ssid);
++	g_free(interface_name);
++	j_release(&parsedObj);
++	return true;
++}
++
++/**
++ *  @brief Handler for "resetServiceCounters" command.
++ *
++ *  Zeroes connman's cumulative traffic counters for a service.
++ *
++ *  JSON format:
++ *  luna://com.webos.service.connectionmanager/resetServiceCounters
++ *      {"ssid":"<ssid>", "interfaceName":"<iface>"}
++ */
++
++static bool handle_reset_service_counters_command(LSHandle *sh,
++        LSMessage *message, void *context)
++{
++	if (!connman_status_check(manager, sh, message))
++	{
++		return true;
++	}
++
++	jvalue_ref parsedObj = {0};
++	if (!LSMessageValidateSchema(sh, message,
++	                             j_cstr_to_buffer(STRICT_SCHEMA(PROPS_2(PROP(ssid, string),
++	                                     PROP(interfaceName, string)))), &parsedObj))
++	{
++		return true;
++	}
++
++	gchar *ssid = NULL;
++	gchar *interface_name = NULL;
++	connman_service_t *service = NULL;
++
++	get_string_value(parsedObj, J_CSTR_TO_BUF("ssid"), &ssid);
++	get_string_value(parsedObj, J_CSTR_TO_BUF("interfaceName"), &interface_name);
++
++	service = retrieve_service_by_ssid(ssid, interface_name);
++
++	if (NULL == service)
++	{
++		LSMessageReplyCustomError(sh, message, "No connected network",
++		                          WCA_API_ERROR_NO_CONNECTED_NW);
++		goto exit;
++	}
++
++	if (connman_service_reset_counters(service))
++	{
++		LSMessageReplySuccess(sh, message);
++	}
++	else
++	{
++		LSMessageReplyErrorUnknown(sh, message);
++	}
++
++exit:
++	g_free(ssid);
++	g_free(interface_name);
++	j_release(&parsedObj);
++	return true;
++}
++
+ static bool handle_set_default_interface(LSHandle *sh, LSMessage *message,
+                                     void *context)
+ {
+@@ -2975,6 +3313,10 @@ static LSMethod connectionmanager_methods[] =
+ 	{ LUNA_METHOD_SETPROXY,             handle_set_proxy_command },
+ 	{ LUNA_METHOD_FINDPROXYFORURL,      handle_find_proxy_for_url_command },
+ 	{ LUNA_METHOD_SETDEFAULT,           handle_set_default_interface },
++	{ LUNA_METHOD_SETTIMESERVERS,       handle_set_timeservers_command },
++	{ LUNA_METHOD_SETMDNS,              handle_set_mdns_command },
++	{ LUNA_METHOD_GETCOUNTERS,          handle_get_service_counters_command },
++	{ LUNA_METHOD_RESETCOUNTERS,        handle_reset_service_counters_command },
+ 	{ },
+ };
+ 
+diff --git a/src/connectionmanager_service.h b/src/connectionmanager_service.h
+index b906455..170ef60 100644
+--- a/src/connectionmanager_service.h
++++ b/src/connectionmanager_service.h
+@@ -46,6 +46,10 @@
+ #define LUNA_METHOD_SETPROXY              "setProxy"
+ #define LUNA_METHOD_FINDPROXYFORURL       "findProxyForURL"
+ #define LUNA_METHOD_SETDEFAULT            "setDefaultInterface"
++#define LUNA_METHOD_SETTIMESERVERS        "setTimeservers"
++#define LUNA_METHOD_SETMDNS               "setmDNS"
++#define LUNA_METHOD_GETCOUNTERS           "getServiceCounters"
++#define LUNA_METHOD_RESETCOUNTERS         "resetServiceCounters"
+ 
+ 
+ enum ipadress_type
+diff --git a/src/connman_service.c b/src/connman_service.c
+index e8e3160..17a4c9b 100644
+--- a/src/connman_service.c
++++ b/src/connman_service.c
+@@ -697,6 +697,90 @@ gboolean connman_service_set_domains(connman_service_t *service, GStrv domains)
+ 	return TRUE;
+ }
+ 
++/**
++ * Set the NTP servers for the given service (see header for API details)
++ */
++
++gboolean connman_service_set_timeservers(connman_service_t *service,
++        GStrv timeservers)
++{
++	GError *error = NULL;
++
++	if (NULL == service || NULL == timeservers)
++	{
++		return FALSE;
++	}
++
++	connman_interface_service_call_set_property_sync(service->remote,
++	        "Timeservers.Configuration",
++	        g_variant_new_variant(g_variant_new_strv((const gchar * const *)
++	                              timeservers, g_strv_length(timeservers))), NULL, &error);
++
++	if (error)
++	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_SERVICE_SET_TIMESERVERS_ERROR, error->message);
++		g_error_free(error);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++/**
++ * Enable or disable multicast DNS on the given service (see header for API details)
++ */
++
++gboolean connman_service_set_mdns(connman_service_t *service, gboolean enabled)
++{
++	GError *error = NULL;
++
++	if (NULL == service)
++	{
++		return FALSE;
++	}
++
++	connman_interface_service_call_set_property_sync(service->remote,
++	        "mDNS.Configuration",
++	        g_variant_new_variant(g_variant_new_boolean(enabled)), NULL, &error);
++
++	if (error)
++	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_SERVICE_SET_MDNS_ERROR, error->message);
++		g_error_free(error);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++/**
++ * Zero the traffic counters for the given service (see header for API details)
++ */
++
++gboolean connman_service_reset_counters(connman_service_t *service)
++{
++	GError *error = NULL;
++
++	if (NULL == service)
++	{
++		return FALSE;
++	}
++
++	connman_interface_service_call_reset_counters_sync(service->remote, NULL,
++	        &error);
++
++	if (error)
++	{
++		WCALOG_ESCAPED_ERRMSG(MSGID_SERVICE_RESET_COUNTERS_ERROR, error->message);
++		g_error_free(error);
++		return FALSE;
++	}
++
++	memset(&service->stats, 0, sizeof(service->stats));
++
++	return TRUE;
++}
++
+ /**
+  * Set auto-connect property for the given service (see header for API details)
+  */
+@@ -978,6 +1062,18 @@ gboolean connman_service_get_ipinfo(connman_service_t *service)
+ 			g_variant_unref(va);
+ 		}
+ 
++		if (!g_strcmp0(key, "Timeservers"))
++		{
++			GVariant *v = g_variant_get_child_value(property, 1);
++			GVariant *va = g_variant_get_child_value(v, 0);
++
++			g_strfreev(service->timeservers);
++			service->timeservers = g_variant_dup_strv(va, NULL);
++
++			g_variant_unref(v);
++			g_variant_unref(va);
++		}
++
+ 		if (!g_strcmp0(key, "HostRoutes"))
+ 		{
+ 			GVariant *v = g_variant_get_child_value(property, 1);
+@@ -1787,6 +1883,46 @@ void connman_service_update_properties(connman_service_t *service,
+ 		{
+ 			service->roaming = g_variant_get_boolean(val);
+ 		}
++		else if (!g_strcmp0(key, "mDNS"))
++		{
++			service->mdns = g_variant_get_boolean(val);
++		}
++		else if (!g_strcmp0(key, "RX.Bytes"))
++		{
++			service->stats.rx_bytes = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "TX.Bytes"))
++		{
++			service->stats.tx_bytes = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "RX.Packets"))
++		{
++			service->stats.rx_packets = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "TX.Packets"))
++		{
++			service->stats.tx_packets = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "RX.Errors"))
++		{
++			service->stats.rx_errors = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "TX.Errors"))
++		{
++			service->stats.tx_errors = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "RX.Dropped"))
++		{
++			service->stats.rx_dropped = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "TX.Dropped"))
++		{
++			service->stats.tx_dropped = g_variant_get_uint32(val);
++		}
++		else if (!g_strcmp0(key, "Time"))
++		{
++			service->stats.time = g_variant_get_uint32(val);
++		}
+ 		else if (!g_strcmp0(key, "Online"))
+ 		{
+ 			connman_service_advance_online_state(service, val);
+@@ -2169,6 +2305,7 @@ void connman_service_free(gpointer data, gpointer user_data)
+ 	g_free(service->ipinfo.ipv6.gateway);
+ 	g_strfreev(service->ipinfo.dns);
+ 	g_strfreev(service->ipinfo.domains);
++	g_strfreev(service->timeservers);
+ 
+ 	g_free(service->proxyinfo.method);
+ 	g_free(service->proxyinfo.url);
+diff --git a/src/connman_service.h b/src/connman_service.h
+index 2b6bf75..4435190 100644
+--- a/src/connman_service.h
++++ b/src/connman_service.h
+@@ -70,6 +70,23 @@ typedef struct ipinfo
+ 	ipv6info_t ipv6;
+ } ipinfo_t;
+ 
++/**
++ * Cumulative traffic counters connman keeps per service
++ *
++ */
++typedef struct servicestats
++{
++	guint32 rx_bytes;
++	guint32 tx_bytes;
++	guint32 rx_packets;
++	guint32 tx_packets;
++	guint32 rx_errors;
++	guint32 tx_errors;
++	guint32 rx_dropped;
++	guint32 tx_dropped;
++	guint32 time; /* seconds the service has been connected */
++} servicestats_t;
++
+ /**
+  * Proxy information for the service
+  *
+@@ -145,8 +162,11 @@ typedef struct connman_service
+ 	gboolean hidden;
+ 	gboolean online;
+ 	gboolean online_checking;
++	gboolean mdns; /* Multicast DNS active on this service */
+ 	gint type;
+ 	ipinfo_t ipinfo;
++	GStrv timeservers; /* NTP servers in use for this service */
++	servicestats_t stats;
+ 	proxyinfo_t proxyinfo;
+ 	GStrv hostroutes;
+ 	gulong sighandler_id;
+@@ -389,6 +409,37 @@ extern gboolean connman_service_set_nameservers(connman_service_t *service,
+ extern gboolean connman_service_set_domains(connman_service_t *service,
+         GStrv domains);
+ 
++/**
++ * Set the NTP servers to use while this service is the default
++ *
++ * @param[IN]  service A service instance
++ * @param[IN]  timeservers A NULL terminated array of NTP server names
++ *
++ * @return FALSE if the call to set "Timeservers.Configuration" failed, TRUE otherwise
++ */
++extern gboolean connman_service_set_timeservers(connman_service_t *service,
++        GStrv timeservers);
++
++/**
++ * Enable or disable multicast DNS resolution on a service
++ *
++ * @param[IN]  service A service instance
++ * @param[IN]  enabled TRUE to enable mDNS
++ *
++ * @return FALSE if the call to set "mDNS.Configuration" failed, TRUE otherwise
++ */
++extern gboolean connman_service_set_mdns(connman_service_t *service,
++        gboolean enabled);
++
++/**
++ * Zero the cumulative traffic counters connman keeps for a service
++ *
++ * @param[IN]  service A service instance
++ *
++ * @return FALSE if the ResetCounters call failed, TRUE otherwise
++ */
++extern gboolean connman_service_reset_counters(connman_service_t *service);
++
+ /**
+  * Set the "autoconnect" flag for a service
+  *
+diff --git a/src/logging.h b/src/logging.h
+index 31ee1da..5823fd5 100644
+--- a/src/logging.h
++++ b/src/logging.h
+@@ -120,6 +120,9 @@ extern PmLogContext gLogContext;
+ #define MSGID_SERVICE_SET_IPV6_ERROR                    "SRVC_SET_IPV6_ERR"
+ #define MSGID_SERVICE_SET_NAMESERVER_ERROR              "SRVC_SET_NAMESERVER_ERR"
+ #define MSGID_SERVICE_SET_DOMAINS_ERROR                 "SRVC_SET_DOMAINS_ERR"
++#define MSGID_SERVICE_SET_TIMESERVERS_ERROR             "SRVC_SET_TIMESERVERS_ERR"
++#define MSGID_SERVICE_SET_MDNS_ERROR                    "SRVC_SET_MDNS_ERR"
++#define MSGID_SERVICE_RESET_COUNTERS_ERROR              "SRVC_RESET_COUNTERS_ERR"
+ #define MSGID_SERVICE_AUTOCONNECT_ERROR                 "SRVC_AUTOCONNECT_ERR"
+ #define MSGID_SERVICE_GET_IPINFO_ERROR                  "SRVC_GET_IPINFO_ERR"
+ #define MSGID_SERVICE_FETCH_PROPERTIES_ERROR            "SRVC_FETCH_PROPERTIES_ERR"


### PR DESCRIPTION
Extend the base connman 2.0 port with the remaining adapter work from the platform branch:

- tethering: read the station list from connman instead of scraping
- agent: implement Cancel and Release, map connman 2.0 error strings
- connectionmanager: implement setDefaultInterface via connman's default-service move
- expose DNS search domains and cellular roaming state
- expose per-service timeservers and the mDNS toggle

wca-support-api gets the CMake-variable-syntax install() fix the other webOS components already received for CMake 4's CMP0053.
