### PR TITLE
luneos-device-config: want the container, do not require it

### DIFF
--- a/meta-luneos/recipes-core/luneos-device-config/luneos-device-config/luneos-device-config.service
+++ b/meta-luneos/recipes-core/luneos-device-config/luneos-device-config/luneos-device-config.service
@@ -3,8 +3,18 @@ Description=Derive LuneOS device configuration
 DefaultDependencies=no
 # Needs the container's property service to read the *vendor's* idea of which
 # device this is, and must land before anything that consumes the result.
+#
+# Wants, not Requires: this only needs the container to be *running* (getprop
+# answering), not android-system.service's readiness verdict. That service is
+# marked failed if its ExecStartPost probes (lshal, the graphics-HAL wait) time
+# out or crash even though the container itself is up - and a Requires= turned
+# that into a skipped device-config, which leaves the compositor and luna-sysmgr
+# on the shipped placeholder: no touch device and no power keys, i.e. a phone
+# that cannot be unlocked and whose power button does not wake the screen. With
+# Wants=, After= still orders us after the container has finished starting (or
+# failed), but a failed verdict no longer suppresses config generation.
 After=android-system.service
-Requires=android-system.service
+Wants=android-system.service
 # Before configd, so the generated layer is in place and the stale cache is
 # gone before it builds its merged view.
 #


### PR DESCRIPTION
A crashing lshal in start-android-hals plus a start-post timeout shorter than the internally-bounded getprop wait marks android-system.service failed even though the LXC container is up and answering getprop. With Requires=, that cascaded: device-config was skipped, and the compositor and luna-sysmgr fell back to the shipped placeholder input config - no touch device and no power keys, i.e. a phone that cannot be unlocked and whose power button does not wake the screen, which is exactly what this unit's own comment warns about.

This service only needs the container running, not android-system's readiness verdict. After= still orders it after the container has finished starting (or failed); Wants= stops a failed verdict from suppressing config generation.
