### PR TITLE
luneos-device-config: publish the adaptation's video-call policy

### DIFF
--- a/meta-luneos/recipes-core/luneos-device-config/luneos-device-config/luneos-device-config
+++ b/meta-luneos/recipes-core/luneos-device-config/luneos-device-config/luneos-device-config
@@ -162,6 +162,16 @@ else
     log "no adaptation for '$codename', running on derived values alone"
 fi
 
+# Video calling. The rtc engine derives capability by probing the camera HAL's
+# device count, which is wrong on devices whose cameras are wired up and
+# enumerated but not actually usable. deviceinfo_video_call="false" closes the
+# feature off, "true" forces it on, absent leaves it derived. Published under
+# $RUN so consumers never parse adaptations themselves.
+if [ -n "${deviceinfo_video_call:-}" ]; then
+    printf '%s\n' "$deviceinfo_video_call" > "$RUN/video-call"
+    log "video-call policy from deviceinfo: $deviceinfo_video_call"
+fi
+
 cat > "$RUN/device.env" <<EOF
 LUNEOS_DEVICE_CODENAME=$codename
 LUNEOS_VENDOR_API_LEVEL=$api_level


### PR DESCRIPTION
The rtc engine derives video-call capability by probing the camera HAL's device count, which is wrong on devices whose cameras are wired up and enumerated but not actually usable. deviceinfo_video_call ("false" closes the feature, "true" forces it on, absent leaves it derived) is published to /run/luneos-device/video-call so consumers never parse adaptations themselves.